### PR TITLE
Feature: Radial Gradients

### DIFF
--- a/examples/bench/paths_bench.rs
+++ b/examples/bench/paths_bench.rs
@@ -36,8 +36,8 @@ impl PaintingViewer {
                 path,
                 linear_gradient(
                     180.,
-                    linear_color_stop(rgb(0xFACC15), 0.7),
-                    linear_color_stop(rgb(0xD56D0C), 1.),
+                    gradient_color_stop(rgb(0xFACC15), 0.7),
+                    gradient_color_stop(rgb(0xD56D0C), 1.),
                 )
                 .color_space(ColorSpace::Oklab),
             ));

--- a/examples/bench/pattern.rs
+++ b/examples/bench/pattern.rs
@@ -91,8 +91,8 @@ impl Render for PatternExample {
                     .h(px(40.0))
                     .bg(linear_gradient(
                         45.,
-                        linear_color_stop(gpui::red(), 0.),
-                        linear_color_stop(gpui::blue(), 1.),
+                        gradient_color_stop(gpui::red(), 0.),
+                        gradient_color_stop(gpui::blue(), 1.),
                     )),
             )
     }

--- a/examples/learn/blur_showcase.rs
+++ b/examples/learn/blur_showcase.rs
@@ -47,8 +47,35 @@ fn blur_card(
         .backdrop_blur(blur_radius)
         .border_1()
         .border_color(rgb(0x444444))
-        .child(div().text_sm().font_weight(gpui::FontWeight::BOLD).child(title))
+        .child(
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::BOLD)
+                .child(title),
+        )
         .child(div().text_xs().text_color(rgb(0x999999)).child(subtitle))
+}
+
+fn radial_background_1() -> impl IntoElement {
+    div().h_20().rounded_lg().bg(gpui::radial_gradient(
+        0.5,
+        0.5,
+        0.8,
+        0.8,
+        gpui::gradient_color_stop(rgb(0xff5d73), 0.0),
+        gpui::gradient_color_stop(rgb(0x6d77ff), 1.0),
+    ))
+}
+
+fn radial_background_2() -> impl IntoElement {
+    div().h_20().rounded_lg().bg(gpui::radial_gradient(
+        0.7,
+        0.32,
+        0.9,
+        0.6,
+        gpui::gradient_color_stop(rgb(0x80ed99), 0.0),
+        gpui::gradient_color_stop(rgb(0x000000), 1.0),
+    ))
 }
 
 fn demo_row(
@@ -64,34 +91,68 @@ fn demo_row(
         .gap_2()
         .child(div().text_xs().text_color(rgb(0x999999)).child(heading))
         .child(
-            div()
-                .relative()
-                .child(color_strip())
-                .child(
-                    div()
-                        .absolute()
-                        .top_0()
-                        .left_0()
-                        .right_0()
-                        .bottom_0()
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .p_4()
-                        .child(blur_card(
-                            "blur-card",
-                            "Frosted Glass",
-                            "Backdrop blur + opacity",
-                            blur_radius,
-                            opacity,
-                        )).w_full(),
-                ),
+            div().relative().child(color_strip()).child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .left_0()
+                    .right_0()
+                    .bottom_0()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .p_4()
+                    .child(blur_card(
+                        "blur-card",
+                        "Frosted Glass",
+                        "Backdrop blur + opacity",
+                        blur_radius,
+                        opacity,
+                    ))
+                    .w_full(),
+            ),
+        )
+}
+
+fn radial_demo_row(
+    id: &'static str,
+    heading: &'static str,
+    blur_radius: f32,
+    opacity: f32,
+    background: impl IntoElement,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(div().text_xs().text_color(rgb(0x999999)).child(heading))
+        .child(
+            div().relative().child(background).child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .left_0()
+                    .right_0()
+                    .bottom_0()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .p_4()
+                    .child(blur_card(
+                        "blur-card",
+                        "Frosted Glass",
+                        "Backdrop blur + radial gradient",
+                        blur_radius,
+                        opacity,
+                    ))
+                    .w_full(),
+            ),
         )
 }
 
 impl Render for BlurShowcase {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-
         div()
             .size_full()
             .p_6()
@@ -129,6 +190,20 @@ impl Render for BlurShowcase {
                 "backdrop_blur(18.0), opacity(0.82)",
                 18.0,
                 0.82,
+            ))
+            .child(radial_demo_row(
+                "radial-1",
+                "Radial Gradient #1",
+                6.0,
+                0.82,
+                radial_background_1(),
+            ))
+            .child(radial_demo_row(
+                "radial-2",
+                "Radial Gradient #2",
+                12.0,
+                0.82,
+                radial_background_2(),
             ))
     }
 }

--- a/examples/legacy/gradient.rs
+++ b/examples/legacy/gradient.rs
@@ -1,6 +1,6 @@
 use gpui::{
     App, Application, Bounds, ColorSpace, Context, Half, Render, Window, WindowOptions, canvas,
-    div, linear_color_stop, linear_gradient, point, prelude::*, px, size,
+    div, linear_color_stop, linear_gradient, point, prelude::*, px, radial_gradient, size,
 };
 
 struct GradientViewer {
@@ -239,6 +239,46 @@ impl Render for GradientViewer {
                     );
                 },
             )))
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .gap_3()
+                    .h_32()
+                    .child(
+                        div().flex_1().rounded_xl().bg(radial_gradient(
+                            0.5,
+                            0.5,
+                            0.5,
+                            0.5,
+                            linear_color_stop(gpui::white(), 0.0),
+                            linear_color_stop(gpui::blue(), 1.0),
+                        )
+                        .color_space(color_space)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(radial_gradient(
+                            0.3,
+                            0.3,
+                            0.7,
+                            0.7,
+                            linear_color_stop(gpui::yellow(), 0.0),
+                            linear_color_stop(gpui::red(), 1.0),
+                        )
+                        .color_space(color_space)),
+                    )
+                    .child(
+                        div().flex_1().rounded_xl().bg(radial_gradient(
+                            0.8,
+                            0.2,
+                            0.8,
+                            0.6,
+                            linear_color_stop(gpui::green(), 0.0),
+                            linear_color_stop(gpui::black(), 1.0),
+                        )
+                        .color_space(color_space)),
+                    ),
+            )
     }
 }
 

--- a/examples/legacy/gradient.rs
+++ b/examples/legacy/gradient.rs
@@ -1,6 +1,6 @@
 use gpui::{
     App, Application, Bounds, ColorSpace, Context, Half, Render, Window, WindowOptions, canvas,
-    div, linear_color_stop, linear_gradient, point, prelude::*, px, radial_gradient, size,
+    div, gradient_color_stop, linear_gradient, point, prelude::*, px, radial_gradient, size,
 };
 
 struct GradientViewer {
@@ -93,32 +93,32 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             45.,
-                            linear_color_stop(gpui::red(), 0.),
-                            linear_color_stop(gpui::blue(), 1.),
+                            gradient_color_stop(gpui::red(), 0.),
+                            gradient_color_stop(gpui::blue(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             135.,
-                            linear_color_stop(gpui::red(), 0.),
-                            linear_color_stop(gpui::green(), 1.),
+                            gradient_color_stop(gpui::red(), 0.),
+                            gradient_color_stop(gpui::green(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             225.,
-                            linear_color_stop(gpui::green(), 0.),
-                            linear_color_stop(gpui::blue(), 1.),
+                            gradient_color_stop(gpui::green(), 0.),
+                            gradient_color_stop(gpui::blue(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             315.,
-                            linear_color_stop(gpui::green(), 0.),
-                            linear_color_stop(gpui::yellow(), 1.),
+                            gradient_color_stop(gpui::green(), 0.),
+                            gradient_color_stop(gpui::yellow(), 1.),
                         )
                         .color_space(color_space)),
                     ),
@@ -133,32 +133,32 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             0.,
-                            linear_color_stop(gpui::red(), 0.),
-                            linear_color_stop(gpui::white(), 1.),
+                            gradient_color_stop(gpui::red(), 0.),
+                            gradient_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             90.,
-                            linear_color_stop(gpui::blue(), 0.),
-                            linear_color_stop(gpui::white(), 1.),
+                            gradient_color_stop(gpui::blue(), 0.),
+                            gradient_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             180.,
-                            linear_color_stop(gpui::green(), 0.),
-                            linear_color_stop(gpui::white(), 1.),
+                            gradient_color_stop(gpui::green(), 0.),
+                            gradient_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     )
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             360.,
-                            linear_color_stop(gpui::yellow(), 0.),
-                            linear_color_stop(gpui::white(), 1.),
+                            gradient_color_stop(gpui::yellow(), 0.),
+                            gradient_color_stop(gpui::white(), 1.),
                         )
                         .color_space(color_space)),
                     ),
@@ -166,16 +166,16 @@ impl Render for GradientViewer {
             .child(
                 div().flex_1().rounded_xl().bg(linear_gradient(
                     0.,
-                    linear_color_stop(gpui::green(), 0.05),
-                    linear_color_stop(gpui::yellow(), 0.95),
+                    gradient_color_stop(gpui::green(), 0.05),
+                    gradient_color_stop(gpui::yellow(), 0.95),
                 )
                 .color_space(color_space)),
             )
             .child(
                 div().flex_1().rounded_xl().bg(linear_gradient(
                     90.,
-                    linear_color_stop(gpui::blue(), 0.05),
-                    linear_color_stop(gpui::red(), 0.95),
+                    gradient_color_stop(gpui::blue(), 0.05),
+                    gradient_color_stop(gpui::red(), 0.95),
                 )
                 .color_space(color_space)),
             )
@@ -188,8 +188,8 @@ impl Render for GradientViewer {
                         div().flex().flex_1().gap_3().child(
                             div().flex_1().rounded_xl().bg(linear_gradient(
                                 90.,
-                                linear_color_stop(gpui::blue(), 0.5),
-                                linear_color_stop(gpui::red(), 0.5),
+                                gradient_color_stop(gpui::blue(), 0.5),
+                                gradient_color_stop(gpui::red(), 0.5),
                             )
                             .color_space(color_space)),
                         ),
@@ -197,8 +197,8 @@ impl Render for GradientViewer {
                     .child(
                         div().flex_1().rounded_xl().bg(linear_gradient(
                             180.,
-                            linear_color_stop(gpui::green(), 0.),
-                            linear_color_stop(gpui::blue(), 0.5),
+                            gradient_color_stop(gpui::green(), 0.),
+                            gradient_color_stop(gpui::blue(), 0.5),
                         )
                         .color_space(color_space)),
                     ),
@@ -232,8 +232,8 @@ impl Render for GradientViewer {
                         path,
                         linear_gradient(
                             180.,
-                            linear_color_stop(gpui::red(), 0.),
-                            linear_color_stop(gpui::blue(), 1.),
+                            gradient_color_stop(gpui::red(), 0.),
+                            gradient_color_stop(gpui::blue(), 1.),
                         )
                         .color_space(color_space),
                     );
@@ -251,8 +251,8 @@ impl Render for GradientViewer {
                             0.5,
                             0.5,
                             0.5,
-                            linear_color_stop(gpui::white(), 0.0),
-                            linear_color_stop(gpui::blue(), 1.0),
+                            gradient_color_stop(gpui::white(), 0.0),
+                            gradient_color_stop(gpui::blue(), 1.0),
                         )
                         .color_space(color_space)),
                     )
@@ -262,8 +262,8 @@ impl Render for GradientViewer {
                             0.3,
                             0.7,
                             0.7,
-                            linear_color_stop(gpui::yellow(), 0.0),
-                            linear_color_stop(gpui::red(), 1.0),
+                            gradient_color_stop(gpui::yellow(), 0.0),
+                            gradient_color_stop(gpui::red(), 1.0),
                         )
                         .color_space(color_space)),
                     )
@@ -273,8 +273,8 @@ impl Render for GradientViewer {
                             0.2,
                             0.8,
                             0.6,
-                            linear_color_stop(gpui::green(), 0.0),
-                            linear_color_stop(gpui::black(), 1.0),
+                            gradient_color_stop(gpui::green(), 0.0),
+                            gradient_color_stop(gpui::black(), 1.0),
                         )
                         .color_space(color_space)),
                     ),

--- a/examples/legacy/gradient.rs
+++ b/examples/legacy/gradient.rs
@@ -203,7 +203,7 @@ impl Render for GradientViewer {
                         .color_space(color_space)),
                     ),
             )
