### PR TITLE
Fix thread panic and ensure window redraw on WakeUp event

### DIFF
--- a/src/platform/cross/platform.rs
+++ b/src/platform/cross/platform.rs
@@ -380,6 +380,9 @@ impl winit::application::ApplicationHandler<CrossEvent> for AppState {
         match event {
             CrossEvent::WakeUp => {
                 self.drain_main_queue();
+                for window in self.windows.values() {
+                    window.window().request_redraw();
+                }
             }
             CrossEvent::SurfacePresent(window_id) => {
                 if let Some(window) = self.windows.get(&window_id) {

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -1266,6 +1266,9 @@ impl WgpuRenderer {
         let pipelines =
             WgpuPipelines::new(context.as_ref(), &surface_configuration, path_sample_count);
 
+        // Configure the surface for presentation before the first draw call.
+        surface.configure(&context.device, &surface_configuration);
+
         Ok(Self {
             context: context.clone(),
             surface,


### PR DESCRIPTION
This pull request focuses on improving the rendering pipeline initialization and ensuring that window redraws are properly requested when the application wakes up. The main changes are related to surface configuration and event handling for redraws.

Rendering pipeline and surface configuration improvements:
* Configured the rendering surface for presentation before the first draw call in the `WgpuRenderer` initialization to ensure correct rendering behavior. (`src/platform/cross/renderer.rs`)

Window event handling enhancements:
* Updated the `CrossEvent::WakeUp` event handler to request a redraw for all windows, ensuring the UI is refreshed appropriately when the application wakes. (`src/platform/cross/platform.rs`)