### PR TITLE
Implemented zero-copy cross-device texture sharing via platform-nativ…

### DIFF
--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -298,6 +298,7 @@ mod windows {
             "underline",
             "monochrome_sprite",
             "polychrome_sprite",
+            "surface",
         ];
 
         let rust_binding_path = format!("{}/shaders_bytes.rs", out_dir);

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -1,26 +1,34 @@
 use crate::{
-    App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
-    ObjectFit, Pixels, Style, StyleRefinement, Styled, Window,
+    App, Bounds, Element, ElementId, GpuTextureFormat, GlobalElementId, InspectorElementId,
+    IntoElement, LayoutId, ObjectFit, Pixels, Style, StyleRefinement, Styled, Window,
 };
 #[cfg(target_os = "macos")]
 use core_video::pixel_buffer::CVPixelBuffer;
 use refineable::Refineable;
 
 /// A source of a surface's content.
+///
+/// Each variant carries platform-native handles that reference shared GPU memory,
+/// enabling zero-copy texture sharing between separate GPU devices. External
+/// renderers create textures on their own device and share the underlying memory
+/// via OS-level handles. GPUI's compositor imports these handles on its own
+/// device for compositing — no shared device, no contention.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SurfaceSource {
     /// A macOS image buffer from CoreVideo
     #[cfg(target_os = "macos")]
     ImageBuffer(CVPixelBuffer),
-    /// Windows shared texture handle
+    /// Windows shared texture handle (NT handle from IDXGIResource1::CreateSharedHandle)
     #[cfg(target_os = "windows")]
     SharedTexture {
-        /// Native handle to the shared texture
+        /// Native NT handle to the shared texture
         nt_handle: isize,
         /// Width of the texture in pixels
         width: u32,
         /// Height of the texture in pixels
         height: u32,
+        /// Texture format
+        format: GpuTextureFormat,
     },
     /// Linux DMA-BUF file descriptor
     #[cfg(target_os = "linux")]
@@ -31,13 +39,15 @@ pub enum SurfaceSource {
         width: u32,
         /// Height of the texture in pixels
         height: u32,
+        /// Texture format
+        format: GpuTextureFormat,
     },
 }
 
 #[cfg(target_os = "macos")]
 impl From<CVPixelBuffer> for SurfaceSource {
     fn from(value: CVPixelBuffer) -> Self {
-        SurfaceSource::Surface(value)
+        SurfaceSource::ImageBuffer(value)
     }
 }
 