-            .child(div().h_24().child(canvas(
+            .child(div().h_16().child(canvas(
                 move |_, _, _| {},
                 move |bounds, _, window, _| {
                     let size = size(bounds.size.width * 0.8, px(80.));
@@ -216,7 +216,7 @@ impl Render for GradientViewer {
                     };
                     let height = square_bounds.size.height;
                     let horizontal_offset = height;
-                    let vertical_offset = px(30.);
+                    let vertical_offset = px(0.);
                     let mut builder = gpui::PathBuilder::fill();
                     builder.move_to(square_bounds.bottom_left());
                     builder

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, bail};
+use derive_more::Display;
 use schemars::{JsonSchema, json_schema};
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -658,6 +659,7 @@ pub(crate) enum BackgroundTag {
     Solid = 0,
     LinearGradient = 1,
     PatternSlash = 2,
+    RadialGradient = 3,
 }
 
 /// A color space for color interpolation.
@@ -691,7 +693,7 @@ pub struct Background {
     pub(crate) tag: BackgroundTag,
     pub(crate) color_space: ColorSpace,
     pub(crate) solid: Hsla,
-    pub(crate) gradient_angle_or_pattern_height: f32,
+    pub(crate) gradient_params: GradientParams,
     pub(crate) colors: [GradientStop; 2],
     /// Padding for alignment for repr(C) layout.
     pub(crate) pad: u32,
@@ -705,14 +707,21 @@ impl std::fmt::Debug for Background {
                 write!(
                     f,
                     "LinearGradient({}, {:?}, {:?})",
-                    self.gradient_angle_or_pattern_height, self.colors[0], self.colors[1]
+                    self.gradient_params, self.colors[0], self.colors[1]
                 )
             }
             BackgroundTag::PatternSlash => {
                 write!(
                     f,
                     "PatternSlash({:?}, {})",
-                    self.solid, self.gradient_angle_or_pattern_height
+                    self.solid, self.gradient_params
+                )
+            }
+            BackgroundTag::RadialGradient => {
+                write!(
+                    f,
+                    "RadialGradient(params: {:?}, {:?}, {:?})",
+                    self.gradient_params, self.colors[0], self.colors[1]
                 )
             }
         }
@@ -726,7 +735,7 @@ impl Default for Background {
             tag: BackgroundTag::Solid,
             solid: Hsla::default(),
             color_space: ColorSpace::default(),
-            gradient_angle_or_pattern_height: 0.0,
+            gradient_params: GradientParams::default(),
             colors: [GradientStop::default(), GradientStop::default()],
             pad: 0,
         }
@@ -742,7 +751,9 @@ pub fn pattern_slash(color: Hsla, width: f32, interval: f32) -> Background {
     Background {
         tag: BackgroundTag::PatternSlash,
         solid: color,
-        gradient_angle_or_pattern_height: height,
+        gradient_params: GradientParams {
+            params: [height, 0.0, 0.0, 0.0],
+        },
         ..Default::default()
     }
 }
@@ -769,7 +780,9 @@ pub fn linear_gradient(
 ) -> Background {
     Background {
         tag: BackgroundTag::LinearGradient,
-        gradient_angle_or_pattern_height: angle,
+        gradient_params: GradientParams {
+            params: [angle, 0.0, 0.0, 0.0],
+        },
         colors: [from.into(), to.into()],
         ..Default::default()
     }
@@ -803,10 +816,20 @@ pub struct GradientStop {
 ///
 /// Additional gradient types may interpret these values differently.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct GradientParams {
     /// The parameters for the gradient, interpreted based on the gradient type.
     pub params: [f32; 4],
+}
+
+impl Display for GradientParams {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "GradientParams({}, {}, {}, {})",
+            self.params[0], self.params[1], self.params[2], self.params[3]
+        )
+    }
 }
 
 /// Creates a new linear color stop.
@@ -855,6 +878,7 @@ impl Background {
             BackgroundTag::Solid => self.solid.is_transparent(),
             BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.is_transparent()),
             BackgroundTag::PatternSlash => self.solid.is_transparent(),
+            BackgroundTag::RadialGradient => self.colors.iter().all(|c| c.color.is_transparent()),
         }
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -788,12 +788,10 @@ pub fn linear_gradient(
 }
 
 /// Creates a radial gradient background color.
-///
 /// The gradient radiates outward from a center point.
 ///
 /// `center_x` and `center_y` define the center of the gradient
 /// in normalized coordinates, where:
-///
 /// - `0.0` represents the start (left or top)
 /// - `1.0` represents the end (right or bottom)
 ///
@@ -835,28 +833,6 @@ pub struct GradientStop {
     pub color: Hsla,
     /// The position of the gradient, in the range 0.0 to 1.0.
     pub position: f32,
-}
-
-/// Generic parameters for procedural gradients.
-/// The interpretation of the parameters depends on the gradient type.
-///
-/// Current conventions:
-///
-/// Linear gradients:
-/// - data[0]: angle in degrees
-///
-/// Radial gradients:
-/// - data[0]: center x, normalized to [-1.0, 1.0]
-/// - data[1]: center y, normalized to [-1.0, 1.0]
-/// - data[2]: radius x
-/// - data[3]: radius y
-///
-/// Additional gradient types may interpret these values differently.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct GradientParams {
-    /// The parameters for the gradient, interpreted based on the gradient type.
-    pub params: [f32; 4],
 }
 
 /// Creates a new gradient color stop.

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context as _, bail};
-use derive_more::Display;
 use schemars::{JsonSchema, json_schema};
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -659,7 +658,6 @@ pub(crate) enum BackgroundTag {
     Solid = 0,
     LinearGradient = 1,
     PatternSlash = 2,
-    RadialGradient = 3,
 }
 
 /// A color space for color interpolation.
@@ -693,7 +691,7 @@ pub struct Background {
     pub(crate) tag: BackgroundTag,
     pub(crate) color_space: ColorSpace,
     pub(crate) solid: Hsla,
-    pub(crate) gradient_params: GradientParams,
+    pub(crate) gradient_angle_or_pattern_height: f32,
     pub(crate) colors: [GradientStop; 2],
     /// Padding for alignment for repr(C) layout.
     pub(crate) pad: u32,
@@ -707,21 +705,14 @@ impl std::fmt::Debug for Background {
                 write!(
                     f,
                     "LinearGradient({}, {:?}, {:?})",
-                    self.gradient_params, self.colors[0], self.colors[1]
+                    self.gradient_angle_or_pattern_height, self.colors[0], self.colors[1]
                 )
             }
             BackgroundTag::PatternSlash => {
                 write!(
                     f,
                     "PatternSlash({:?}, {})",
-                    self.solid, self.gradient_params
-                )
-            }
-            BackgroundTag::RadialGradient => {
-                write!(
-                    f,
-                    "RadialGradient(params: {:?}, {:?}, {:?})",
-                    self.gradient_params, self.colors[0], self.colors[1]
+                    self.solid, self.gradient_angle_or_pattern_height
                 )
             }
         }
@@ -735,7 +726,7 @@ impl Default for Background {
             tag: BackgroundTag::Solid,
             solid: Hsla::default(),
             color_space: ColorSpace::default(),
-            gradient_params: GradientParams::default(),
+            gradient_angle_or_pattern_height: 0.0,
             colors: [GradientStop::default(), GradientStop::default()],
             pad: 0,
         }
@@ -751,9 +742,7 @@ pub fn pattern_slash(color: Hsla, width: f32, interval: f32) -> Background {
     Background {
         tag: BackgroundTag::PatternSlash,
         solid: color,
-        gradient_params: GradientParams {
-            params: [height, 0.0, 0.0, 0.0],
-        },
+        gradient_angle_or_pattern_height: height,
         ..Default::default()
     }
 }
@@ -780,9 +769,7 @@ pub fn linear_gradient(
 ) -> Background {
     Background {
         tag: BackgroundTag::LinearGradient,
-        gradient_params: GradientParams {
-            params: [angle, 0.0, 0.0, 0.0],
-        },
+        gradient_angle_or_pattern_height: angle,
         colors: [from.into(), to.into()],
         ..Default::default()
     }
@@ -816,20 +803,10 @@ pub struct GradientStop {
 ///
 /// Additional gradient types may interpret these values differently.
 #[repr(C)]
-#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GradientParams {
     /// The parameters for the gradient, interpreted based on the gradient type.
     pub params: [f32; 4],
-}
-
-impl Display for GradientParams {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "GradientParams({}, {}, {}, {})",
-            self.params[0], self.params[1], self.params[2], self.params[3]
-        )
-    }
 }
 
 /// Creates a new linear color stop.
@@ -878,7 +855,6 @@ impl Background {
             BackgroundTag::Solid => self.solid.is_transparent(),
             BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.is_transparent()),
             BackgroundTag::PatternSlash => self.solid.is_transparent(),
-            BackgroundTag::RadialGradient => self.colors.iter().all(|c| c.color.is_transparent()),
         }
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -696,8 +696,6 @@ pub struct Background {
     pub(crate) param2: f32,
     pub(crate) param3: f32,
     pub(crate) colors: [GradientStop; 2],
-    /// Padding for alignment for repr(C) layout.
-    pub(crate) pad: u8,
 }
 
 impl std::fmt::Debug for Background {
@@ -730,7 +728,6 @@ impl Default for Background {
             param2: 0.0,
             param3: 0.0,
             colors: [GradientStop::default(), GradientStop::default()],
-            pad: 0,
         }
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -692,7 +692,7 @@ pub struct Background {
     pub(crate) color_space: ColorSpace,
     pub(crate) solid: Hsla,
     pub(crate) gradient_angle_or_pattern_height: f32,
-    pub(crate) colors: [LinearColorStop; 2],
+    pub(crate) colors: [GradientStop; 2],
     /// Padding for alignment for repr(C) layout.
     pub(crate) pad: u32,
 }
@@ -727,7 +727,7 @@ impl Default for Background {
             solid: Hsla::default(),
             color_space: ColorSpace::default(),
             gradient_angle_or_pattern_height: 0.0,
-            colors: [LinearColorStop::default(), LinearColorStop::default()],
+            colors: [GradientStop::default(), GradientStop::default()],
             pad: 0,
         }
     }
