### PR TITLE
Add clipboard support via arboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +761,15 @@ name = "circular-buffer"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c638459986b83c2b885179bd4ea6a2cbb05697b001501a56adb3a3d230803b"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -1356,6 +1385,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etagere"
@@ -1974,6 +2009,7 @@ name = "gpui-ce"
 version = "0.3.3"
 dependencies = [
  "anyhow",
+ "arboard",
  "async-task",
  "backtrace",
  "bytemuck",
@@ -2005,7 +2041,7 @@ dependencies = [
  "lyon",
  "num_cpus",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "parking",
  "parking_lot",
@@ -3592,6 +3628,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3684,19 @@ dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3693,6 +3754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-link-presentation"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,7 +3772,7 @@ checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -6972,7 +7044,7 @@ dependencies = [
  "memmap2",
  "ndk",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ wgpu = { git = "https://github.com/Far-Beyond-Pulsar/wgpu", rev = "fce5b80e80173
 priority-threadpool = { git = "https://github.com/mdeand/priority-threadpool" }
 anyhow = "1.0.86"
 async-task = "4.7"
+arboard = "3.6.1"
 backtrace = { version = "0.3", optional = true }
 bytemuck = { version = "1.24", features = ["derive"] }
 circular-buffer = "1.0"

--- a/src/platform/cross/platform.rs
+++ b/src/platform/cross/platform.rs
@@ -27,6 +27,7 @@ fn device_button_to_gpui(button: u32) -> Option<MouseButton> {
     }
 }
 use anyhow::Result;
+use arboard::Clipboard;
 use collections::FxHashMap;
 use std::{cell::Cell, rc::Rc, sync::Arc, time::Instant};
 use winit::event_loop::ActiveEventLoop;
@@ -405,12 +406,26 @@ impl Platform for CrossPlatform {
         false
     }
 
-    fn write_to_clipboard(&self, _item: crate::ClipboardItem) {
-        log::warn!("write_to_clipboard is not yet implemented on this platform");
+    fn write_to_clipboard(&self, item: crate::ClipboardItem) {
+        let Some(text) = item.text() else {
+            log::warn!("write_to_clipboard currently supports text entries only on this platform");
+            return;
+        };
+
+        match Clipboard::new().and_then(|mut clipboard| clipboard.set_text(text)) {
+            Ok(()) => {}
+            Err(error) => log::warn!("failed to write to clipboard: {error}"),
+        }
     }
 
     fn read_from_clipboard(&self) -> Option<crate::ClipboardItem> {
-        None
+        match Clipboard::new().and_then(|mut clipboard| clipboard.get_text()) {
+            Ok(text) => Some(crate::ClipboardItem::new_string(text)),
+            Err(error) => {
+                log::warn!("failed to read from clipboard: {error}");
+                None
+            }
+        }
     }
 
     fn write_credentials(
@@ -1060,7 +1075,18 @@ fn winit_key_to_keystroke(
                 | NamedKey::Meta => return None,
                 _ => return None,
             };
-            (key_name.to_string(), None)
+            let key_char = match named {
+                NamedKey::Space
+                    if !modifiers.control
+                        && !modifiers.platform
+                        && !modifiers.function
+                        && !modifiers.alt =>
+                {
+                    Some(" ".to_string())
+                }
+                _ => None,
+            };
+            (key_name.to_string(), key_char)
         }
         WKey::Character(ch) => {
             let key = ch.to_lowercase();
@@ -1089,6 +1115,38 @@ fn winit_key_to_keystroke(
         key,
         key_char,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::winit_key_to_keystroke;
+    use crate::Modifiers;
+    use winit::keyboard::{Key, NamedKey};
+
+    #[test]
+    fn translates_space_to_text_input() {
+        let keystroke = winit_key_to_keystroke(&Key::Named(NamedKey::Space), Modifiers::default(), &None)
+            .expect("space should produce a keystroke");
+
+        assert_eq!(keystroke.key, "space");
+        assert_eq!(keystroke.key_char.as_deref(), Some(" "));
+    }
+
+    #[test]
+    fn does_not_treat_command_space_as_text_input() {
+        let keystroke = winit_key_to_keystroke(
+            &Key::Named(NamedKey::Space),
+            Modifiers {
+                platform: true,
+                ..Modifiers::default()
+            },
+            &None,
+        )
+        .expect("command-space should still produce a keystroke");
+
+        assert_eq!(keystroke.key, "space");
+        assert_eq!(keystroke.key_char, None);
+    }
 }
 
 /// Set the macOS application Dock icon by calling `NSApp setApplicationIconImage:`.


### PR DESCRIPTION
Implement clipboard read/write on the cross platform backend using the arboard crate. write_to_clipboard now writes text entries (logs and returns for non-text items) and read_from_clipboard returns a string ClipboardItem or logs an error. Added arboard to Cargo.toml and updated Cargo.lock accordingly. Also adjust key handling to return a space character for NamedKey::Space when no modifiers are held.