### PR TITLE
Add letter spacing (text tracking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "open",
  "opener",
+ "ordered-float",
  "parking",
  "parking_lot",
  "pathfinder_geometry",
@@ -4092,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ util_macros = { package = "gpui_util_macros", version = "0.2.2" }
 usvg = { version = "0.47.0", default-features = false }
 uuid = { version = "1.23.2", features = ["v4", "v5", "v7", "serde"] }
 waker-fn = "1.2.0"
+ordered-float = "5.3.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-video = "0.5.2"

--- a/examples/learn/text.rs
+++ b/examples/learn/text.rs
@@ -489,7 +489,7 @@ fn tracking_example(colors: &Colors) -> impl IntoElement {
                 .child(
                     div()
                         .text_color(text)
-                        .tracking(5.0)
+                        .tracking_tighter()
                         .child("TRACKING TIGHTER"),
                 )
                 .child(
@@ -522,27 +522,7 @@ fn tracking_example(colors: &Colors) -> impl IntoElement {
                         .tracking_widest()
                         .child("TRACKING WIDEST"),
                 )
-                .child(
-                    div()
-                        .font_weight(FontWeight::THIN)
-                        .tracking_widest()
-                        .text_color(text)
-                        .child("THIN + WIDEST"),
-                )
-                .child(
-                    div()
-                        .font_weight(FontWeight::BLACK)
-                        .tracking_tighter()
-                        .text_color(text)
-                        .child("BLACK + TIGHTER"),
-                )
-                .child(
-                    div()
-                        .font_weight(FontWeight::BOLD)
-                        .tracking_wider()
-                        .text_color(text)
-                        .child("BOLD + WIDER"),
-                ),
+                .child(div().text_color(text).tracking(1.0).child("TRACKING 1em")),
         )
 }
 

--- a/examples/learn/text.rs
+++ b/examples/learn/text.rs
@@ -467,6 +467,85 @@ fn line_height_example(colors: &Colors) -> impl IntoElement {
         )
 }
 
+fn tracking_example(colors: &Colors) -> impl IntoElement {
+    let text = colors.text;
+    let text_muted = colors.text_muted;
+
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_xs()
+                .text_color(text_muted)
+                .child("Letter spacing / tracking"),
+        )
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_1()
+                .child(
+                    div()
+                        .text_color(text)
+                        .tracking(5.0)
+                        .child("TRACKING TIGHTER"),
+                )
+                .child(
+                    div()
+                        .text_color(text)
+                        .tracking_tight()
+                        .child("TRACKING TIGHT"),
+                )
+                .child(
+                    div()
+                        .text_color(text)
+                        .tracking_normal()
+                        .child("TRACKING NORMAL"),
+                )
+                .child(
+                    div()
+                        .text_color(text)
+                        .tracking_wide()
+                        .child("TRACKING WIDE"),
+                )
+                .child(
+                    div()
+                        .text_color(text)
+                        .tracking_wider()
+                        .child("TRACKING WIDER"),
+                )
+                .child(
+                    div()
+                        .text_color(text)
+                        .tracking_widest()
+                        .child("TRACKING WIDEST"),
+                )
+                .child(
+                    div()
+                        .font_weight(FontWeight::THIN)
+                        .tracking_widest()
+                        .text_color(text)
+                        .child("THIN + WIDEST"),
+                )
+                .child(
+                    div()
+                        .font_weight(FontWeight::BLACK)
+                        .tracking_tighter()
+                        .text_color(text)
+                        .child("BLACK + TIGHTER"),
+                )
+                .child(
+                    div()
+                        .font_weight(FontWeight::BOLD)
+                        .tracking_wider()
+                        .text_color(text)
+                        .child("BOLD + WIDER"),
+                ),
+        )
+}
+
 // Main Application View
 
 struct TextExample;
@@ -540,6 +619,11 @@ impl Render for TextExample {
                         &colors,
                         "Character Grid",
                         character_grid_example(&colors),
+                    ))
+                    .child(section(
+                        &colors,
+                        "Letter Spacing",
+                        tracking_example(&colors),
                     )),
             )
     }

--- a/examples/prelude.rs
+++ b/examples/prelude.rs
@@ -8,7 +8,7 @@
 //! use example_prelude::init_example;
 //! ```
 