@@ -764,8 +764,8 @@ pub fn solid_background(color: impl Into<Hsla>) -> Background {
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient>
 pub fn linear_gradient(
     angle: f32,
-    from: impl Into<LinearColorStop>,
-    to: impl Into<LinearColorStop>,
+    from: impl Into<GradientStop>,
+    to: impl Into<GradientStop>,
 ) -> Background {
     Background {
         tag: BackgroundTag::LinearGradient,
@@ -780,7 +780,7 @@ pub fn linear_gradient(
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#linear-color-stop>
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[repr(C)]
-pub struct LinearColorStop {
+pub struct GradientStop {
     /// The color of the color stop.
     pub color: Hsla,
     /// The percentage of the gradient, in the range 0.0 to 1.0.
@@ -790,14 +790,14 @@ pub struct LinearColorStop {
 /// Creates a new linear color stop.
 ///
 /// The percentage of the gradient, in the range 0.0 to 1.0.
-pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> LinearColorStop {
-    LinearColorStop {
+pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> GradientStop {
+    GradientStop {
         color: color.into(),
         percentage,
     }
 }
 
-impl LinearColorStop {
+impl GradientStop {
     /// Returns a new color stop with the same color, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         Self {

--- a/src/color.rs
+++ b/src/color.rs
@@ -658,6 +658,7 @@ pub(crate) enum BackgroundTag {
     Solid = 0,
     LinearGradient = 1,
     PatternSlash = 2,
+    RadialGradient = 3,
 }
 
 /// A color space for color interpolation.
@@ -711,6 +712,18 @@ impl std::fmt::Debug for Background {
             }
             BackgroundTag::PatternSlash => {
                 write!(f, "PatternSlash({:?}, {})", self.solid, self.param0)
+            }
+            BackgroundTag::RadialGradient => {
+                write!(
+                    f,
+                    "RadialGradient(center=({}, {}), radius=({}, {}), {:?}, {:?})",
+                    self.param0,
+                    self.param1,
+                    self.param2,
+                    self.param3,
+                    self.colors[0],
+                    self.colors[1]
+                )
             }
         }
     }
@@ -769,6 +782,44 @@ pub fn linear_gradient(
     Background {
         tag: BackgroundTag::LinearGradient,
         param0: angle,
+        colors: [from.into(), to.into()],
+        ..Default::default()
+    }
+}
+
+/// Creates a radial gradient background color.
+///
+/// The gradient radiates outward from a center point.
+///
+/// `center_x` and `center_y` define the center of the gradient
+/// in normalized coordinates, where:
+///
+/// - `0.0` represents the start (left or top)
+/// - `1.0` represents the end (right or bottom)
+///
+/// `radius_x` and `radius_y` define the horizontal and vertical
+/// radii of the gradient in normalized space.
+///
+/// A value of `0.5` generally fills about half the container
+/// along that axis.
+///
+/// The gradient interpolates between the provided color stops.
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/radial-gradient>
+pub fn radial_gradient(
+    center_x: f32,
+    center_y: f32,
+    radius_x: f32,
+    radius_y: f32,
+    from: impl Into<GradientStop>,
+    to: impl Into<GradientStop>,
+) -> Background {
+    Background {
+        tag: BackgroundTag::RadialGradient,
+        param0: center_x,
+        param1: center_y,
+        param2: radius_x,
+        param3: radius_y,
         colors: [from.into(), to.into()],
         ..Default::default()
     }
@@ -852,7 +903,9 @@ impl Background {
     pub fn is_transparent(&self) -> bool {
         match self.tag {
             BackgroundTag::Solid => self.solid.is_transparent(),
-            BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.is_transparent()),
+            BackgroundTag::LinearGradient | BackgroundTag::RadialGradient => {
+                self.colors.iter().all(|c| c.color.is_transparent())
+            }
             BackgroundTag::PatternSlash => self.solid.is_transparent(),
         }
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -775,7 +775,7 @@ pub fn linear_gradient(
     }
 }
 
-/// A color stop in a linear gradient.
+/// A color stop for a gradient.
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#linear-color-stop>
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -785,6 +785,27 @@ pub struct GradientStop {
     pub color: Hsla,
     /// The percentage of the gradient, in the range 0.0 to 1.0.
     pub percentage: f32,
+}
+
+/// Generic parameters for procedural gradients.
+/// The interpretation of the parameters depends on the gradient type.
+///
+/// Current conventions:
+///
+/// Linear gradients:
+/// - data[0]: angle in degrees
+///
+/// Radial gradients:
+/// - data[0]: center x, normalized to [-1.0, 1.0]
+/// - data[1]: center y, normalized to [-1.0, 1.0]
+/// - data[2]: radius x
+/// - data[3]: radius y
+///
+/// Additional gradient types may interpret these values differently.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GradientParams {
+    pub data: [f32; 4],
 }
 
 /// Creates a new linear color stop.

--- a/src/color.rs
+++ b/src/color.rs
@@ -859,10 +859,10 @@ pub struct GradientParams {
     pub params: [f32; 4],
 }
 
-/// Creates a new linear color stop.
+/// Creates a new gradient color stop.
 ///
 /// The position of the gradient, in the range 0.0 to 1.0.
-pub fn linear_color_stop(color: impl Into<Hsla>, position: f32) -> GradientStop {
+pub fn gradient_color_stop(color: impl Into<Hsla>, position: f32) -> GradientStop {
     GradientStop {
         color: color.into(),
         position,
@@ -993,8 +993,8 @@ mod tests {
 
     #[test]
     fn test_background_linear_gradient() {
-        let from = linear_color_stop(rgba(0xff0099ff), 0.0);
-        let to = linear_color_stop(rgba(0x00ff99ff), 1.0);
+        let from = gradient_color_stop(rgba(0xff0099ff), 0.0);
+        let to = gradient_color_stop(rgba(0x00ff99ff), 1.0);
         let background = linear_gradient(90.0, from, to);
         assert_eq!(background.tag, BackgroundTag::LinearGradient);
         assert_eq!(background.colors[0], from);

--- a/src/color.rs
+++ b/src/color.rs
@@ -691,10 +691,13 @@ pub struct Background {
     pub(crate) tag: BackgroundTag,
     pub(crate) color_space: ColorSpace,
     pub(crate) solid: Hsla,
-    pub(crate) gradient_angle_or_pattern_height: f32,
+    pub(crate) param0: f32,
+    pub(crate) param1: f32,
+    pub(crate) param2: f32,
+    pub(crate) param3: f32,
     pub(crate) colors: [GradientStop; 2],
     /// Padding for alignment for repr(C) layout.
-    pub(crate) pad: u32,
+    pub(crate) pad: u8,
 }
 
 impl std::fmt::Debug for Background {
@@ -705,15 +708,11 @@ impl std::fmt::Debug for Background {
                 write!(
                     f,
                     "LinearGradient({}, {:?}, {:?})",
-                    self.gradient_angle_or_pattern_height, self.colors[0], self.colors[1]
+                    self.param0, self.colors[0], self.colors[1]
                 )
             }
             BackgroundTag::PatternSlash => {
-                write!(
-                    f,
-                    "PatternSlash({:?}, {})",
-                    self.solid, self.gradient_angle_or_pattern_height
-                )
+                write!(f, "PatternSlash({:?}, {})", self.solid, self.param0)
             }
         }
     }
@@ -726,7 +725,10 @@ impl Default for Background {
             tag: BackgroundTag::Solid,
             solid: Hsla::default(),
             color_space: ColorSpace::default(),
-            gradient_angle_or_pattern_height: 0.0,
+            param0: 0.0,
+            param1: 0.0,
+            param2: 0.0,
+            param3: 0.0,
             colors: [GradientStop::default(), GradientStop::default()],
             pad: 0,
         }
@@ -742,7 +744,7 @@ pub fn pattern_slash(color: Hsla, width: f32, interval: f32) -> Background {
     Background {
         tag: BackgroundTag::PatternSlash,
         solid: color,
-        gradient_angle_or_pattern_height: height,
+        param0: height,
         ..Default::default()
     }
 }
@@ -769,7 +771,7 @@ pub fn linear_gradient(
 ) -> Background {
     Background {
         tag: BackgroundTag::LinearGradient,
-        gradient_angle_or_pattern_height: angle,
+        param0: angle,
         colors: [from.into(), to.into()],
         ..Default::default()
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -783,8 +783,8 @@ pub fn linear_gradient(
 pub struct GradientStop {
     /// The color of the color stop.
     pub color: Hsla,
-    /// The percentage of the gradient, in the range 0.0 to 1.0.
-    pub percentage: f32,
+    /// The position of the gradient, in the range 0.0 to 1.0.
+    pub position: f32,
 }
 
 /// Generic parameters for procedural gradients.
@@ -805,16 +805,17 @@ pub struct GradientStop {
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GradientParams {
-    pub data: [f32; 4],
+    /// The parameters for the gradient, interpreted based on the gradient type.
+    pub params: [f32; 4],
 }
 
 /// Creates a new linear color stop.
 ///
-/// The percentage of the gradient, in the range 0.0 to 1.0.
-pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> GradientStop {
+/// The position of the gradient, in the range 0.0 to 1.0.
+pub fn linear_color_stop(color: impl Into<Hsla>, position: f32) -> GradientStop {
     GradientStop {
         color: color.into(),
-        percentage,
+        position,
     }
 }
 
@@ -822,7 +823,7 @@ impl GradientStop {
     /// Returns a new color stop with the same color, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         Self {
-            percentage: self.percentage,
+            position: self.position,
             color: self.color.opacity(factor),
         }
     }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -4,11 +4,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::{
-    AtlasTextureId, AtlasTile, DevicePixels, GpuSpecs, Hsla, LinearColorStop, MonochromeSprite,
-    PlatformAtlas, Pixels, PrimitiveBatch, Quad, ScaledPixels, Scene, TransformationMatrix,
-    color, geometry,
+    AtlasTextureId, AtlasTile, DevicePixels, GpuSpecs, GradientStop, Hsla, MonochromeSprite,
+    Pixels, PlatformAtlas, PrimitiveBatch, Quad, ScaledPixels, Scene, TransformationMatrix, color,
+    geometry,
     platform::cross::{
-        atlas::WgpuAtlas, render_context::{WgpuContext, ensure_buffer_size},
+        atlas::WgpuAtlas,
+        render_context::{WgpuContext, ensure_buffer_size},
         surface_registry::SurfaceId,
     },
 };
@@ -63,15 +64,15 @@ impl color::Hsla {
     ];
 }
 
-impl color::LinearColorStop {
+impl color::GradientStop {
     const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 2] = &[
         wgpu::VertexAttribute {
-            offset: std::mem::offset_of!(LinearColorStop, color) as wgpu::BufferAddress,
+            offset: std::mem::offset_of!(GradientStop, color) as wgpu::BufferAddress,
             shader_location: 0,
             format: wgpu::VertexFormat::Float32x4,
         },
         wgpu::VertexAttribute {
-            offset: std::mem::offset_of!(LinearColorStop, percentage) as wgpu::BufferAddress,
+            offset: std::mem::offset_of!(GradientStop, percentage) as wgpu::BufferAddress,
             shader_location: 1,
             format: wgpu::VertexFormat::Float32,
         },
@@ -81,7 +82,7 @@ impl color::LinearColorStop {
 impl color::Background {
     const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 7] = &{
         let linear_color_stop_vertex_attributes = map_attributes(
-            LinearColorStop::VERTEX_ATTRIBUTES,
+            GradientStop::VERTEX_ATTRIBUTES,
             4,
             std::mem::offset_of!(color::Background, colors) as wgpu::BufferAddress,
         );
@@ -332,12 +333,12 @@ struct PathsData {
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct GpuPathVertex {
-    xy_position:         [f32; 2],  // offset  0
-    st_position:         [f32; 2],  // offset  8
-    hsla:                [f32; 4],  // offset 16  (h, s, l, a)
-    content_mask_origin: [f32; 2],  // offset 32
-    content_mask_size:   [f32; 2],  // offset 40
-}                                   // stride  48
+    xy_position: [f32; 2],         // offset  0
+    st_position: [f32; 2],         // offset  8
+    hsla: [f32; 4],                // offset 16  (h, s, l, a)
+    content_mask_origin: [f32; 2], // offset 32
+    content_mask_size: [f32; 2],   // offset 40
+} // stride  48
 
 struct UnderlinesData {
     globals: GlobalParams,
@@ -633,12 +634,15 @@ impl WgpuPipelines {
                 source: wgpu::ShaderSource::Wgsl(include_str!("shaders/shadows.wgsl").into()),
             });
 
-        let backdrop_blur_shader = context
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("backdrop_blur_shader"),
-                source: wgpu::ShaderSource::Wgsl(include_str!("shaders/backdrop_blur.wgsl").into()),
-            });
+        let backdrop_blur_shader =
+            context
+                .device
+                .create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: Some("backdrop_blur_shader"),
+                    source: wgpu::ShaderSource::Wgsl(
+                        include_str!("shaders/backdrop_blur.wgsl").into(),
+                    ),
+                });
 
         let underlines_shader = context
             .device
@@ -761,7 +765,10 @@ impl WgpuPipelines {
                 .device
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("quads_pipeline_layout"),
-                    bind_group_layouts: &[Some(&globals_bind_group_layout), Some(&quads_bind_group_layout)],
+                    bind_group_layouts: &[
+                        Some(&globals_bind_group_layout),
+                        Some(&quads_bind_group_layout),
+                    ],
                     immediate_size: 0,
                 });
 
@@ -787,7 +794,10 @@ impl WgpuPipelines {
                 .device
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("shadows_pipeline_layout"),
-                    bind_group_layouts: &[Some(&globals_bind_group_layout), Some(&shadows_bind_group_layout)],
+                    bind_group_layouts: &[
+                        Some(&globals_bind_group_layout),
+                        Some(&shadows_bind_group_layout),
+                    ],
                     immediate_size: 0,
                 });
 
@@ -983,7 +993,10 @@ impl WgpuPipelines {
                 .device
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("surfaces_pipeline_layout"),
-                    bind_group_layouts: &[Some(&globals_bind_group_layout), Some(&surfaces_bind_group_layout)],
+                    bind_group_layouts: &[
+                        Some(&globals_bind_group_layout),
+                        Some(&surfaces_bind_group_layout),
+                    ],
                     immediate_size: 0,
                 });
 
@@ -1613,7 +1626,9 @@ impl WgpuRenderer {
                 &self.context.quads_buffer,
                 data.len() as u64,
                 "Quads Buffer",
-                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+                wgpu::BufferUsages::VERTEX
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::STORAGE,
             );
             self.context
                 .queue
@@ -1626,7 +1641,9 @@ impl WgpuRenderer {
                 &self.context.shadows_buffer,
                 data.len() as u64,
                 "Shadows Buffer",
-                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+                wgpu::BufferUsages::VERTEX
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::STORAGE,
             );
             self.context
                 .queue
@@ -1641,9 +1658,11 @@ impl WgpuRenderer {
                 "Backdrop Blurs Buffer",
                 wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             );
-            self.context
-                .queue
-                .write_buffer(&self.context.backdrop_blurs_buffer.lock().unwrap(), 0, data);
+            self.context.queue.write_buffer(
+                &self.context.backdrop_blurs_buffer.lock().unwrap(),
+                0,
+                data,
+            );
         }
         if !scene.underlines.is_empty() {
             let data = unsafe { as_bytes(&scene.underlines) };
@@ -1652,11 +1671,15 @@ impl WgpuRenderer {
                 &self.context.underlines_buffer,
                 data.len() as u64,
                 "Underlines Buffer",
-                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+                wgpu::BufferUsages::VERTEX
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::STORAGE,
             );
-            self.context
-                .queue
-                .write_buffer(&self.context.underlines_buffer.lock().unwrap(), 0, data);
+            self.context.queue.write_buffer(
+                &self.context.underlines_buffer.lock().unwrap(),
+                0,
+                data,
+            );
         }
         if !scene.monochrome_sprites.is_empty() {
             let data = unsafe { as_bytes(&scene.monochrome_sprites) };
@@ -1665,11 +1688,15 @@ impl WgpuRenderer {
                 &self.context.mono_sprites_buffer,
                 data.len() as u64,
                 "Monosprites Buffer",
-                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+                wgpu::BufferUsages::VERTEX
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::STORAGE,
             );
-            self.context
-                .queue
-                .write_buffer(&self.context.mono_sprites_buffer.lock().unwrap(), 0, data);
+            self.context.queue.write_buffer(
+                &self.context.mono_sprites_buffer.lock().unwrap(),
+                0,
+                data,
+            );
         }
         if !scene.polychrome_sprites.is_empty() {
             let data = unsafe { as_bytes(&scene.polychrome_sprites) };
@@ -1678,11 +1705,15 @@ impl WgpuRenderer {
                 &self.context.poly_sprites_buffer,
                 data.len() as u64,
                 "Poly Sprites Buffer",
-                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+                wgpu::BufferUsages::VERTEX
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::STORAGE,
             );
-            self.context
-                .queue
-                .write_buffer(&self.context.poly_sprites_buffer.lock().unwrap(), 0, data);
+            self.context.queue.write_buffer(
+                &self.context.poly_sprites_buffer.lock().unwrap(),
+                0,
+                data,
+            );
         }
 
         // Build flat vertex array for all paths (color + content mask baked per-vertex)
@@ -1691,14 +1722,14 @@ impl WgpuRenderer {
             let color = path.color.solid;
             let cm = &path.content_mask.bounds;
             let cm_origin = [cm.origin.x.0, cm.origin.y.0];
-            let cm_size   = [cm.size.width.0, cm.size.height.0];
+            let cm_size = [cm.size.width.0, cm.size.height.0];
             for vertex in &path.vertices {
                 flat_path_vertices.push(GpuPathVertex {
-                    xy_position:         [vertex.xy_position.x.0, vertex.xy_position.y.0],
-                    st_position:         [vertex.st_position.x,   vertex.st_position.y],
-                    hsla:                [color.h, color.s, color.l, color.a],
+                    xy_position: [vertex.xy_position.x.0, vertex.xy_position.y.0],
+                    st_position: [vertex.st_position.x, vertex.st_position.y],
+                    hsla: [color.h, color.s, color.l, color.a],
                     content_mask_origin: cm_origin,
-                    content_mask_size:   cm_size,
+                    content_mask_size: cm_size,
                 });
             }
         }
@@ -1846,7 +1877,7 @@ impl WgpuRenderer {
                         wgpu::BindGroupEntry {
                             binding: 0,
                             resource: wgpu::BindingResource::TextureView(
-                                self.backdrop_blur_texture_view.as_ref().unwrap()
+                                self.backdrop_blur_texture_view.as_ref().unwrap(),
                             ),
                         },
                         wgpu::BindGroupEntry {
@@ -1904,21 +1935,21 @@ impl WgpuRenderer {
                     }],
                 });
 
-        let paths_bind_group =
-            self.context
-                .device
-                .create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some("paths_bind_group"),
-                    layout: &self.pipelines.paths_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: &paths_vertices_buffer_ref,
-                            offset: 0,
-                            size: None,
-                        }),
-                    }],
-                });
+        let paths_bind_group = self
+            .context
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("paths_bind_group"),
+                layout: &self.pipelines.paths_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &paths_vertices_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                }],
+            });
 
         {
             let clear_color = if self.transparent {
@@ -2106,7 +2137,10 @@ impl WgpuRenderer {
                         pass.set_bind_group(0, &self.pipelines.globals_bind_group, &[]);
                         pass.set_bind_group(1, &backdrop_blurs_bind_group, &[]);
                         pass.set_bind_group(2, &backdrop_texture_bind_group, &[]);
-                        pass.draw(0..4, backdrop_blurs_first_instance..backdrop_blurs_first_instance + count);
+                        pass.draw(
+                            0..4,
+                            backdrop_blurs_first_instance..backdrop_blurs_first_instance + count,
+                        );
                         backdrop_blurs_first_instance += count;
                     }
                     PrimitiveBatch::Underlines(underlines) => {
@@ -2124,18 +2158,15 @@ impl WgpuRenderer {
                         log::debug!("Renderer: processing {} surface(s)", surfaces.len());
                         for surface in surfaces {
                             if let crate::SurfaceContent::Wgpu(surface_id) = &surface.content {
-
                                 // Atomically swap ready ↔ display buffers with GPU sync
-                                let swapped = self.context.surface_registry.swap_ready_display(
-                                    &self.context.device,
-                                    *surface_id
-                                );
-
+                                let swapped = self
+                                    .context
+                                    .surface_registry
+                                    .swap_ready_display(&self.context.device, *surface_id);
 
                                 if let Some(view) =
                                     self.context.surface_registry.front_view(*surface_id)
                                 {
-
                                     let params = SurfaceParams {
                                         bounds: Bounds {
                                             origin: [
@@ -2176,15 +2207,25 @@ impl WgpuRenderer {
                                             },
                                             content_mask: geometry::Bounds {
                                                 origin: geometry::Point {
-                                                    x: Pixels(surface.content_mask.bounds.origin.x.0),
-                                                    y: Pixels(surface.content_mask.bounds.origin.y.0),
+                                                    x: Pixels(
+                                                        surface.content_mask.bounds.origin.x.0,
+                                                    ),
+                                                    y: Pixels(
+                                                        surface.content_mask.bounds.origin.y.0,
+                                                    ),
                                                 },
                                                 size: geometry::Size {
-                                                    width: Pixels(surface.content_mask.bounds.size.width.0),
-                                                    height: Pixels(surface.content_mask.bounds.size.height.0),
+                                                    width: Pixels(
+                                                        surface.content_mask.bounds.size.width.0,
+                                                    ),
+                                                    height: Pixels(
+                                                        surface.content_mask.bounds.size.height.0,
+                                                    ),
                                                 },
                                             },
-                                            layout_version: self.layout_version.load(Ordering::Acquire),
+                                            layout_version: self
+                                                .layout_version
+                                                .load(Ordering::Acquire),
                                         },
                                     );
 
@@ -2194,9 +2235,8 @@ impl WgpuRenderer {
                                         bytemuck::bytes_of(&params),
                                     );
 
-                                    let surface_bind_group = self.context
-                                        .device
-                                        .create_bind_group(&wgpu::BindGroupDescriptor {
+                                    let surface_bind_group = self.context.device.create_bind_group(
+                                        &wgpu::BindGroupDescriptor {
                                             label: Some("surface_bind_group"),
                                             layout: &self.pipelines.surfaces_bind_group_layout,
                                             entries: &[
@@ -2223,14 +2263,11 @@ impl WgpuRenderer {
                                                     ),
                                                 },
                                             ],
-                                        });
+                                        },
+                                    );
 
                                     pass.set_pipeline(&self.pipelines.surfaces_pipeline);
-                                    pass.set_bind_group(
-                                        0,
-                                        &self.pipelines.globals_bind_group,
-                                        &[],
-                                    );
+                                    pass.set_bind_group(0, &self.pipelines.globals_bind_group, &[]);
                                     pass.set_bind_group(1, &surface_bind_group, &[]);
                                     pass.draw(0..4, 0..1);
 
@@ -2241,7 +2278,9 @@ impl WgpuRenderer {
                                     // Clear redraw pending AFTER we're done with the view
                                     // This prevents the external thread from triggering another compositor
                                     // pass while we're still using this view
-                                    self.context.surface_registry.clear_redraw_pending(*surface_id);
+                                    self.context
+                                        .surface_registry
+                                        .clear_redraw_pending(*surface_id);
 
                                     seen_surfaces.push(*surface_id);
                                 }
@@ -2250,8 +2289,7 @@ impl WgpuRenderer {
                     }
                     // TODO(mdeand): Implement paths rendering.
                     PrimitiveBatch::Paths(paths) => {
-                        let vertex_count: u32 =
-                            paths.iter().map(|p| p.vertices.len() as u32).sum();
+                        let vertex_count: u32 = paths.iter().map(|p| p.vertices.len() as u32).sum();
                         if vertex_count > 0 {
                             pass.set_pipeline(&self.pipelines.paths_pipeline);
                             pass.set_bind_group(0, &self.pipelines.globals_bind_group, &[]);
@@ -2305,12 +2343,16 @@ impl WgpuRenderer {
         drop(cache); // Release lock
 
         // 3. Atomic buffer swap with GPU synchronization
-        let swapped = self.context
+        let swapped = self
+            .context
             .surface_registry
             .swap_ready_display(&self.context.device, surface_id);
 
         if !swapped {
-            log::trace!("[surface_id={:?}] No new frame, reusing current display buffer", surface_id);
+            log::trace!(
+                "[surface_id={:?}] No new frame, reusing current display buffer",
+                surface_id
+            );
         }
 
         // 4. Get surface texture view
@@ -2358,12 +2400,12 @@ impl WgpuRenderer {
             }
         };
 
-        let mut encoder = self
-            .context
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fast_surface_blit"),
-            });
+        let mut encoder =
+            self.context
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("fast_surface_blit"),
+                });
 
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -2386,8 +2428,8 @@ impl WgpuRenderer {
             });
 
             // Prepare surface params with cached bounds
-            let scale_factor = self.surface_configuration.width as f32
-                / self.surface_configuration.width as f32; // TODO: Get actual scale factor
+            let scale_factor =
+                self.surface_configuration.width as f32 / self.surface_configuration.width as f32; // TODO: Get actual scale factor
             let params = SurfaceParams {
                 bounds: Bounds {
                     origin: [screen_bounds.origin.x.0, screen_bounds.origin.y.0],
@@ -2406,31 +2448,31 @@ impl WgpuRenderer {
             );
 
             // Create bind group for this surface (must match surfaces.wgsl binding order)
-            let surface_bind_group = self
-                .context
-                .device
-                .create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some("fast_blit_surface_bind_group"),
-                    layout: &self.pipelines.surfaces_bind_group_layout,
-                    entries: &[
-                        wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                                buffer: &self.surface_params_buffer,
-                                offset: 0,
-                                size: None,
-                            }),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 1,
-                            resource: wgpu::BindingResource::TextureView(&view),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 2,
-                            resource: wgpu::BindingResource::Sampler(&self.surface_sampler),
-                        },
-                    ],
-                });
+            let surface_bind_group =
+                self.context
+                    .device
+                    .create_bind_group(&wgpu::BindGroupDescriptor {
+                        label: Some("fast_blit_surface_bind_group"),
+                        layout: &self.pipelines.surfaces_bind_group_layout,
+                        entries: &[
+                            wgpu::BindGroupEntry {
+                                binding: 0,
+                                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                    buffer: &self.surface_params_buffer,
+                                    offset: 0,
+                                    size: None,
+                                }),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 1,
+                                resource: wgpu::BindingResource::TextureView(&view),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 2,
+                                resource: wgpu::BindingResource::Sampler(&self.surface_sampler),
+                            },
+                        ],
+                    });
 
             // Render surface quad using existing surfaces.wgsl shader
             pass.set_pipeline(&self.pipelines.surfaces_pipeline);
