### PR TITLE
Update window.rs

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1219,7 +1219,9 @@ impl Window {
         }));
         platform_window.on_active_status_change(Box::new({
             let mut cx = cx.to_async();
+            let active_state = active.clone();
             move |active| {
+                active_state.set(active);
                 handle
                     .update(&mut cx, |_, window, cx| {
                         window.active.set(active);


### PR DESCRIPTION
This pull request introduces a small but important change to the window activation logic to ensure the window's active state is consistently updated.

- Window active state management:
  * In `src/window.rs`, within the `Window` implementation, the closure for `on_active_status_change` now explicitly updates the cloned `active` state using `active_state.set(active)`, ensuring the state is kept in sync with the platform window's active status.