### PR TITLE
fix(flake) get toolchain (channel, extensions)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,11 @@
           ];
         };
 
-        naersk' = pkgs.callPackage naersk { };
+        toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
 
         buildInputs = with pkgs; [
           libxkbcommon
@@ -47,13 +51,7 @@
         ];
 
         nativeBuildInputs = with pkgs; [
-          (pkgs.rust-bin.stable.latest.default.override {
-            extensions = [
-              "rust-src"
-              "cargo"
-              "rustc"
-            ];
-          })
+          toolchain
           pkg-config
           cmake
           perl
@@ -61,7 +59,7 @@
         ];
       in
       rec {
-        defaultPackage = packages.isofs-cli;
+        defaultPackage = packages.gpui-ce;
         packages = {
           gpui-ce = naersk'.buildPackage {
             src = ./.;
@@ -76,12 +74,6 @@
         };
 
         devShell = pkgs.mkShell {
-          RUST_SRC_PATH = "${
-            pkgs.rust-bin.stable.latest.default.override {
-              extensions = [ "rust-src" ];
-            }
-          }/lib/rustlib/src/rust/library";
-
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
           XDG_SESSION_TYPE = "wayland";
           shellHook = ''
@@ -94,11 +86,6 @@
             [
               nixfmt
               cmake
-              rustc
-              rustfmt
-              cargo
-              clippy
-              rust-analyzer
             ]
             ++ buildInputs
             ++ nativeBuildInputs;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
 channel = "1.91.1"
 profile = "minimal"
-components = [ "rustfmt", "clippy" ]
+components = [ "rustfmt", "clippy", "rust-analyzer", "rust-src", "cargo", "rustc" ]
 targets = [
     "wasm32-wasip2", # extensions
     "x86_64-unknown-linux-musl", # remote server


### PR DESCRIPTION
from `toolchain.toml`. No need to define toolchain twice (in `flake.nix` and `toolchain.toml`).

Feel free to push that change into [upstream](https://github.com/gpui-ce/gpui-ce) as well. Currently I'm just interested to  have `gpui` running with  `wgpu`.  And `WGPUI` looks promising!