@@ -2475,24 +2517,24 @@ impl WgpuRenderer {
             .configure(&self.context.device, &self.surface_configuration);
 
         // Recreate persistent framebuffer at new size
-        let persistent_framebuffer =
-            self.context
-                .device
-                .create_texture(&wgpu::TextureDescriptor {
-                    label: Some("persistent_framebuffer"),
-                    size: wgpu::Extent3d {
-                        width: self.surface_configuration.width,
-                        height: self.surface_configuration.height,
-                        depth_or_array_layers: 1,
-                    },
-                    mip_level_count: 1,
-                    sample_count: 1,
-                    dimension: wgpu::TextureDimension::D2,
-                    format: self.surface_configuration.format,
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                        | wgpu::TextureUsages::TEXTURE_BINDING,
-                    view_formats: &[],
-                });
+        let persistent_framebuffer = self
+            .context
+            .device
+            .create_texture(&wgpu::TextureDescriptor {
+                label: Some("persistent_framebuffer"),
+                size: wgpu::Extent3d {
+                    width: self.surface_configuration.width,
+                    height: self.surface_configuration.height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: self.surface_configuration.format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
 
         let persistent_framebuffer_view =
             persistent_framebuffer.create_view(&wgpu::TextureViewDescriptor::default());
@@ -2502,25 +2544,25 @@ impl WgpuRenderer {
 
         // Recreate backdrop blur capture texture at the new size so that
         // copy_texture_to_texture doesn't silently skip due to a size mismatch.
-        let backdrop_blur_texture =
-            self.context
-                .device
-                .create_texture(&wgpu::TextureDescriptor {
-                    label: Some("backdrop_blur_texture"),
-                    size: wgpu::Extent3d {
-                        width: self.surface_configuration.width,
-                        height: self.surface_configuration.height,
-                        depth_or_array_layers: 1,
-                    },
-                    mip_level_count: 1,
-                    sample_count: 1,
-                    dimension: wgpu::TextureDimension::D2,
-                    format: self.surface_configuration.format,
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                        | wgpu::TextureUsages::TEXTURE_BINDING
-                        | wgpu::TextureUsages::COPY_DST,
-                    view_formats: &[],
-                });
+        let backdrop_blur_texture = self
+            .context
+            .device
+            .create_texture(&wgpu::TextureDescriptor {
+                label: Some("backdrop_blur_texture"),
+                size: wgpu::Extent3d {
+                    width: self.surface_configuration.width,
+                    height: self.surface_configuration.height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: self.surface_configuration.format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
         let backdrop_blur_texture_view =
             backdrop_blur_texture.create_view(&wgpu::TextureViewDescriptor::default());
         self.backdrop_blur_texture = Some(backdrop_blur_texture);
@@ -2552,9 +2594,15 @@ impl WgpuRenderer {
 
         self.surface_configuration.alpha_mode = if transparent {
             // Pick the best transparent alpha mode the surface supports.
-            if self.supported_alpha_modes.contains(&wgpu::CompositeAlphaMode::PreMultiplied) {
+            if self
+                .supported_alpha_modes
+                .contains(&wgpu::CompositeAlphaMode::PreMultiplied)
+            {
                 wgpu::CompositeAlphaMode::PreMultiplied
-            } else if self.supported_alpha_modes.contains(&wgpu::CompositeAlphaMode::PostMultiplied) {
+            } else if self
+                .supported_alpha_modes
+                .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
+            {
                 wgpu::CompositeAlphaMode::PostMultiplied
             } else {
                 // Surface doesn't natively support transparency (e.g. Windows DX12).
@@ -2563,7 +2611,10 @@ impl WgpuRenderer {
                 self.surface_configuration.alpha_mode
             }
         } else {
-            if self.supported_alpha_modes.contains(&wgpu::CompositeAlphaMode::Opaque) {
+            if self
+                .supported_alpha_modes
+                .contains(&wgpu::CompositeAlphaMode::Opaque)
+            {
                 wgpu::CompositeAlphaMode::Opaque
             } else {
                 self.supported_alpha_modes[0]
@@ -2579,7 +2630,6 @@ impl WgpuRenderer {
             height: DevicePixels(self.surface_configuration.height as i32),
         }
     }
-
 }
 
 impl Drop for WgpuRenderer {

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -80,10 +80,10 @@ impl color::GradientStop {
 }
 
 impl color::Background {
-    const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 10] = &{
+    const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 9] = &{
         let linear_color_stop_vertex_attributes = map_attributes(
             GradientStop::VERTEX_ATTRIBUTES,
-            4,
+            7,
             std::mem::offset_of!(color::Background, colors) as wgpu::BufferAddress,
         );
 
@@ -125,11 +125,11 @@ impl color::Background {
             },
             linear_color_stop_vertex_attributes[0],
             linear_color_stop_vertex_attributes[1],
-            wgpu::VertexAttribute {
-                offset: std::mem::offset_of!(color::Background, pad) as wgpu::BufferAddress,
-                shader_location: 9,
-                format: wgpu::VertexFormat::Uint8,
-            },
+            // wgpu::VertexAttribute {
+            //     offset: std::mem::offset_of!(color::Background, pad) as wgpu::BufferAddress,
+            //     shader_location: 9,
+            //     format: wgpu::VertexFormat::Uint8,
+            // },
         ]
     };
 }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -104,7 +104,7 @@ impl color::Background {
                 format: wgpu::VertexFormat::Uint32,
             },
             wgpu::VertexAttribute {
-                offset: std::mem::offset_of!(color::Background, gradient_angle_or_pattern_height)
+                offset: std::mem::offset_of!(color::Background, gradient_params)
                     as wgpu::BufferAddress,
                 shader_location: 3,
                 format: wgpu::VertexFormat::Float32,

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -104,7 +104,7 @@ impl color::Background {
                 format: wgpu::VertexFormat::Uint32,
             },
             wgpu::VertexAttribute {
-                offset: std::mem::offset_of!(color::Background, gradient_params)
+                offset: std::mem::offset_of!(color::Background, gradient_angle_or_pattern_height)
                     as wgpu::BufferAddress,
                 shader_location: 3,
                 format: wgpu::VertexFormat::Float32,

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -72,7 +72,7 @@ impl color::GradientStop {
             format: wgpu::VertexFormat::Float32x4,
         },
         wgpu::VertexAttribute {
-            offset: std::mem::offset_of!(GradientStop, percentage) as wgpu::BufferAddress,
+            offset: std::mem::offset_of!(GradientStop, position) as wgpu::BufferAddress,
             shader_location: 1,
             format: wgpu::VertexFormat::Float32,
         },

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -80,7 +80,7 @@ impl color::GradientStop {
 }
 
 impl color::Background {
-    const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 7] = &{
+    const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 10] = &{
         let linear_color_stop_vertex_attributes = map_attributes(
             GradientStop::VERTEX_ATTRIBUTES,
             4,
@@ -104,17 +104,31 @@ impl color::Background {
                 format: wgpu::VertexFormat::Uint32,
             },
             wgpu::VertexAttribute {
-                offset: std::mem::offset_of!(color::Background, gradient_angle_or_pattern_height)
-                    as wgpu::BufferAddress,
+                offset: std::mem::offset_of!(color::Background, param0) as wgpu::BufferAddress,
                 shader_location: 3,
+                format: wgpu::VertexFormat::Float32,
+            },
+            wgpu::VertexAttribute {
+                offset: std::mem::offset_of!(color::Background, param1) as wgpu::BufferAddress,
+                shader_location: 4,
+                format: wgpu::VertexFormat::Float32,
+            },
+            wgpu::VertexAttribute {
+                offset: std::mem::offset_of!(color::Background, param2) as wgpu::BufferAddress,
+                shader_location: 5,
+                format: wgpu::VertexFormat::Float32,
+            },
+            wgpu::VertexAttribute {
+                offset: std::mem::offset_of!(color::Background, param3) as wgpu::BufferAddress,
+                shader_location: 6,
                 format: wgpu::VertexFormat::Float32,
             },
             linear_color_stop_vertex_attributes[0],
             linear_color_stop_vertex_attributes[1],
             wgpu::VertexAttribute {
                 offset: std::mem::offset_of!(color::Background, pad) as wgpu::BufferAddress,
-                shader_location: 6,
-                format: wgpu::VertexFormat::Uint32,
+                shader_location: 9,
+                format: wgpu::VertexFormat::Uint8,
             },
         ]
     };

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -178,7 +178,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
     if tag == 0u || tag == 2u {
         result[0] = hsla_to_rgba(solid);
-    } else if tag == 1u {
+    } else if tag == 1u || tag == 3u {
         result[1] = hsla_to_rgba(color0.color);
         result[2] = hsla_to_rgba(color1.color);
 
@@ -199,11 +199,11 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     if background.tag == 0u || background.tag == 2u {
         return solid_color;
     } else if background.tag == 1u {
-        let angle = background.gradient_angle_or_pattern_height;
+        let angle = background.gradient_params.x;
         let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
         var direction = vec2<f32>(cos(radians), sin(radians));
-        let stop0_percentage = background.color0.percentage;
-        let stop1_percentage = background.color1.percentage;
+        let stop0_percentage = background.color0.position;
+        let stop1_percentage = background.color1.position;
 
         if bounds.size.x > bounds.size.y {
             direction.y *= bounds.size.y / bounds.size.x;

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -180,7 +180,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
     if tag == 0u || tag == 2u {
         result[0] = hsla_to_rgba(solid);
-    } else if tag == 1u {
+    } else if tag == 1u || tag == 3u {
         result[1] = hsla_to_rgba(color0.color);
         result[2] = hsla_to_rgba(color1.color);
 

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -32,7 +32,7 @@ struct Edges {
     left: f32,
 }
 
-struct LinearColorStop {
+struct GradientStop {
     color: Hsla,
     percentage: f32,
 }
@@ -42,8 +42,8 @@ struct Background {
     color_space: u32,
     solid: Hsla,
     gradient_angle_or_pattern_height: f32,
-    color0: LinearColorStop,
-    color1: LinearColorStop,
+    color0: GradientStop,
+    color1: GradientStop,
     pad: u32,
 }
 
@@ -90,19 +90,19 @@ fn hsla_to_rgba(hsla: Hsla) -> vec4<f32> {
     let m = l - c / 2.0;
     var color = vec3<f32>(m);
 
-    if (h >= 0.0 && h < 1.0) {
+    if h >= 0.0 && h < 1.0 {
         color.r += c;
         color.g += x;
-    } else if (h >= 1.0 && h < 2.0) {
+    } else if h >= 1.0 && h < 2.0 {
         color.r += x;
         color.g += c;
-    } else if (h >= 2.0 && h < 3.0) {
+    } else if h >= 2.0 && h < 3.0 {
         color.g += c;
         color.b += x;
-    } else if (h >= 3.0 && h < 4.0) {
+    } else if h >= 3.0 && h < 4.0 {
         color.g += x;
         color.b += c;
-    } else if (h >= 4.0 && h < 5.0) {
+    } else if h >= 4.0 && h < 5.0 {
         color.r += x;
         color.b += c;
     } else {
@@ -117,7 +117,7 @@ fn linear_to_srgba(linear: vec4<f32>) -> vec4<f32> {
     let a = 0.055;
     var srgb: vec3<f32>;
     for (var i = 0; i < 3; i++) {
-        if (linear[i] <= 0.0031308) {
+        if linear[i] <= 0.0031308 {
             srgb[i] = linear[i] * 12.92;
         } else {
             srgb[i] = (1.0 + a) * pow(linear[i], 1.0 / 2.4) - a;
@@ -129,7 +129,7 @@ fn linear_to_srgba(linear: vec4<f32>) -> vec4<f32> {
 fn srgba_to_linear(srgb: vec4<f32>) -> vec4<f32> {
     var linear: vec3<f32>;
     for (var i = 0; i < 3; i++) {
-        if (srgb[i] <= 0.04045) {
+        if srgb[i] <= 0.04045 {
             linear[i] = srgb[i] / 12.92;
         } else {
             linear[i] = pow((srgb[i] + 0.055) / 1.055, 2.4);
@@ -173,19 +173,19 @@ fn linear_srgb_to_oklab(color: vec4<f32>) -> vec4<f32> {
 }
 
 fn prepare_gradient_color(tag: u32, color_space: u32,
-    solid: Hsla, color0: LinearColorStop, color1: LinearColorStop) -> array<vec4<f32>, 3> {
+    solid: Hsla, color0: GradientStop, color1: GradientStop) -> array<vec4<f32>, 3> {
     var result: array<vec4<f32>, 3>;
 
-    if (tag == 0u || tag == 2u) {
+    if tag == 0u || tag == 2u {
         result[0] = hsla_to_rgba(solid);
-    } else if (tag == 1u) {
+    } else if tag == 1u {
         result[1] = hsla_to_rgba(color0.color);
         result[2] = hsla_to_rgba(color1.color);
 
-        if (color_space == 0u) {
+        if color_space == 0u {
             result[1] = linear_to_srgba(result[1]);
             result[2] = linear_to_srgba(result[2]);
-        } else if (color_space == 1u) {
+        } else if color_space == 1u {
             result[1] = linear_srgb_to_oklab(result[1]);
             result[2] = linear_srgb_to_oklab(result[2]);
         }
@@ -196,16 +196,16 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
 fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
-    if (background.tag == 0u || background.tag == 2u) {
+    if background.tag == 0u || background.tag == 2u {
         return solid_color;
-    } else if (background.tag == 1u) {
+    } else if background.tag == 1u {
         let angle = background.gradient_angle_or_pattern_height;
         let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
         var direction = vec2<f32>(cos(radians), sin(radians));
         let stop0_percentage = background.color0.percentage;
         let stop1_percentage = background.color1.percentage;
 
-        if (bounds.size.x > bounds.size.y) {
+        if bounds.size.x > bounds.size.y {
             direction.y *= bounds.size.y / bounds.size.x;
         } else {
             direction.x *= bounds.size.x / bounds.size.y;
@@ -215,7 +215,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         let center = bounds.origin + half_size;
         let center_to_point = position - center;
         var t = dot(center_to_point, direction) / length(direction);
-        if (abs(direction.x) > abs(direction.y)) {
+        if abs(direction.x) > abs(direction.y) {
             t = (t + half_size.x) / bounds.size.x;
         } else {
             t = (t + half_size.y) / bounds.size.y;
@@ -224,9 +224,9 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         t = (t - stop0_percentage) / (stop1_percentage - stop0_percentage);
         t = clamp(t, 0.0, 1.0);
 
-        if (background.color_space == 0u) {
+        if background.color_space == 0u {
             return srgba_to_linear(mix(color0, color1, t));
-        } else if (background.color_space == 1u) {
+        } else if background.color_space == 1u {
             let oklab_color = mix(color0, color1, t);
             return oklab_to_linear_srgb(oklab_color);
         }
@@ -244,14 +244,14 @@ fn quad_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners) -> f32 {
     let center = bounds.origin + bounds.size / 2.0;
     let half_size = bounds.size / 2.0;
     var radii_size = vec2<f32>(0.0);
-    if (point.x < center.x) {
-        if (point.y < center.y) {
+    if point.x < center.x {
+        if point.y < center.y {
             radii_size = vec2<f32>(corner_radii.top_left);
         } else {
             radii_size = vec2<f32>(corner_radii.bottom_left);
         }
     } else {
-        if (point.y < center.y) {
+        if point.y < center.y {
             radii_size = vec2<f32>(corner_radii.top_right);
         } else {
             radii_size = vec2<f32>(corner_radii.bottom_right);
@@ -298,7 +298,7 @@ fn vs_backdrop_blur(@builtin(vertex_index) vertex_id: u32, @builtin(instance_ind
 @fragment
 fn fs_backdrop_blur(input: BackdropBlurVarying) -> @location(0) vec4<f32> {
     // Clip test
-    if (any(input.clip_distances < vec4<f32>(0.0))) {
+    if any(input.clip_distances < vec4<f32>(0.0)) {
         return vec4<f32>(0.0);
     }
 
@@ -312,7 +312,7 @@ fn fs_backdrop_blur(input: BackdropBlurVarying) -> @location(0) vec4<f32> {
     let blur_radius = backdrop_blur.blur_radius;
 
     // Skip blur sampling if radius is very small
-    if (blur_radius < 0.5) {
+    if blur_radius < 0.5 {
         let uv = pixel_position / globals.viewport_size;
         blurred_color = textureSample(backdrop_texture, backdrop_sampler, uv);
     } else {
@@ -329,7 +329,7 @@ fn fs_backdrop_blur(input: BackdropBlurVarying) -> @location(0) vec4<f32> {
                 let sample_uv = sample_pos / globals.viewport_size;
 
                 // Clamp UV to valid range
-                if (sample_uv.x >= 0.0 && sample_uv.x <= 1.0 && sample_uv.y >= 0.0 && sample_uv.y <= 1.0) {
+                if sample_uv.x >= 0.0 && sample_uv.x <= 1.0 && sample_uv.y >= 0.0 && sample_uv.y <= 1.0 {
                     let sample_color = textureSample(backdrop_texture, backdrop_sampler, sample_uv);
                     blurred_color += sample_color * weight;
                     total_weight += weight;
@@ -337,7 +337,7 @@ fn fs_backdrop_blur(input: BackdropBlurVarying) -> @location(0) vec4<f32> {
             }
         }
 
-        if (total_weight > 0.0) {
+        if total_weight > 0.0 {
             blurred_color /= total_weight;
         }
     }

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -41,10 +41,12 @@ struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_angle_or_pattern_height: f32,
+    param0: f32,
+    param1: f32,
+    param2: f32,
+    param3: f32,
     color0: GradientStop,
     color1: GradientStop,
-    pad: u32,
 }
 
 struct BackdropBlur {
@@ -198,8 +200,8 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
     if background.tag == 0u || background.tag == 2u {
         return solid_color;
-    } else if background.tag == 1u {
-        let angle = background.gradient_angle_or_pattern_height;
+    } else if background.tag == 1u || background.tag == 3u {
+        let angle = background.param0;
         let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
         var direction = vec2<f32>(cos(radians), sin(radians));
         let stop0_percentage = background.color0.percentage;

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -34,14 +34,14 @@ struct Edges {
 
 struct GradientStop {
     color: Hsla,
-    position: f32,
+    percentage: f32,
 }
 
 struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_params: vec4<f32>,
+    gradient_angle_or_pattern_height: f32,
     color0: GradientStop,
     color1: GradientStop,
     pad: u32,
@@ -198,7 +198,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
     if background.tag == 0u || background.tag == 2u {
         return solid_color;
-    } else if background.tag == 1u || background.tag == 3u {
+    } else if background.tag == 1u {
         let angle = background.gradient_params.x;
         let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
         var direction = vec2<f32>(cos(radians), sin(radians));

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -34,14 +34,14 @@ struct Edges {
 
 struct GradientStop {
     color: Hsla,
-    percentage: f32,
+    position: f32,
 }
 
 struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_angle_or_pattern_height: f32,
+    gradient_params: vec4<f32>,
     color0: GradientStop,
     color1: GradientStop,
     pad: u32,
@@ -198,7 +198,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
     if background.tag == 0u || background.tag == 2u {
         return solid_color;
-    } else if background.tag == 1u {
+    } else if background.tag == 1u || background.tag == 3u {
         let angle = background.gradient_params.x;
         let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
         var direction = vec2<f32>(cos(radians), sin(radians));

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -178,7 +178,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
     if tag == 0u || tag == 2u {
         result[0] = hsla_to_rgba(solid);
-    } else if tag == 1u || tag == 3u {
+    } else if tag == 1u {
         result[1] = hsla_to_rgba(color0.color);
         result[2] = hsla_to_rgba(color1.color);
 
@@ -199,11 +199,11 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     if background.tag == 0u || background.tag == 2u {
         return solid_color;
     } else if background.tag == 1u {
-        let angle = background.gradient_params.x;
+        let angle = background.gradient_angle_or_pattern_height;
         let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
         var direction = vec2<f32>(cos(radians), sin(radians));
-        let stop0_percentage = background.color0.position;
-        let stop1_percentage = background.color1.position;
+        let stop0_percentage = background.color0.percentage;
+        let stop1_percentage = background.color1.percentage;
 
         if bounds.size.x > bounds.size.y {
             direction.y *= bounds.size.y / bounds.size.x;

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -7,50 +7,50 @@ struct Globals {
 }
 
 struct GradientColor {
-  solid: vec4<f32>,
-  color0: vec4<f32>,
-  color1: vec4<f32>,
+    solid: vec4<f32>,
+    color0: vec4<f32>,
+    color1: vec4<f32>,
 }
 
 struct Hsla {
-  h: f32,
-  s: f32,
-  l: f32,
-  a: f32,
+    h: f32,
+    s: f32,
+    l: f32,
+    a: f32,
 }
 
 struct Bounds {
-  origin: vec2<f32>,
-  size: vec2<f32>,
+    origin: vec2<f32>,
+    size: vec2<f32>,
 }
 
-struct LinearColorStop {
-  color: Hsla,
-  percentage: f32,
+struct GradientStop {
+    color: Hsla,
+    percentage: f32,
 }
 
 struct Background {
-  tag: u32,
-  color_space: u32,
-  solid: Hsla,
-  gradient_angle_or_pattern_height: f32,
-  color0: LinearColorStop,
-  color1: LinearColorStop,
-  pad: u32,
+    tag: u32,
+    color_space: u32,
+    solid: Hsla,
+    gradient_angle_or_pattern_height: f32,
+    color0: GradientStop,
+    color1: GradientStop,
+    pad: u32,
 }
 
 struct Edges {
-  top: f32,
-  right: f32,
-  bottom: f32,
-  left: f32,
+    top: f32,
+    right: f32,
+    bottom: f32,
+    left: f32,
 }
 
-struct Corners { 
-  top_left: f32,
-  top_right: f32,
-  bottom_right: f32,
-  bottom_left: f32,
+struct Corners {
+    top_left: f32,
+    top_right: f32,
+    bottom_right: f32,
+    bottom_left: f32,
 }
 
 struct Quad {
@@ -80,20 +80,20 @@ struct QuadVarying {
 
 /// Convert an Oklab color to linear sRGB space.
 fn oklab_to_linear_srgb(color: vec4<f32>) -> vec4<f32> {
-	let l_ = color.r + 0.3963377774 * color.g + 0.2158037573 * color.b;
-	let m_ = color.r - 0.1055613458 * color.g - 0.0638541728 * color.b;
-	let s_ = color.r - 0.0894841775 * color.g - 1.2914855480 * color.b;
+    let l_ = color.r + 0.3963377774 * color.g + 0.2158037573 * color.b;
+    let m_ = color.r - 0.1055613458 * color.g - 0.0638541728 * color.b;
+    let s_ = color.r - 0.0894841775 * color.g - 1.2914855480 * color.b;
 
-	let l = l_ * l_ * l_;
-	let m = m_ * m_ * m_;
-	let s = s_ * s_ * s_;
+    let l = l_ * l_ * l_;
+    let m = m_ * m_ * m_;
+    let s = s_ * s_ * s_;
 
-	return vec4<f32>(
-		4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
-		-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
-		-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
-		color.a
-	);
+    return vec4<f32>(
+        4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+        -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+        -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
+        color.a
+    );
 }
 
 // https://gamedev.stackexchange.com/questions/92015/optimized-linear-to-srgb-glsl
@@ -123,14 +123,14 @@ fn linear_to_srgba(color: vec4<f32>) -> vec4<f32> {
 
 // Selects corner radius based on quadrant.
 fn pick_corner_radius(center_to_point: vec2<f32>, radii: Corners) -> f32 {
-    if (center_to_point.x < 0.0) {
-        if (center_to_point.y < 0.0) {
+    if center_to_point.x < 0.0 {
+        if center_to_point.y < 0.0 {
             return radii.top_left;
         } else {
             return radii.bottom_left;
         }
     } else {
-        if (center_to_point.y < 0.0) {
+        if center_to_point.y < 0.0 {
             return radii.top_right;
         } else {
             return radii.bottom_right;
@@ -141,20 +141,20 @@ fn pick_corner_radius(center_to_point: vec2<f32>, radii: Corners) -> f32 {
 /// Convert a linear sRGB to Oklab space.
 /// Reference: https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
 fn linear_srgb_to_oklab(color: vec4<f32>) -> vec4<f32> {
-	let l = 0.4122214708 * color.r + 0.5363325363 * color.g + 0.0514459929 * color.b;
-	let m = 0.2119034982 * color.r + 0.6806995451 * color.g + 0.1073969566 * color.b;
-	let s = 0.0883024619 * color.r + 0.2817188376 * color.g + 0.6299787005 * color.b;
+    let l = 0.4122214708 * color.r + 0.5363325363 * color.g + 0.0514459929 * color.b;
+    let m = 0.2119034982 * color.r + 0.6806995451 * color.g + 0.1073969566 * color.b;
+    let s = 0.0883024619 * color.r + 0.2817188376 * color.g + 0.6299787005 * color.b;
 
-	let l_ = pow(l, 1.0 / 3.0);
-	let m_ = pow(m, 1.0 / 3.0);
-	let s_ = pow(s, 1.0 / 3.0);
+    let l_ = pow(l, 1.0 / 3.0);
+    let m_ = pow(m, 1.0 / 3.0);
+    let s_ = pow(s, 1.0 / 3.0);
 
-	return vec4<f32>(
-		0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
-		1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
-		0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
-		color.a
-	);
+    return vec4<f32>(
+        0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
+        1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+        0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_,
+        color.a
+    );
 }
 
 fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
@@ -179,19 +179,19 @@ fn hsla_to_rgba(hsla: Hsla) -> vec4<f32> {
     let m = l - c / 2.0;
     var color = vec3<f32>(m);
 
-    if (h >= 0.0 && h < 1.0) {
+    if h >= 0.0 && h < 1.0 {
         color.r += c;
         color.g += x;
-    } else if (h >= 1.0 && h < 2.0) {
+    } else if h >= 1.0 && h < 2.0 {
         color.r += x;
         color.g += c;
-    } else if (h >= 2.0 && h < 3.0) {
+    } else if h >= 2.0 && h < 3.0 {
         color.g += c;
         color.b += x;
-    } else if (h >= 3.0 && h < 4.0) {
+    } else if h >= 3.0 && h < 4.0 {
         color.g += x;
         color.b += c;
-    } else if (h >= 4.0 && h < 5.0) {
+    } else if h >= 4.0 && h < 5.0 {
         color.r += x;
         color.b += c;
     } else {
@@ -203,23 +203,23 @@ fn hsla_to_rgba(hsla: Hsla) -> vec4<f32> {
 }
 
 fn prepare_gradient_color(tag: u32, color_space: u32,
-    solid: Hsla, color0: LinearColorStop, color1: LinearColorStop) -> GradientColor {
+    solid: Hsla, color0: GradientStop, color1: GradientStop) -> GradientColor {
     var result = GradientColor();
 
-    if (tag == 0u || tag == 2u) {
+    if tag == 0u || tag == 2u {
         result.solid = hsla_to_rgba(solid);
-    } else if (tag == 1u) {
+    } else if tag == 1u {
         // The hsla_to_rgba is returns a linear sRGB color
         result.color0 = hsla_to_rgba(color0.color);
         result.color1 = hsla_to_rgba(color1.color);
 
         // Prepare color space in vertex for avoid conversion
         // in fragment shader for performance reasons
-        if (color_space == 0u) {
+        if color_space == 0u {
             // sRGB
             result.color0 = linear_to_srgba(result.color0);
             result.color1 = linear_to_srgba(result.color1);
-        } else if (color_space == 1u) {
+        } else if color_space == 1u {
             // Oklab
             result.color0 = linear_srgb_to_oklab(result.color0);
             result.color1 = linear_srgb_to_oklab(result.color1);
@@ -233,7 +233,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
     solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
     var background_color = vec4<f32>(0.0);
 
-    switch (background.tag) {
+    switch background.tag {
         default: {
             return solid_color;
         }
@@ -247,7 +247,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             let stop1_percentage = background.color1.percentage;
 
             // Expand the short side to be the same as the long side
-            if (bounds.size.x > bounds.size.y) {
+            if bounds.size.x > bounds.size.y {
                 direction.y *= bounds.size.y / bounds.size.x;
             } else {
                 direction.x *= bounds.size.x / bounds.size.y;
@@ -259,7 +259,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             let center_to_point = position - center;
             var t = dot(center_to_point, direction) / length(direction);
             // Check the direct to determine the use x or y
-            if (abs(direction.x) > abs(direction.y)) {
+            if abs(direction.x) > abs(direction.y) {
                 t = (t + half_size.x) / bounds.size.x;
             } else {
                 t = (t + half_size.y) / bounds.size.y;
@@ -269,7 +269,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             t = (t - stop0_percentage) / (stop1_percentage - stop0_percentage);
             t = clamp(t, 0.0, 1.0);
 
-            switch (background.color_space) {
+            switch background.color_space {
                 default: {
                     background_color = srgba_to_linear(mix(color0, color1, t));
                 }
@@ -293,7 +293,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             let relative_position = position - bounds.origin;
             let rotated_point = rotation * relative_position;
             let pattern = rotated_point.x % pattern_period;
-            let distance = min(pattern, pattern_period - pattern) - pattern_period * (pattern_width / pattern_height) /  2.0f;
+            let distance = min(pattern, pattern_period - pattern) - pattern_period * (pattern_width / pattern_height) / 2.0f;
             background_color = solid_color;
             background_color.a *= saturate(0.5 - distance);
         }
@@ -337,14 +337,13 @@ fn quad_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners) -> f32 {
 }
 
 fn quad_sdf_impl(corner_center_to_point: vec2<f32>, corner_radius: f32) -> f32 {
-    if (corner_radius == 0.0) {
+    if corner_radius == 0.0 {
         // Fast path for unrounded corners.
         return max(corner_center_to_point.x, corner_center_to_point.y);
     } else {
         // Signed distance of the point from a quad that is inset by corner_radius.
         // It is negative inside this quad, and positive outside.
-        let signed_distance_to_inset_quad =
-            // 0 inside the inset quad, and positive outside.
+        let signed_distance_to_inset_quad = // 0 inside the inset quad, and positive outside.
             length(max(vec2<f32>(0.0), corner_center_to_point)) +
             // 0 outside the inset quad, and negative inside.
             min(0.0, max(corner_center_to_point.x, corner_center_to_point.y));
@@ -378,9 +377,9 @@ fn quarter_ellipse_sdf(point: vec2<f32>, radii: vec2<f32>) -> f32 {
 // An alternative to this might be to appropriately interpolate the dash
 // velocity around the corner, but that seems overcomplicated.
 fn corner_dash_velocity(dv1: f32, dv2: f32) -> f32 {
-    if (dv1 == 0.0) {
+    if dv1 == 0.0 {
         return dv2;
-    } else if (dv2 == 0.0) {
+    } else if dv2 == 0.0 {
         return dv1;
     } else {
         return min(dv1, dv2);
@@ -427,7 +426,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
         quad.background.color0,
         quad.background.color1
     );
-    
+
     out.background_solid = gradient.solid;
     out.background_color0 = gradient.color0;
     out.background_color1 = gradient.color1;
@@ -440,7 +439,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
 @fragment
 fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     // Alpha clip first, since we don't have `clip_distance`.
-    if (any(input.clip_distances < vec4<f32>(0.0))) {
+    if any(input.clip_distances < vec4<f32>(0.0)) {
         return vec4<f32>(0.0);
     }
 
@@ -455,11 +454,11 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
         quad.corner_radii.bottom_right == 0.0;
 
     // Fast path when the quad is not rounded and doesn't have any border
-    if (quad.border_widths.top == 0.0 &&
+    if quad.border_widths.top == 0.0 &&
             quad.border_widths.left == 0.0 &&
             quad.border_widths.right == 0.0 &&
             quad.border_widths.bottom == 0.0 &&
-            unrounded) {
+            unrounded {
         return blend_color(background_color, 1.0);
     }
 
@@ -480,17 +479,19 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
         select(
             quad.border_widths.right,
             quad.border_widths.left,
-            center_to_point.x < 0.0),
+            center_to_point.x < 0.0
+        ),
         select(
             quad.border_widths.bottom,
             quad.border_widths.top,
-            center_to_point.y < 0.0));
+            center_to_point.y < 0.0
+        )
+    );
 
     // 0-width borders are reduced so that `inner_sdf >= antialias_threshold`.
     // The purpose of this is to not draw antialiasing pixels in this case.
-    let reduced_border =
-        vec2<f32>(select(border.x, -antialias_threshold, border.x == 0.0),
-                  select(border.y, -antialias_threshold, border.y == 0.0));
+    let reduced_border = vec2<f32>(select(border.x, -antialias_threshold, border.x == 0.0),
+        select(border.y, -antialias_threshold, border.y == 0.0));
 
     // Vector from the corner of the quad bounds to the point, after mirroring
     // the point into the bottom right quadrant. Both components are <= 0.
@@ -501,22 +502,19 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     let corner_center_to_point = corner_to_point + corner_radius;
 
     // Whether the nearest point on the border is rounded
-    let is_near_rounded_corner =
-            corner_center_to_point.x >= 0 &&
+    let is_near_rounded_corner = corner_center_to_point.x >= 0 &&
             corner_center_to_point.y >= 0;
 
     // Vector from straight border inner corner to point.
     let straight_border_inner_corner_to_point = corner_to_point + reduced_border;
 
     // Whether the point is beyond the inner edge of the straight border.
-    let is_beyond_inner_straight_border =
-            straight_border_inner_corner_to_point.x > 0 ||
+    let is_beyond_inner_straight_border = straight_border_inner_corner_to_point.x > 0 ||
             straight_border_inner_corner_to_point.y > 0;
 
     // Whether the point is far enough inside the quad, such that the pixels are
     // not affected by the straight border.
-    let is_within_inner_straight_border =
-        straight_border_inner_corner_to_point.x < -antialias_threshold &&
+    let is_within_inner_straight_border = straight_border_inner_corner_to_point.x < -antialias_threshold &&
         straight_border_inner_corner_to_point.y < -antialias_threshold;
 
     // Fast path for points that must be part of the background.
@@ -525,7 +523,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     // points in an inscribed rectangle, or some other quick linear check.
     // However, that might negatively impact performance in the case of
     // reasonable sizes for rounded corners.
-    if (is_within_inner_straight_border && !is_near_rounded_corner) {
+    if is_within_inner_straight_border && !is_near_rounded_corner {
         return blend_color(background_color, 1.0);
     }
 
@@ -542,14 +540,14 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     //   nearest-point-on-ellipse.
     // * When it is quickly known to be outside the edge, -1.0 is used.
     var inner_sdf = 0.0;
-    if (corner_center_to_point.x <= 0 || corner_center_to_point.y <= 0) {
+    if corner_center_to_point.x <= 0 || corner_center_to_point.y <= 0 {
         // Fast paths for straight borders.
         inner_sdf = -max(straight_border_inner_corner_to_point.x,
-                         straight_border_inner_corner_to_point.y);
-    } else if (is_beyond_inner_straight_border) {
+            straight_border_inner_corner_to_point.y);
+    } else if is_beyond_inner_straight_border {
         // Fast path for points that must be outside the inner edge.
         inner_sdf = -1.0;
-    } else if (reduced_border.x == reduced_border.y) {
+    } else if reduced_border.x == reduced_border.y {
         // Fast path for circular inner edge.
         inner_sdf = -(outer_sdf + reduced_border.x);
     } else {
@@ -561,11 +559,11 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     let border_sdf = max(inner_sdf, outer_sdf);
 
     var color = background_color;
-    if (border_sdf < antialias_threshold) {
+    if border_sdf < antialias_threshold {
         var border_color = input.border_color;
 
         // Dashed border logic when border_style == 1
-        if (quad.border_style == 1) {
+        if quad.border_style == 1 {
             // Position along the perimeter in "dash space", where each dash
             // period has length 1
             var t = 0.0;
@@ -592,12 +590,11 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
             // Dividing this by the border width gives the dash velocity
             let dv_numerator = 1.0 / dash_period_per_width;
 
-            if (unrounded) {
+            if unrounded {
                 // When corners aren't rounded, the dashes are separately laid
                 // out on each straight line, rather than around the whole
                 // perimeter. This way each line starts and ends with a dash.
-                let is_horizontal =
-                        corner_center_to_point.x <
+                let is_horizontal = corner_center_to_point.x <
                         corner_center_to_point.y;
 
                 // When applying dashed borders to just some, not all, the sides.
@@ -606,15 +603,15 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                 // TODO: A better solution exists taking a look at the whole file.
                 // this does not fix single dashed borders at the corners
                 let dashed_border = vec2<f32>(
-                        max(
-                            quad.border_widths.bottom,
-                            quad.border_widths.top,
-                        ),
-                        max(
-                            quad.border_widths.right,
-                            quad.border_widths.left,
-                        )
-                   );
+                    max(
+                        quad.border_widths.bottom,
+                        quad.border_widths.top,
+                    ),
+                    max(
+                        quad.border_widths.right,
+                        quad.border_widths.left,
+                    )
+                );
 
                 let border_width = select(dashed_border.y, dashed_border.x, is_horizontal);
                 dash_velocity = dv_numerator / border_width;
@@ -667,13 +664,13 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                 let upto_tl = upto_l + s_l;
                 max_t = upto_tl + c_tl;
 
-                if (is_near_rounded_corner) {
+                if is_near_rounded_corner {
                     let radians = atan2(corner_center_to_point.y,
-                                        corner_center_to_point.x);
+                        corner_center_to_point.x);
                     let corner_t = radians * corner_radius;
 
-                    if (center_to_point.x >= 0.0) {
-                        if (center_to_point.y < 0.0) {
+                    if center_to_point.x >= 0.0 {
+                        if center_to_point.y < 0.0 {
                             dash_velocity = corner_dash_velocity_tr;
                             // Subtracted because radians is pi/2 to 0 when
                             // going clockwise around the top right corner,
@@ -686,7 +683,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                             t = upto_br + corner_t * dash_velocity;
                         }
                     } else {
-                        if (center_to_point.y >= 0.0) {
+                        if center_to_point.y >= 0.0 {
                             dash_velocity = corner_dash_velocity_bl;
                             // Subtracted because radians is pi/2 to 0 when
                             // going clockwise around the bottom-left corner,
@@ -702,11 +699,10 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                     }
                 } else {
                     // Straight borders
-                    let is_horizontal =
-                            corner_center_to_point.x <
+                    let is_horizontal = corner_center_to_point.x <
                             corner_center_to_point.y;
-                    if (is_horizontal) {
-                        if (center_to_point.y < 0.0) {
+                    if is_horizontal {
+                        if center_to_point.y < 0.0 {
                             dash_velocity = dv_t;
                             t = (point.x - r_tl) * dash_velocity;
                         } else {
@@ -714,7 +710,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                             t = upto_bl - (point.x - r_bl) * dash_velocity;
                         }
                     } else {
-                        if (center_to_point.x < 0.0) {
+                        if center_to_point.x < 0.0 {
                             dash_velocity = dv_l;
                             t = upto_tl - (point.y - r_tl) * dash_velocity;
                         } else {
@@ -731,7 +727,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
             // Straight borders should start and end with a dash, so max_t is
             // reduced to cause this.
             max_t -= select(0.0, dash_length, unrounded);
-            if (max_t >= 1.0) {
+            if max_t >= 1.0 {
                 // Adjust dash gap to evenly divide max_t.
                 let dash_count = floor(max_t);
                 let dash_period = max_t / dash_count;
@@ -740,20 +736,22 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                     dash_period,
                     dash_length,
                     dash_velocity,
-                    antialias_threshold);
-            } else if (unrounded) {
+                    antialias_threshold
+                );
+            } else if unrounded {
                 // When there isn't enough space for the full gap between the
                 // two start / end dashes of a straight border, reduce gap to
                 // make them fit.
                 let dash_gap = max_t - dash_length;
-                if (dash_gap > 0.0) {
+                if dash_gap > 0.0 {
                     let dash_period = dash_length + dash_gap;
                     border_color.a *= dash_alpha(
                         t,
                         dash_period,
                         dash_length,
                         dash_velocity,
-                        antialias_threshold);
+                        antialias_threshold
+                    );
                 }
             }
         }
@@ -762,7 +760,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
         // between the two as we slide inside the background.
         let blended_border = over(background_color, border_color);
         color = mix(background_color, blended_border,
-                    saturate(antialias_threshold - inner_sdf));
+            saturate(antialias_threshold - inner_sdf));
     }
 
     return blend_color(color, saturate(antialias_threshold - outer_sdf));

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -210,7 +210,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
     if tag == 0u || tag == 2u {
         result.solid = hsla_to_rgba(solid);
-    } else if tag == 1u {
+    } else if tag == 1u || tag == 3u {
         // The hsla_to_rgba is returns a linear sRGB color
         result.color0 = hsla_to_rgba(color0.color);
         result.color1 = hsla_to_rgba(color1.color);
@@ -298,6 +298,47 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             let distance = min(pattern, pattern_period - pattern) - pattern_period * (pattern_width / pattern_height) / 2.0f;
             background_color = solid_color;
             background_color.a *= saturate(0.5 - distance);
+        }
+        case 3u: {
+            let center = bounds.origin +
+vec2<f32>(
+                background.param0 * bounds.size.x,
+                background.param1 * bounds.size.y
+            );
+
+            let delta = position - center;
+
+            let radius = max(
+                vec2<f32>(
+                    background.param2 * bounds.size.x,
+                    background.param3 * bounds.size.y
+                ),
+                vec2<f32>(0.001)
+            );
+
+            let ellipse_space = delta / radius;
+
+            var t = length(ellipse_space);
+
+            let stop0_percentage = background.color0.percentage;
+            let stop1_percentage = background.color1.percentage;
+
+            t = (t - stop0_percentage) /
+                (stop1_percentage - stop0_percentage);
+
+            t = clamp(t, 0.0, 1.0);
+
+            switch background.color_space {
+                default: {
+                    background_color = srgba_to_linear(
+                        mix(color0, color1, t)
+                    );
+                }
+                case 1u: {
+                    let oklab_color = mix(color0, color1, t);
+                    background_color = oklab_to_linear_srgb(oklab_color);
+                }
+            }
         }
     }
 

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -33,10 +33,12 @@ struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_angle_or_pattern_height: f32,
+    param0: f32,
+    param1: f32,
+    param2: f32,
+    param3: f32,
     color0: GradientStop,
     color1: GradientStop,
-    pad: u32,
 }
 
 struct Edges {
@@ -240,7 +242,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         case 1u: {
             // Linear gradient background.
             // -90 degrees to match the CSS gradient angle.
-            let angle = background.gradient_angle_or_pattern_height;
+            let angle = background.param0;
             let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
             var direction = vec2<f32>(cos(radians), sin(radians));
             let stop0_percentage = background.color0.percentage;
@@ -280,7 +282,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             }
         }
         case 2u: {
-            let gradient_angle_or_pattern_height = background.gradient_angle_or_pattern_height;
+            let gradient_angle_or_pattern_height = background.param0;
             let pattern_width = (gradient_angle_or_pattern_height / 65535.0f) / 255.0f;
             let pattern_interval = (gradient_angle_or_pattern_height % 65535.0f) / 255.0f;
             let pattern_height = pattern_width + pattern_interval;

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -26,14 +26,14 @@ struct Bounds {
 
 struct GradientStop {
     color: Hsla,
-    percentage: f32,
+    position: f32,
 }
 
 struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_angle_or_pattern_height: f32,
+    gradient_params: vec4<f32>,
     color0: GradientStop,
     color1: GradientStop,
     pad: u32,
@@ -208,7 +208,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
     if tag == 0u || tag == 2u {
         result.solid = hsla_to_rgba(solid);
-    } else if tag == 1u {
+    } else if tag == 1u || tag == 3u {
         // The hsla_to_rgba is returns a linear sRGB color
         result.color0 = hsla_to_rgba(color0.color);
         result.color1 = hsla_to_rgba(color1.color);
@@ -240,11 +240,11 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         case 1u: {
             // Linear gradient background.
             // -90 degrees to match the CSS gradient angle.
-            let angle = background.gradient_angle_or_pattern_height;
+            let angle = background.gradient_params.x;
             let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
             var direction = vec2<f32>(cos(radians), sin(radians));
-            let stop0_percentage = background.color0.percentage;
-            let stop1_percentage = background.color1.percentage;
+            let stop0_percentage = background.color0.position;
+            let stop1_percentage = background.color1.position;
 
             // Expand the short side to be the same as the long side
             if bounds.size.x > bounds.size.y {
@@ -280,9 +280,9 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             }
         }
         case 2u: {
-            let gradient_angle_or_pattern_height = background.gradient_angle_or_pattern_height;
-            let pattern_width = (gradient_angle_or_pattern_height / 65535.0f) / 255.0f;
-            let pattern_interval = (gradient_angle_or_pattern_height % 65535.0f) / 255.0f;
+            let pattern_data = background.gradient_params.x;
+            let pattern_width = (pattern_data / 65535.0f) / 255.0f;
+            let pattern_interval = (pattern_data % 65535.0f) / 255.0f;
             let pattern_height = pattern_width + pattern_interval;
             let stripe_angle = M_PI_F / 4.0;
             let pattern_period = pattern_height * sin(stripe_angle);

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -26,14 +26,14 @@ struct Bounds {
 
 struct GradientStop {
     color: Hsla,
-    position: f32,
+    percentage: f32,
 }
 
 struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_params: vec4<f32>,
+    gradient_angle_or_pattern_height: f32,
     color0: GradientStop,
     color1: GradientStop,
     pad: u32,
@@ -208,7 +208,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
 
     if tag == 0u || tag == 2u {
         result.solid = hsla_to_rgba(solid);
-    } else if tag == 1u || tag == 3u {
+    } else if tag == 1u {
         // The hsla_to_rgba is returns a linear sRGB color
         result.color0 = hsla_to_rgba(color0.color);
         result.color1 = hsla_to_rgba(color1.color);
@@ -240,11 +240,11 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         case 1u: {
             // Linear gradient background.
             // -90 degrees to match the CSS gradient angle.
-            let angle = background.gradient_params.x;
+            let angle = background.gradient_angle_or_pattern_height;
             let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
             var direction = vec2<f32>(cos(radians), sin(radians));
-            let stop0_percentage = background.color0.position;
-            let stop1_percentage = background.color1.position;
+            let stop0_percentage = background.color0.percentage;
+            let stop1_percentage = background.color1.percentage;
 
             // Expand the short side to be the same as the long side
             if bounds.size.x > bounds.size.y {
@@ -280,9 +280,9 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             }
         }
         case 2u: {
-            let pattern_data = background.gradient_params.x;
-            let pattern_width = (pattern_data / 65535.0f) / 255.0f;
-            let pattern_interval = (pattern_data % 65535.0f) / 255.0f;
+            let gradient_angle_or_pattern_height = background.gradient_angle_or_pattern_height;
+            let pattern_width = (gradient_angle_or_pattern_height / 65535.0f) / 255.0f;
+            let pattern_interval = (gradient_angle_or_pattern_height % 65535.0f) / 255.0f;
             let pattern_height = pattern_width + pattern_interval;
             let stripe_angle = M_PI_F / 4.0;
             let pattern_period = pattern_height * sin(stripe_angle);

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -29,15 +29,11 @@ struct GradientStop {
     position: f32,
 }
 
-struct GradientParams {
-    params: vec4<f32>,
-}
-
 struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_params: GradientParams,
+    gradient_params: vec4<f32>,
     color0: GradientStop,
     color1: GradientStop,
     pad: u32,
@@ -244,7 +240,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         case 1u: {
             // Linear gradient background.
             // -90 degrees to match the CSS gradient angle.
-            let angle = background.gradient_params.params.x;
+            let angle = background.gradient_params.x;
             let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
             var direction = vec2<f32>(cos(radians), sin(radians));
             let stop0_percentage = background.color0.position;
@@ -284,7 +280,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             }
         }
         case 2u: {
-            let pattern_data = background.gradient_params.params.x;
+            let pattern_data = background.gradient_params.x;
             let pattern_width = (pattern_data / 65535.0f) / 255.0f;
             let pattern_interval = (pattern_data % 65535.0f) / 255.0f;
             let pattern_height = pattern_width + pattern_interval;

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -29,11 +29,15 @@ struct GradientStop {
     position: f32,
 }
 
+struct GradientParams {
+    params: vec4<f32>,
+}
+
 struct Background {
     tag: u32,
     color_space: u32,
     solid: Hsla,
-    gradient_params: vec4<f32>,
+    gradient_params: GradientParams,
     color0: GradientStop,
     color1: GradientStop,
     pad: u32,
@@ -240,7 +244,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         case 1u: {
             // Linear gradient background.
             // -90 degrees to match the CSS gradient angle.
-            let angle = background.gradient_params.x;
+            let angle = background.gradient_params.params.x;
             let radians = (angle % 360.0 - 90.0) * M_PI_F / 180.0;
             var direction = vec2<f32>(cos(radians), sin(radians));
             let stop0_percentage = background.color0.position;
@@ -280,7 +284,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             }
         }
         case 2u: {
-            let pattern_data = background.gradient_params.x;
+            let pattern_data = background.gradient_params.params.x;
             let pattern_width = (pattern_data / 65535.0f) / 255.0f;
             let pattern_interval = (pattern_data % 65535.0f) / 255.0f;
             let pattern_height = pattern_width + pattern_interval;

--- a/src/style.rs
+++ b/src/style.rs
@@ -8,8 +8,8 @@ use crate::{
     AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
     FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black,
-    transparent_black, transparent_white, phi, point, quad, rems, size,
+    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
+    point, quad, rems, size, transparent_black, transparent_white,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -658,7 +658,7 @@ impl Style {
             let mut border_color = match background_color {
                 Some(color) => match color.tag {
                     BackgroundTag::Solid => color.solid,
-                    BackgroundTag::LinearGradient => color
+                    BackgroundTag::LinearGradient | BackgroundTag::RadialGradient => color
                         .colors
                         .first()
                         .map(|stop| stop.color)

--- a/src/style.rs
+++ b/src/style.rs
@@ -8,8 +8,8 @@ use crate::{
     AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
     FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
-    point, quad, rems, size, transparent_black, transparent_white,
+    PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black,
+    transparent_black, transparent_white, phi, point, quad, rems, size,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -658,7 +658,7 @@ impl Style {
             let mut border_color = match background_color {
                 Some(color) => match color.tag {
                     BackgroundTag::Solid => color.solid,
-                    BackgroundTag::LinearGradient | BackgroundTag::RadialGradient => color
+                    BackgroundTag::LinearGradient => color
                         .colors
                         .first()
                         .map(|stop| stop.color)


### PR DESCRIPTION
This PR adds radial gradients to WGPUI.

The `Background` struct has been modified to accept parameters for radial gradients. the old `gradient_angle_or_pattern_height` field has been removed and 4 new fields `param(0-3)` have been added.

this makes it more general purpose and can be utilized by other background types (such as conic gradients) in the future.