@@ -113,11 +123,10 @@ impl Element for Surface {
     ) {
         match &self.source {
             #[cfg(target_os = "macos")]
-            SurfaceSource::Surface(surface) => {
-                let size = crate::size(surface.get_width().into(), surface.get_height().into());
+            SurfaceSource::ImageBuffer(image_buffer) => {
+                let size = crate::size(image_buffer.get_width().into(), image_buffer.get_height().into());
                 let new_bounds = self.object_fit.get_bounds(bounds, size);
-                // TODO: Add support for corner_radii
-                window.paint_surface(new_bounds, surface.clone());
+                window.paint_surface(new_bounds, image_buffer.clone());
             }
             #[allow(unreachable_patterns)]
             _ => {}

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -826,34 +826,36 @@ impl BladeRenderer {
 
                         #[cfg(target_os = "macos")]
                         {
+                            let crate::SurfaceSource::ImageBuffer(ref image_buffer) = surface.source;
+
                             let (t_y, t_cb_cr) = unsafe {
                                 use core_foundation::base::TCFType as _;
                                 use std::ptr;
 
                                 assert_eq!(
-                                        surface.image_buffer.get_pixel_format(),
+                                        image_buffer.get_pixel_format(),
                                         core_video::pixel_buffer::kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
                                     );
 
                                 let y_texture = self
                                     .core_video_texture_cache
                                     .create_texture_from_image(
-                                        surface.image_buffer.as_concrete_TypeRef(),
+                                        image_buffer.as_concrete_TypeRef(),
                                         ptr::null(),
                                         metal::MTLPixelFormat::R8Unorm,
-                                        surface.image_buffer.get_width_of_plane(0),
-                                        surface.image_buffer.get_height_of_plane(0),
+                                        image_buffer.get_width_of_plane(0),
+                                        image_buffer.get_height_of_plane(0),
                                         0,
                                     )
                                     .unwrap();
                                 let cb_cr_texture = self
                                     .core_video_texture_cache
                                     .create_texture_from_image(
-                                        surface.image_buffer.as_concrete_TypeRef(),
+                                        image_buffer.as_concrete_TypeRef(),
                                         ptr::null(),
                                         metal::MTLPixelFormat::RG8Unorm,
-                                        surface.image_buffer.get_width_of_plane(1),
-                                        surface.image_buffer.get_height_of_plane(1),
+                                        image_buffer.get_width_of_plane(1),
+                                        image_buffer.get_height_of_plane(1),
                                         1,
                                     )
                                     .unwrap();

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -1087,35 +1087,37 @@ impl MetalRenderer {
         );
 
         for surface in surfaces {
+            let crate::SurfaceSource::ImageBuffer(ref image_buffer) = surface.source;
+
             let texture_size = size(
-                DevicePixels::from(surface.image_buffer.get_width() as i32),
-                DevicePixels::from(surface.image_buffer.get_height() as i32),
+                DevicePixels::from(image_buffer.get_width() as i32),
+                DevicePixels::from(image_buffer.get_height() as i32),
             );
 
             assert_eq!(
-                surface.image_buffer.get_pixel_format(),
+                image_buffer.get_pixel_format(),
                 kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
             );
 
             let y_texture = self
                 .core_video_texture_cache
                 .create_texture_from_image(
-                    surface.image_buffer.as_concrete_TypeRef(),
+                    image_buffer.as_concrete_TypeRef(),
                     None,
                     MTLPixelFormat::R8Unorm,
-                    surface.image_buffer.get_width_of_plane(0),
-                    surface.image_buffer.get_height_of_plane(0),
+                    image_buffer.get_width_of_plane(0),
+                    image_buffer.get_height_of_plane(0),
                     0,
                 )
                 .unwrap();
             let cb_cr_texture = self
                 .core_video_texture_cache
                 .create_texture_from_image(
-                    surface.image_buffer.as_concrete_TypeRef(),
+                    image_buffer.as_concrete_TypeRef(),
                     None,
                     MTLPixelFormat::RG8Unorm,
-                    surface.image_buffer.get_width_of_plane(1),
-                    surface.image_buffer.get_height_of_plane(1),
+                    image_buffer.get_width_of_plane(1),
+                    image_buffer.get_height_of_plane(1),
                     1,
                 )
                 .unwrap();

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -7,7 +7,7 @@ use ::util::ResultExt;
 use anyhow::{Context, Result};
 use windows::{
     Win32::{
-        Foundation::HWND,
+        Foundation::{HANDLE, HWND},
         Graphics::{
             Direct3D::*,
             Direct3D11::*,
@@ -90,11 +90,13 @@ struct DirectXRenderPipelines {
     underline_pipeline: PipelineState<Underline>,
     mono_sprites: PipelineState<MonochromeSprite>,
     poly_sprites: PipelineState<PolychromeSprite>,
+    surface_pipeline: PipelineState<SurfaceInstance>,
 }
 
 struct DirectXGlobalElements {
     global_params_buffer: Option<ID3D11Buffer>,
     sampler: Option<ID3D11SamplerState>,
+    clamp_sampler: Option<ID3D11SamplerState>,
 }
 
 struct DirectComposition {
@@ -625,6 +627,132 @@ impl DirectXRenderer {
         if surfaces.is_empty() {
             return Ok(());
         }
+        let devices = self.devices.as_ref().context("devices missing")?;
+        let resources = self.resources.as_ref().context("resources missing")?;
+
+        for surface in surfaces {
+            let SurfaceSource::SharedTexture {
+                nt_handle, format, ..
+            } = &surface.source;
+
+            if *nt_handle == 0 {
+                log::warn!("Skipping surface with null NT handle");
+                continue;
+            }
+
+            // Import the shared texture from the external renderer's device.
+            // OpenSharedResource1 opens an NT handle created by
+            // IDXGIResource1::CreateSharedHandle on the producer side.
+            // This is zero-copy — both devices reference the same GPU memory.
+            let texture: ID3D11Texture2D = match unsafe {
+                let device1: ID3D11Device1 = devices.device.cast()?;
+                device1.OpenSharedResource1::<ID3D11Texture2D>(HANDLE(*nt_handle as _))
+            } {
+                Ok(tex) => tex,
+                Err(e) => {
+                    log::error!("Failed to open shared texture (handle={:#x}): {}", nt_handle, e);
+                    continue;
+                }
+            };
+
+            // Validate texture format matches what the producer declared.
+            let desc = unsafe {
+                let mut desc = std::mem::zeroed();
+                texture.GetDesc(&mut desc);
+                desc
+            };
+            let expected_dxgi_format = gpu_texture_format_to_dxgi(*format);
+            if desc.Format != expected_dxgi_format {
+                log::error!(
+                    "Surface format mismatch: producer declared {:?} (DXGI {:?}) but texture has {:?}",
+                    format, expected_dxgi_format, desc.Format
+                );
+                continue;
+            }
+
+            // Keyed mutex protocol for GPU synchronization between devices:
+            //   Producer: AcquireSync(0) → write → ReleaseSync(1)
+            //   Consumer: AcquireSync(1) → read  → ReleaseSync(0)
+            // If the texture doesn't support keyed mutex (created with
+            // MISC_SHARED_NTHANDLE only), the cast fails and we skip sync.
+            let keyed_mutex: Option<IDXGIKeyedMutex> = texture.cast().ok();
+            if let Some(ref mutex) = keyed_mutex {
+                // AcquireSync returns S_OK (0) on success, but the windows crate
+                // wraps HRESULT via .ok() which also treats WAIT_TIMEOUT (0x102) as
+                // Ok(()). We call the vtable directly to get the raw HRESULT so we
+                // can distinguish success from timeout.
+                let raw_hr = unsafe {
+                    (Interface::vtable(mutex).AcquireSync)(
+                        Interface::as_raw(mutex),
+                        1, // consumer key
+                        0, // non-blocking
+                    )
+                };
+                if raw_hr.0 != 0 {
+                    // Producer hasn't released yet — skip this surface for this frame.
+                    continue;
+                }
+            }
+
+            // Create SRV with explicit format to avoid ambiguity with typeless textures.
+            let srv_desc = D3D11_SHADER_RESOURCE_VIEW_DESC {
+                Format: expected_dxgi_format,
+                ViewDimension: D3D_SRV_DIMENSION_TEXTURE2D,
+                Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
+                    Texture2D: D3D11_TEX2D_SRV {
+                        MostDetailedMip: 0,
+                        MipLevels: 1,
+                    },
+                },
+            };
+            let srv = match unsafe {
+                let mut srv = None;
+                devices
+                    .device
+                    .CreateShaderResourceView(&texture, Some(&srv_desc), Some(&mut srv))
+                    .map(|_| srv)
+            } {
+                Ok(Some(srv)) => srv,
+                Ok(None) => {
+                    if let Some(ref mutex) = keyed_mutex {
+                        unsafe { mutex.ReleaseSync(0).ok() };
+                    }
+                    continue;
+                }
+                Err(e) => {
+                    log::error!("Failed to create SRV for shared surface: {}", e);
+                    if let Some(ref mutex) = keyed_mutex {
+                        unsafe { mutex.ReleaseSync(0).ok() };
+                    }
+                    continue;
+                }
+            };
+
+            let instance = SurfaceInstance {
+                bounds: surface.bounds,
+                content_mask: surface.content_mask.bounds,
+            };
+
+            self.pipelines.surface_pipeline.update_buffer(
+                &devices.device,
+                &devices.device_context,
+                &[instance],
+            )?;
+
+            self.pipelines.surface_pipeline.draw_with_texture(
+                &devices.device_context,
+                &[Some(srv)],
+                slice::from_ref(&resources.viewport),
+                slice::from_ref(&self.globals.global_params_buffer),
+                slice::from_ref(&self.globals.clamp_sampler),
+                1,
+            )?;
+
+            if let Some(ref mutex) = keyed_mutex {
+                unsafe { mutex.ReleaseSync(0).ok() };
+            }
+        }
+
         Ok(())
     }
 
@@ -796,6 +924,13 @@ impl DirectXRenderPipelines {
             16,
             create_blend_state(device)?,
         )?;
+        let surface_pipeline = PipelineState::new(
+            device,
+            "surface_pipeline",
+            ShaderModule::Surface,
+            4,
+            create_blend_state(device)?,
+        )?;
 
         Ok(Self {
             shadow_pipeline,
@@ -805,6 +940,7 @@ impl DirectXRenderPipelines {
             underline_pipeline,
             mono_sprites,
             poly_sprites,
+            surface_pipeline,
         })
     }
 }
@@ -865,9 +1001,28 @@ impl DirectXGlobalElements {
             output
         };
 
+        let clamp_sampler = unsafe {
+            let desc = D3D11_SAMPLER_DESC {
+                Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
+                AddressU: D3D11_TEXTURE_ADDRESS_CLAMP,
+                AddressV: D3D11_TEXTURE_ADDRESS_CLAMP,
+                AddressW: D3D11_TEXTURE_ADDRESS_CLAMP,
+                MipLODBias: 0.0,
+                MaxAnisotropy: 1,
+                ComparisonFunc: D3D11_COMPARISON_ALWAYS,
+                BorderColor: [0.0; 4],
+                MinLOD: 0.0,
+                MaxLOD: D3D11_FLOAT32_MAX,
+            };
+            let mut output = None;
+            device.CreateSamplerState(&desc, Some(&mut output))?;
+            output
+        };
+
         Ok(Self {
             global_params_buffer,
             sampler,
+            clamp_sampler,
         })
     }
 }
@@ -1014,6 +1169,13 @@ struct PathRasterizationSprite {
 #[repr(C)]
 struct PathSprite {
     bounds: Bounds<ScaledPixels>,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct SurfaceInstance {
+    bounds: Bounds<ScaledPixels>,
+    content_mask: Bounds<ScaledPixels>,
 }
 
 impl Drop for DirectXRenderer {
@@ -1412,6 +1574,7 @@ pub(crate) mod shader_resources {
         MonochromeSprite,
         PolychromeSprite,
         EmojiRasterization,
+        Surface,
     }
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -1484,6 +1647,10 @@ pub(crate) mod shader_resources {
                 ShaderModule::EmojiRasterization => match target {
                     ShaderTarget::Vertex => EMOJI_RASTERIZATION_VERTEX_BYTES,
                     ShaderTarget::Fragment => EMOJI_RASTERIZATION_FRAGMENT_BYTES,
+                },
+                ShaderModule::Surface => match target {
+                    ShaderTarget::Vertex => SURFACE_VERTEX_BYTES,
+                    ShaderTarget::Fragment => SURFACE_FRAGMENT_BYTES,
                 },
             };
             Self { inner: bytes }
@@ -1571,8 +1738,17 @@ pub(crate) mod shader_resources {
                 ShaderModule::MonochromeSprite => "monochrome_sprite",
                 ShaderModule::PolychromeSprite => "polychrome_sprite",
                 ShaderModule::EmojiRasterization => "emoji_rasterization",
+                ShaderModule::Surface => "surface",
             }
         }
+    }
+}
+
+fn gpu_texture_format_to_dxgi(format: GpuTextureFormat) -> DXGI_FORMAT {
+    match format {
+        GpuTextureFormat::RGBA8 => DXGI_FORMAT_R8G8B8A8_UNORM,
+        GpuTextureFormat::BGRA8 => DXGI_FORMAT_B8G8R8A8_UNORM,
+        GpuTextureFormat::RGBA16F => DXGI_FORMAT_R16G16B16A16_FLOAT,
     }
 }
 

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -1180,3 +1180,42 @@ float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Targe
     color.a *= sprite.opacity * saturate(0.5 - distance);
     return color;
 }
+
+/*
+**
+**              Surfaces (external GPU textures via shared handles)
+**
+*/
+
+struct SurfaceInstance {
+    Bounds bounds;
+    Bounds content_mask;
+};
+
+StructuredBuffer<SurfaceInstance> surface_instances: register(t1);
+
+struct SurfaceVertexOutput {
+    float4 position: SV_Position;
+    float2 uv: TEXCOORD0;
+    float4 clip_distance: SV_ClipDistance;
+};
+
+struct SurfaceFragmentInput {
+    float4 position: SV_Position;
+    float2 uv: TEXCOORD0;
+};
+
+SurfaceVertexOutput surface_vertex(uint vertex_id: SV_VertexID, uint instance_id: SV_InstanceID) {
+    float2 unit_vertex = float2(float(vertex_id & 1u), 0.5 * float(vertex_id & 2u));
+    SurfaceInstance surface = surface_instances[instance_id];
+
+    SurfaceVertexOutput output;
+    output.position = to_device_position(unit_vertex, surface.bounds);
+    output.uv = unit_vertex;
+    output.clip_distance = distance_from_clip_rect(unit_vertex, surface.bounds, surface.content_mask);
+    return output;
+}
+
+float4 surface_fragment(SurfaceFragmentInput input): SV_Target {
+    return t_sprite.Sample(s_sprite, input.uv);
+}

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3555,6 +3555,11 @@ impl Window {
     }
 
     /// Paint a GPU texture into the scene for the next frame at the current z-index.
+    ///
+    /// This converts a platform-agnostic `GpuTextureHandle` into a platform-specific
+    /// `SurfaceSource` for the renderer to import and composite. The external renderer
+    /// and GPUI's compositor use separate GPU devices — texture memory is shared
+    /// zero-copy via OS-level handles.
     pub fn paint_gpu_texture(
         &mut self,
         bounds: Bounds<Pixels>,
@@ -3566,25 +3571,29 @@ impl Window {
         self.invalidator.debug_assert_paint();
 
         let scale_factor = self.scale_factor();
-        let bounds = bounds.scale(scale_factor);
         let content_mask = self.content_mask().scale(scale_factor);
 
-        // Convert universal GpuTextureHandle to platform-specific SurfaceSource
-        // All platforms use the same RGBA8 byte format - just different OS handles
+        // Apply object_fit to adjust bounds based on texture aspect ratio
+        let texture_size = crate::size(
+            crate::Pixels(texture_handle.width as f32),
+            crate::Pixels(texture_handle.height as f32),
+        );
+        let fitted_bounds = object_fit.get_bounds(bounds, texture_size);
+        let bounds = fitted_bounds.scale(scale_factor);
+
         #[cfg(target_os = "windows")]
         let source = SurfaceSource::SharedTexture {
             nt_handle: texture_handle.native_handle,
             width: texture_handle.width,
             height: texture_handle.height,
+            format: texture_handle.format,
         };
 
         #[cfg(target_os = "macos")]
         let source = {
             // On macOS, native_handle is an IOSurface ID
-            // Create IOSurface from the handle
             use metal::IOSurface;
             let io_surface = unsafe {
-                // IOSurface::from_id creates an IOSurface from its integer ID
                 IOSurface::from_id(texture_handle.native_handle as u32)
             };
             SurfaceSource::ImageBuffer(io_surface)
@@ -3595,6 +3604,7 @@ impl Window {
             fd: texture_handle.native_handle as i32,
             width: texture_handle.width,
             height: texture_handle.height,
+            format: texture_handle.format,
         };
 
         self.next_frame.scene.insert_primitive(PaintSurface {
@@ -3611,7 +3621,7 @@ impl Window {
     /// This method should only be called as part of the paint phase of element drawing.
     #[cfg(target_os = "macos")]
     pub fn paint_surface(&mut self, bounds: Bounds<Pixels>, image_buffer: CVPixelBuffer) {
-        use crate::PaintSurface;
+        use crate::{PaintSurface, SurfaceSource};
 
         self.invalidator.debug_assert_paint();
 
@@ -3622,7 +3632,8 @@ impl Window {
             order: 0,
             bounds,
             content_mask,
-            image_buffer,
+            object_fit: crate::ObjectFit::Fill,
+            source: SurfaceSource::ImageBuffer(image_buffer),
         });
     }
 


### PR DESCRIPTION
Bug fixes (all platforms):

   - surface.rs — Fixed SurfaceSource::Surface → SurfaceSource::ImageBuffer for macOS, added format: GpuTextureFormat to SharedTexture/DmaBuf variants
   - window.rs — Fixed paint_surface() to use SurfaceSource::ImageBuffer(...), added object_fit bounds calculation to paint_gpu_texture(), plumbed format through
   - metal_renderer.rs / blade_renderer.rs — Fixed surface.image_buffer → destructure surface.source

  New Windows rendering pipeline:

   - shaders.hlsl — Added surface vertex/fragment shaders (textured quad with content mask clipping via SV_ClipDistance)
   - build.rs — Added "surface" to FXC shader compilation modules
   - directx_renderer.rs — Full implementation:
    - SurfaceInstance repr(C) struct matching HLSL layout
    - surface_pipeline: PipelineState<SurfaceInstance> 
    - clamp_sampler (CLAMP address mode, prevents edge bleeding)
    - ShaderModule::Surface with debug/release shader loading
    - gpu_texture_format_to_dxgi() converter (RGBA8/BGRA8/RGBA16F)
    - draw_surfaces() — complete implementation:
     - Imports shared texture via OpenSharedResource1(NT_HANDLE)
     - Validates format with GetDesc() against producer declaration
     - Keyed mutex GPU sync with correct consumer protocol (AcquireSync(1)/ReleaseSync(0))
     - Uses raw vtable call to bypass windows crate's HRESULT wrapping (WAIT_TIMEOUT = 0x102 is a success HRESULT that .ok() incorrectly treats as Ok(()))
     - Creates explicit SRV desc for format safety
     - Per-surface error handling (log + skip, never crash the frame)