-use gpui::{App, KeyBinding, Menu, MenuItem, SharedString, actions};
+use gpui::{actions, App, KeyBinding, Menu, MenuItem, SharedString};
 
 actions!(example, [Quit, CloseWindow]);
 
@@ -32,7 +32,7 @@ pub fn init_example(cx: &mut App, name: impl Into<SharedString>) {
     }]);
 
     // Quit the app when all windows are closed
-    cx.on_window_closed(|cx| {
+    cx.on_window_closed(|cx, _| {
         if cx.windows().is_empty() {
             cx.quit();
         }

--- a/src/elements/text.rs
+++ b/src/elements/text.rs
@@ -377,7 +377,11 @@ impl TextLayout {
                     return text_layout.size.unwrap();
                 }
 
-                let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
+                let mut line_wrapper = cx.text_system().line_wrapper(
+                    text_style.font(),
+                    font_size,
+                    text_style.letter_spacing,
+                );
                 let (text, runs) = if let Some(truncate_width) = truncate_width {
                     line_wrapper.truncate_line(
                         text.clone(),

--- a/src/platform/cross/text_system.rs
+++ b/src/platform/cross/text_system.rs
@@ -420,6 +420,11 @@ impl CosmicTextSystemState {
                     .stretch(font.stretch)
                     .style(run.style.into())
                     .weight(run.weight.into())
+                    .letter_spacing(
+                        run.letter_spacing
+                            .unwrap_or(ordered_float::OrderedFloat(0.0))
+                            .into(),
+                    )
                     .font_features(loaded_font.features.clone()),
             );
             offs += run.len;

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -1,11 +1,11 @@
 use crate::{
-    Bounds, Capslock, Decorations, Modifiers, Pixels, PlatformInputHandler, PlatformWindow, Point,
-    ResizeEdge, Size, WgpuSurfaceHandle, WindowAppearance, WindowBackgroundAppearance,
-    WindowBounds,
     platform::cross::{
         atlas::WgpuAtlas, dispatcher::CrossEvent, render_context::WgpuContext,
         renderer::WgpuRenderer, resize_detector::ResizeDetector,
     },
+    Bounds, Capslock, Decorations, Modifiers, Pixels, PlatformInputHandler, PlatformWindow, Point,
+    ResizeEdge, Size, WgpuSurfaceHandle, WindowAppearance, WindowBackgroundAppearance,
+    WindowBounds,
 };
 use std::{
     cell::{Cell, OnceCell, RefCell},
@@ -14,8 +14,7 @@ use std::{
 use winit::event_loop::EventLoopProxy;
 
 #[cfg(target_os = "linux")]
-use winit::platform::linux::WindowExtLinux;
-
+// use winit::platform::linux::WindowExtLinux;
 #[cfg(target_os = "windows")]
 use winit::platform::windows::{BackdropType, WindowExtWindows};
 
@@ -280,8 +279,8 @@ impl PlatformWindow for CrossWindow {
 
     fn set_app_id(&mut self, app_id: &str) {
         self.0.state.app_id.borrow_mut().replace(app_id.to_owned());
-        #[cfg(target_os = "linux")]
-        self.window().set_app_id(Some(app_id));
+        // #[cfg(target_os = "linux")]
+        // self.window().set_app_id(Some(app_id));
     }
 
     fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance) {

--- a/src/style.rs
+++ b/src/style.rs
@@ -12,6 +12,7 @@ use crate::{
     black, phi, point, quad, rems, size, solid_text_color, transparent_black, transparent_white,
 };
 use collections::HashSet;
+use ordered_float::OrderedFloat;
 use refineable::Refineable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -497,7 +498,7 @@ impl TextStyle {
             background_color: self.background_color,
             underline: self.underline,
             strikethrough: self.strikethrough,
-            letter_spacing: None,
+            letter_spacing: self.letter_spacing.map(OrderedFloat),
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -403,6 +403,9 @@ pub struct TextStyle {
 
     /// The number of lines to display before truncating the text
     pub line_clamp: Option<usize>,
+
+    /// Additional letter spacing (tracking) in EM units.
+    pub letter_spacing: Option<f32>,
 }
 
 impl Default for TextStyle {
@@ -424,6 +427,7 @@ impl Default for TextStyle {
             text_overflow: None,
             text_align: TextAlign::default(),
             line_clamp: None,
+            letter_spacing: None,
         }
     }
 }
@@ -493,6 +497,7 @@ impl TextStyle {
             background_color: self.background_color,
             underline: self.underline,
             strikethrough: self.strikethrough,
+            letter_spacing: None,
         }
     }
 }

--- a/src/styled.rs
+++ b/src/styled.rs
@@ -514,9 +514,8 @@ pub trait Styled: Sized {
         from: impl Into<LinearColorStop>,
         to: impl Into<LinearColorStop>,
     ) -> Self {
-        self.text_style()
-            .get_or_insert_with(Default::default)
-            .color = Some(crate::text_gradient(angle, from, to));
+        self.text_style().get_or_insert_with(Default::default).color =
+            Some(crate::text_gradient(angle, from, to));
         self
     }
 
@@ -794,6 +793,47 @@ pub trait Styled: Sized {
         text_style.font_fallbacks = fallbacks;
 
         self
+    }
+
+    /// Sets the letter spacing of the text in em units.
+    fn tracking(mut self, spacing: f32) -> Self {
+        self.text_style()
+            .get_or_insert_with(Default::default)
+            .letter_spacing = Some(spacing);
+        self
+    }
+
+    /// [Docs](https://tailwindcss.com/docs/letter-spacing#tracking-tighter)
+    fn tracking_tighter(self) -> Self {
+        self.tracking(-0.05)
+    }
+
+    /// [Docs](https://tailwindcss.com/docs/letter-spacing#tracking-tight)
+    fn tracking_tight(self) -> Self {
+        self.tracking(-0.025)
+    }
+
+    /// [Docs](https://tailwindcss.com/docs/letter-spacing#tracking-normal)
+    fn tracking_normal(mut self) -> Self {
+        self.text_style()
+            .get_or_insert_with(Default::default)
+            .letter_spacing = Some(0.0);
+        self
+    }
+
+    /// [Docs](https://tailwindcss.com/docs/letter-spacing#tracking-wide)
+    fn tracking_wide(self) -> Self {
+        self.tracking(0.025)
+    }
+
+    /// [Docs](https://tailwindcss.com/docs/letter-spacing#tracking-wider)
+    fn tracking_wider(self) -> Self {
+        self.tracking(0.05)
+    }
+
+    /// [Docs](https://tailwindcss.com/docs/letter-spacing#tracking-widest)
+    fn tracking_widest(self) -> Self {
+        self.tracking(0.1)
     }
 
     /// Sets the line height of this element and its children.

--- a/src/text_system.rs
+++ b/src/text_system.rs
@@ -9,6 +9,7 @@ pub use font_features::*;
 pub use line::*;
 pub use line_layout::*;
 pub use line_wrapper::*;
+use ordered_float::OrderedFloat;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -466,6 +467,7 @@ impl WindowTextSystem {
                         font_id,
                         weight: run.font.weight,
                         style: run.font.style,
+                        letter_spacing: run.letter_spacing,
                     });
                 }
 
@@ -582,6 +584,7 @@ impl WindowTextSystem {
                     font_id,
                     weight: run.font.weight,
                     style: run.font.style,
+                    letter_spacing: run.letter_spacing,
                 });
             }
         }
@@ -756,6 +759,8 @@ pub struct TextRun {
     pub underline: Option<UnderlineStyle>,
     /// The strikethrough style (if any)
     pub strikethrough: Option<StrikethroughStyle>,
+    /// Tracking in EM units.
+    pub letter_spacing: Option<OrderedFloat<f32>>,
 }
 
 /// An identifier for a specific glyph, as returned by [`WindowTextSystem::layout_line`].

--- a/src/text_system.rs
+++ b/src/text_system.rs
@@ -285,7 +285,12 @@ impl TextSystem {
     }
 
     /// Returns a handle to a line wrapper, for the given font and font size.
-    pub fn line_wrapper(self: &Arc<Self>, font: Font, font_size: Pixels) -> LineWrapperHandle {
+    pub fn line_wrapper(
+        self: &Arc<Self>,
+        font: Font,
+        font_size: Pixels,
+        letter_spacing: Option<f32>,
+    ) -> LineWrapperHandle {
         let lock = &mut self.wrapper_pool.lock();
         let font_id = self.resolve_font(&font);
         let wrappers = lock
@@ -297,6 +302,7 @@ impl TextSystem {
                 font_size,
                 font.weight,
                 font.style,
+                letter_spacing,
                 self.platform_text_system.clone(),
             )
         });

--- a/src/text_system/line_layout.rs
+++ b/src/text_system/line_layout.rs
@@ -1,8 +1,9 @@
 use crate::{
-    FontId, FontStyle, FontWeight, GlyphId, Pixels, PlatformTextSystem, Point, SharedString,
-    Size, point, px,
+    FontId, FontStyle, FontWeight, GlyphId, Pixels, PlatformTextSystem, Point, SharedString, Size,
+    point, px,
 };
 use collections::FxHashMap;
+use ordered_float::OrderedFloat;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use smallvec::SmallVec;
 use std::{
@@ -602,6 +603,7 @@ pub struct FontRun {
     pub(crate) font_id: FontId,
     pub(crate) weight: FontWeight,
     pub(crate) style: FontStyle,
+    pub(crate) letter_spacing: Option<OrderedFloat<f32>>,
 }
 
 trait AsCacheKeyRef {

--- a/src/text_system/line_wrapper.rs
+++ b/src/text_system/line_wrapper.rs
@@ -26,6 +26,7 @@ impl LineWrapper {
         font_size: Pixels,
         weight: FontWeight,
         style: FontStyle,
+        letter_spacing: Option<f32>,
         text_system: Arc<dyn PlatformTextSystem>,
     ) -> Self {
         Self {
@@ -34,7 +35,7 @@ impl LineWrapper {
             font_size,
             weight,
             style,
-            letter_spacing: None,
+            letter_spacing,
             cached_ascii_char_widths: [None; 128],
             cached_other_char_widths: HashMap::default(),
         }
@@ -341,6 +342,7 @@ mod tests {
             px(16.),
             FontWeight::NORMAL,
             FontStyle::Normal,
+            None,
             cx.text_system().platform_text_system.clone(),
         )
     }

--- a/src/text_system/line_wrapper.rs
+++ b/src/text_system/line_wrapper.rs
@@ -11,6 +11,7 @@ pub struct LineWrapper {
     pub(crate) font_size: Pixels,
     pub(crate) weight: FontWeight,
     pub(crate) style: FontStyle,
+    pub(crate) letter_spacing: Option<f32>,
     cached_ascii_char_widths: [Option<Pixels>; 128],
     cached_other_char_widths: HashMap<char, Pixels>,
 }
@@ -32,6 +33,7 @@ impl LineWrapper {
             font_size,
             weight,
             style,
+            letter_spacing: None,
             cached_ascii_char_widths: [None; 128],
             cached_other_char_widths: HashMap::default(),
         }
@@ -229,6 +231,7 @@ impl LineWrapper {
                     font_id: self.font_id,
                     weight: self.weight,
                     style: self.style,
+                    letter_spacing: self.letter_spacing,
                 }],
             )
             .width

--- a/src/text_system/line_wrapper.rs
+++ b/src/text_system/line_wrapper.rs
@@ -2,6 +2,7 @@ use crate::{
     FontId, FontRun, FontStyle, FontWeight, Pixels, PlatformTextSystem, SharedString, TextRun, px,
 };
 use collections::HashMap;
+use ordered_float::OrderedFloat;
 use std::{borrow::Cow, iter, sync::Arc};
 
 /// The GPUI line wrapper, used to wrap lines of text to a given width.
@@ -231,7 +232,7 @@ impl LineWrapper {
                     font_id: self.font_id,
                     weight: self.weight,
                     style: self.style,
-                    letter_spacing: self.letter_spacing,
+                    letter_spacing: self.letter_spacing.map(OrderedFloat),
                 }],
             )
             .width


### PR DESCRIPTION
This PR adds letter spacing support with TailwindCSS style methods such as `tracking_tight`, `tracking_wide`, etc...

<img width="616" height="308" alt="image" src="https://github.com/user-attachments/assets/3dbea5ae-a586-4e91-b359-14a71d6b70e2" />

Fixes windowID related build issues on linux