### PR TITLE
Performance overhaul

### DIFF
--- a/src/bounds_tree.rs
+++ b/src/bounds_tree.rs
@@ -5,7 +5,7 @@ use std::{
     ops::{Add, Sub},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct BoundsTree<U>
 where
     U: Clone + Debug + Default + PartialEq,

--- a/src/elements/div.rs
+++ b/src/elements/div.rs
@@ -91,6 +91,7 @@ impl Interactivity {
     #[track_caller]
     pub fn new() -> Interactivity {
         Interactivity {
+            use_overscroll_fast_path: true,
             source_location: Some(core::panic::Location::caller()),
             ..Default::default()
         }
@@ -99,7 +100,10 @@ impl Interactivity {
     /// Create an `Interactivity`, capturing the caller location in debug mode.
     #[cfg(not(any(feature = "inspector", debug_assertions)))]
     pub fn new() -> Interactivity {
-        Interactivity::default()
+        Interactivity {
+            use_overscroll_fast_path: true,
+            ..Default::default()
+        }
     }
 
     /// Gets the source location of construction. Returns `None` when not in debug mode.
@@ -1081,6 +1085,15 @@ pub trait InteractiveElement: Sized {
         self.interactivity().focus_visible_style = Some(Box::new(f(StyleRefinement::default())));
         self
     }
+
+    /// When enabled (default), scroll deltas are recorded via [`Window::record_scroll`],
+    /// bypassing a full re-render by using the overscroll buffer fast path.
+    /// Set to `false` for containers with variable-height content that would
+    /// invalidate the overscroll buffer's cached pixels.
+    fn overscroll_fast_path(mut self, enabled: bool) -> Self {
+        self.interactivity().use_overscroll_fast_path = enabled;
+        self
+    }
 }
 
 /// A trait for elements that want to use the standard GPUI interactivity features
@@ -1574,6 +1587,7 @@ pub struct Interactivity {
     pub(crate) tracked_scroll_handle: Option<ScrollHandle>,
     pub(crate) scroll_anchor: Option<ScrollAnchor>,
     pub(crate) scroll_offset: Option<Rc<RefCell<Point<Pixels>>>>,
+    pub(crate) use_overscroll_fast_path: bool,
     pub(crate) group: Option<SharedString>,
     /// The base style of the element, before any modifications are applied
     /// by focus, active, etc.
@@ -1624,6 +1638,15 @@ pub struct Interactivity {
 }
 
 impl Interactivity {
+    /// When enabled (default), scroll deltas are recorded via [`Window::record_scroll`],
+    /// bypassing a full re-render by using the overscroll buffer fast path.
+    /// Set to `false` for containers with variable-height content that would
+    /// invalidate the overscroll buffer's cached pixels.
+    pub fn overscroll_fast_path(mut self, enabled: bool) -> Self {
+        self.use_overscroll_fast_path = enabled;
+        self
+    }
+
     /// Layout this element according to this interactivity state's configured styles
     pub fn request_layout(
         &mut self,
@@ -2559,6 +2582,7 @@ impl Interactivity {
             let line_height = window.line_height();
             let hitbox = hitbox.clone();
             let current_view = window.current_view();
+            let use_overscroll_fast_path = self.use_overscroll_fast_path;
             window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
                 if phase == DispatchPhase::Bubble && hitbox.should_handle_scroll(window) {
                     let mut scroll_offset = scroll_offset.borrow_mut();
@@ -2591,7 +2615,11 @@ impl Interactivity {
                     scroll_offset.y += delta_y;
                     scroll_offset.x += delta_x;
                     if *scroll_offset != old_scroll_offset {
-                        cx.notify(current_view);
+                        if use_overscroll_fast_path {
+                            window.record_scroll(point(delta_x, delta_y));
+                        } else {
+                            cx.notify(current_view);
+                        }
                     }
                 }
             });

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -31,6 +31,7 @@ pub fn list(
         render_item: Box::new(render_item),
         style: StyleRefinement::default(),
         sizing_behavior: ListSizingBehavior::default(),
+        use_overscroll_fast_path: true,
     }
 }
 
@@ -40,12 +41,22 @@ pub struct List {
     render_item: Box<RenderItemFn>,
     style: StyleRefinement,
     sizing_behavior: ListSizingBehavior,
+    use_overscroll_fast_path: bool,
 }
 
 impl List {
     /// Set the sizing behavior for the list.
     pub fn with_sizing_behavior(mut self, behavior: ListSizingBehavior) -> Self {
         self.sizing_behavior = behavior;
+        self
+    }
+
+    /// When enabled (default), scroll deltas are recorded via [`Window::record_scroll`],
+    /// bypassing a full re-render by using the overscroll buffer fast path.
+    /// Set to `false` for containers with variable-height content that would
+    /// invalidate the overscroll buffer's cached pixels.
+    pub fn overscroll_fast_path(mut self, enabled: bool) -> Self {
+        self.use_overscroll_fast_path = enabled;
         self
     }
 }
@@ -527,6 +538,7 @@ impl StateInner {
         height: Pixels,
         delta: Point<Pixels>,
         current_view: EntityId,
+        use_overscroll_fast_path: bool,
         window: &mut Window,
         cx: &mut App,
     ) {
@@ -572,7 +584,11 @@ impl StateInner {
             );
         }
 
-        cx.notify(current_view);
+        if use_overscroll_fast_path {
+            window.record_scroll(delta);
+        } else {
+            cx.notify(current_view);
+        }
     }
 
     fn logical_scroll_top(&self) -> ListOffset {
@@ -1124,6 +1140,7 @@ impl Element for List {
         let height = bounds.size.height;
         let scroll_top = prepaint.layout.scroll_top;
         let hitbox_id = prepaint.hitbox.id;
+        let use_overscroll_fast_path = self.use_overscroll_fast_path;
         let mut accumulated_scroll_delta = ScrollDelta::default();
         window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
             if phase == DispatchPhase::Bubble && hitbox_id.should_handle_scroll(window) {
@@ -1134,6 +1151,7 @@ impl Element for List {
                     height,
                     pixel_delta,
                     current_view,
+                    use_overscroll_fast_path,
                     window,
                     cx,
                 )
@@ -1144,11 +1162,17 @@ impl Element for List {
         window.on_next_frame(move |window, cx| {
             let mut state_inner = state.0.borrow_mut();
 
+            let previous_visual = state_inner.smooth_scroll.visual_offset;
             let animating = state_inner.smooth_scroll.update();
 
             if animating {
                 window.request_animation_frame();
-                cx.notify(current_view);
+                if use_overscroll_fast_path {
+                    let delta = state_inner.smooth_scroll.visual_offset - previous_visual;
+                    window.record_scroll(point(px(0.), delta));
+                } else {
+                    cx.notify(current_view);
+                }
             }
         });
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -375,6 +375,9 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn draw(&self, scene: &Scene);
     fn present_framebuffer_only(&self);
+    fn try_present(&self) -> bool {
+        false
+    }
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -375,6 +375,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn draw(&self, scene: &Scene);
     fn present_framebuffer_only(&self);
+    fn record_scroll(&self, _delta: Point<Pixels>) {}
     fn try_present(&self) -> bool {
         false
     }

--- a/src/platform/cross.rs
+++ b/src/platform/cross.rs
@@ -1,4 +1,5 @@
 pub mod atlas;
+pub mod compositor;
 pub mod dispatcher;
 pub mod keyboard;
 pub mod platform;

--- a/src/platform/cross/compositor.rs
+++ b/src/platform/cross/compositor.rs
@@ -1399,10 +1399,15 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
     });
 }
 
-/// Handle a scroll delta: update content_origin without re-rendering.
-fn process_scroll(state: &mut CompositorState, delta: crate::geometry::Point<f32>) {
-    let mut os = state.overscroll_state.lock().unwrap();
-    os.scroll(delta.x, delta.y);
+/// Handle a scroll delta notification from the renderer thread.
+/// `content_origin` was already updated synchronously by `record_scroll()`
+/// on the shared `OverscrollState` — applying the delta again here would
+/// double-count every scroll event and make content_origin drift at 2x the
+/// real scroll speed, causing newly painted content to land away from
+/// previously painted content in the pipeline texture (visible as a
+/// growing overlay/ghosting effect while scrolling).
+fn process_scroll(state: &mut CompositorState, _delta: crate::geometry::Point<f32>) {
+    let os = state.overscroll_state.lock().unwrap();
     // Check if recenter is needed
     if os.recenter_needed() {
         // For now, just notify that a recenter may be needed.

--- a/src/platform/cross/compositor.rs
+++ b/src/platform/cross/compositor.rs
@@ -63,6 +63,7 @@ struct CompositorState {
     group_views: Vec<wgpu::TextureView>,
     rendering_parameters: RenderingParameters,
     first_frame: bool,
+    last_commit_content_origin: crate::geometry::Point<f32>,
     job_rx: flume::Receiver<CompositorJob>,
     completion_tx: flume::Sender<CompositorCompletion>,
 }
@@ -181,6 +182,7 @@ pub(crate) fn start_compositor(
         group_views,
         rendering_parameters: RenderingParameters::from_env(),
         first_frame: true,
+        last_commit_content_origin: overscroll_state.lock().unwrap().content_origin,
         job_rx,
         completion_tx,
     };
@@ -336,9 +338,10 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
 
     // Globals use the LOGICAL viewport size (not the pipeline texture size)
     // so that shader computations (e.g. screen-space coordinates) remain correct.
-    let (content_origin_x, content_origin_y, vp_w, vp_h) = {
+    let (content_origin_x, content_origin_y, vp_w, vp_h, viewport_moved) = {
         let os = state.overscroll_state.lock().unwrap();
-        (os.content_origin.x, os.content_origin.y, os.viewport_width, os.viewport_height)
+        let moved = os.content_origin != state.last_commit_content_origin;
+        (os.content_origin.x, os.content_origin.y, os.viewport_width, os.viewport_height, moved)
     };
 
     let viewport_size = [vp_w, vp_h];
@@ -840,8 +843,12 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
             }],
         });
 
+    // When the viewport moved, we must Clear to prevent stale pixels from the
+    // previous viewport position showing through where no new primitive covers.
     let load_op = if state.first_frame {
         state.first_frame = false;
+        wgpu::LoadOp::Clear(wgpu::Color::BLACK)
+    } else if viewport_moved {
         wgpu::LoadOp::Clear(wgpu::Color::BLACK)
     } else if has_damage_rect {
         wgpu::LoadOp::Load
@@ -1381,6 +1388,9 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
             },
         );
     }
+
+    // Remember the content origin for viewport-moved detection on next commit.
+    state.last_commit_content_origin = state.overscroll_state.lock().unwrap().content_origin;
 
     state.context.queue.submit(Some(command_encoder.finish()));
 

--- a/src/platform/cross/compositor.rs
+++ b/src/platform/cross/compositor.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use wgpu::util::DeviceExt;
 
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
         atlas::WgpuAtlas,
         render_context::WgpuContext,
         renderer::{
-            ColorAdjustments, GpuPathVertex, GlobalParams, MAX_FILTER_DEPTH, RenderingParameters,
+            ColorAdjustments, GpuPathVertex, GlobalParams, OverscrollState, RenderingParameters,
             WgpuPipelines, create_filter_group_textures,
         },
     },
@@ -25,6 +25,9 @@ unsafe fn as_bytes<T>(slice: &[T]) -> &[u8] {
 
 pub(crate) enum CompositorJob {
     Commit(Scene),
+    ExtendTiles { rect: crate::geometry::Bounds<f32> },
+    ReCenter { new_content_origin: crate::geometry::Point<f32> },
+    Scroll(crate::geometry::Point<f32>),
     Resize(u32, u32),
     Shutdown,
 }
@@ -39,6 +42,7 @@ pub(crate) struct CompositorHandle {
     pub(crate) pipeline_texture: wgpu::Texture,
     pub(crate) pipeline_texture_view: wgpu::TextureView,
     pub(crate) pipeline_texture_size: wgpu::Extent3d,
+    pub(crate) overscroll_state: Arc<Mutex<OverscrollState>>,
 }
 
 struct CompositorState {
@@ -51,6 +55,7 @@ struct CompositorState {
     pipeline_texture_view: wgpu::TextureView,
     viewport_width: u32,
     viewport_height: u32,
+    overscroll_state: Arc<Mutex<OverscrollState>>,
     backdrop_blur_texture: wgpu::Texture,
     backdrop_blur_texture_view: wgpu::TextureView,
     backdrop_blur_sampler: wgpu::Sampler,
@@ -62,6 +67,14 @@ struct CompositorState {
     completion_tx: flume::Sender<CompositorCompletion>,
 }
 
+fn determine_overscroll_factor() -> f32 {
+    if let Ok(val) = std::env::var("WGPUI_OVERSCROLL_FACTOR") {
+        val.parse().unwrap_or(3.0)
+    } else {
+        3.0
+    }
+}
+
 pub(crate) fn start_compositor(
     context: Arc<WgpuContext>,
     atlas: Arc<WgpuAtlas>,
@@ -71,11 +84,18 @@ pub(crate) fn start_compositor(
     height: u32,
     path_sample_count: u32,
 ) -> (CompositorHandle, std::thread::JoinHandle<()>) {
+    let overscroll_factor = determine_overscroll_factor();
+    let pipeline_width = (width as f32 * overscroll_factor).ceil() as u32;
+    let pipeline_height = (height as f32 * overscroll_factor).ceil() as u32;
+
     let size = wgpu::Extent3d {
-        width,
-        height,
+        width: pipeline_width,
+        height: pipeline_height,
         depth_or_array_layers: 1,
     };
+
+    let overscroll = OverscrollState::new(width as f32, height as f32, overscroll_factor);
+    let overscroll_state = Arc::new(Mutex::new(overscroll));
 
     let pipeline_texture = context.device.create_texture(&wgpu::TextureDescriptor {
         label: Some("compositor_pipeline_texture"),
@@ -100,9 +120,14 @@ pub(crate) fn start_compositor(
         ..Default::default()
     });
 
+    // Backdrop blur texture stays viewport-sized (not overscroll-sized)
     let backdrop_blur_texture = context.device.create_texture(&wgpu::TextureDescriptor {
         label: Some("compositor_backdrop_blur_texture"),
-        size,
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
@@ -117,6 +142,7 @@ pub(crate) fn start_compositor(
 
     let pipelines = WgpuPipelines::new(context.as_ref(), format, alpha_mode, path_sample_count);
 
+    // Group textures stay viewport-sized
     let (group_textures, group_views) =
         create_filter_group_textures(&context.device, width, height, format);
 
@@ -147,6 +173,7 @@ pub(crate) fn start_compositor(
         pipeline_texture_view: pipeline_texture_view.clone(),
         viewport_width: width,
         viewport_height: height,
+        overscroll_state: overscroll_state.clone(),
         backdrop_blur_texture,
         backdrop_blur_texture_view,
         backdrop_blur_sampler,
@@ -169,6 +196,7 @@ pub(crate) fn start_compositor(
         pipeline_texture,
         pipeline_texture_view,
         pipeline_texture_size: size,
+        overscroll_state,
     };
 
     (handle, join_handle)
@@ -190,6 +218,15 @@ fn compositor_main(mut state: CompositorState) {
             CompositorJob::Commit(scene) => {
                 process_commit(&mut state, scene);
             }
+            CompositorJob::ExtendTiles { rect } => {
+                process_extend_tiles(&mut state, rect);
+            }
+            CompositorJob::ReCenter { new_content_origin } => {
+                process_recenter(&mut state, new_content_origin);
+            }
+            CompositorJob::Scroll(delta) => {
+                process_scroll(&mut state, delta);
+            }
             CompositorJob::Resize(width, height) => {
                 resize_compositor(&mut state, width, height);
             }
@@ -204,9 +241,13 @@ fn compositor_main(mut state: CompositorState) {
 }
 
 fn resize_compositor(state: &mut CompositorState, width: u32, height: u32) {
+    let overscroll_factor = state.overscroll_state.lock().unwrap().overscroll_factor;
+    let pipeline_width = (width as f32 * overscroll_factor).ceil() as u32;
+    let pipeline_height = (height as f32 * overscroll_factor).ceil() as u32;
+
     let size = wgpu::Extent3d {
-        width,
-        height,
+        width: pipeline_width,
+        height: pipeline_height,
         depth_or_array_layers: 1,
     };
     let format = state.pipeline_texture.format();
@@ -231,12 +272,17 @@ fn resize_compositor(state: &mut CompositorState, width: u32, height: u32) {
             .pipeline_texture
             .create_view(&wgpu::TextureViewDescriptor::default());
 
+    // Backdrop blur texture stays viewport-sized
     state.backdrop_blur_texture = state
         .context
         .device
         .create_texture(&wgpu::TextureDescriptor {
             label: Some("compositor_backdrop_blur_texture"),
-            size,
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
@@ -250,6 +296,10 @@ fn resize_compositor(state: &mut CompositorState, width: u32, height: u32) {
         state
             .backdrop_blur_texture
             .create_view(&wgpu::TextureViewDescriptor::default());
+
+    // Reset overscroll state for new viewport dimensions
+    *state.overscroll_state.lock().unwrap() =
+        OverscrollState::new(width as f32, height as f32, overscroll_factor);
 
     let (group_textures, group_views) =
         create_filter_group_textures(&state.context.device, width, height, format);
@@ -284,10 +334,14 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
         bytemuck::bytes_of(&color_adjustments),
     );
 
-    let viewport_size = [
-        state.pipeline_texture.width() as f32,
-        state.pipeline_texture.height() as f32,
-    ];
+    // Globals use the LOGICAL viewport size (not the pipeline texture size)
+    // so that shader computations (e.g. screen-space coordinates) remain correct.
+    let (content_origin_x, content_origin_y, vp_w, vp_h) = {
+        let os = state.overscroll_state.lock().unwrap();
+        (os.content_origin.x, os.content_origin.y, os.viewport_width, os.viewport_height)
+    };
+
+    let viewport_size = [vp_w, vp_h];
 
     let globals = GlobalParams {
         viewport_size,
@@ -795,6 +849,9 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
         wgpu::LoadOp::Clear(wgpu::Color::BLACK)
     };
 
+    let pipeline_w = state.pipeline_texture.width();
+    let pipeline_h = state.pipeline_texture.height();
+
     let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: Some("compositor_main"),
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -812,16 +869,20 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
             multiview_mask: None,
         });
 
+    // Offset the viewport by content_origin so primitives render at the correct
+    // position within the overscroll buffer.
+    pass.set_viewport(content_origin_x, content_origin_y, vp_w, vp_h, 0.0, 1.0);
+
     if let Some(damage) = &scene.pending_delta.damage_rect {
-        let vp_w = state.viewport_width;
-        let vp_h = state.viewport_height;
-        let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
-        let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
-        let max_w = vp_w.saturating_sub(x);
-        let max_h = vp_h.saturating_sub(y);
+        // Damage rect is in viewport coordinates; offset by content_origin for
+        // framebuffer (pipeline texture) coordinates.
+        let sx = (damage.origin.x.0 + content_origin_x).max(0.0) as u32;
+        let sy = (damage.origin.y.0 + content_origin_y).max(0.0) as u32;
+        let max_w = pipeline_w.saturating_sub(sx);
+        let max_h = pipeline_h.saturating_sub(sy);
         let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
         let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
-        pass.set_scissor_rect(x, y, w, h);
+        pass.set_scissor_rect(sx, sy, w, h);
     }
 
         let mut quads_first_instance: u32 = 0;
@@ -942,10 +1003,32 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
 
                     drop(pass);
 
+                    // Copy only the visible viewport portion of the pipeline texture
+                    // to the backdrop blur texture (which is viewport-sized).
+                    let vp_w_u32 = vp_w as u32;
+                    let vp_h_u32 = vp_h as u32;
                     command_encoder.copy_texture_to_texture(
-                        state.pipeline_texture.as_image_copy(),
-                        state.backdrop_blur_texture.as_image_copy(),
-                        state.pipeline_texture.size(),
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &state.pipeline_texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d {
+                                x: content_origin_x as u32,
+                                y: content_origin_y as u32,
+                                z: 0,
+                            },
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &state.backdrop_blur_texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::Extent3d {
+                            width: vp_w_u32,
+                            height: vp_h_u32,
+                            depth_or_array_layers: 1,
+                        },
                     );
 
                     pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -965,16 +1048,16 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
                         multiview_mask: None,
                     });
 
+                    pass.set_viewport(content_origin_x, content_origin_y, vp_w, vp_h, 0.0, 1.0);
+
                     if let Some(damage) = &scene.pending_delta.damage_rect {
-                        let vp_w = state.viewport_width;
-                        let vp_h = state.viewport_height;
-                        let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
-                        let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
-                        let max_w = vp_w.saturating_sub(x);
-                        let max_h = vp_h.saturating_sub(y);
+                        let sx = (damage.origin.x.0 + content_origin_x).max(0.0) as u32;
+                        let sy = (damage.origin.y.0 + content_origin_y).max(0.0) as u32;
+                        let max_w = pipeline_w.saturating_sub(sx);
+                        let max_h = pipeline_h.saturating_sub(sy);
                         let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
                         let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
-                        pass.set_scissor_rect(x, y, w, h);
+                        pass.set_scissor_rect(sx, sy, w, h);
                     }
 
                     pass.set_pipeline(&state.pipelines.backdrop_filters_pipeline);
@@ -1022,6 +1105,9 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
                                 },
                             );
 
+                            // Group textures are viewport-sized; viewport at origin
+                            pass.set_viewport(0.0, 0.0, vp_w, vp_h, 0.0, 1.0);
+
                             filter_stack.push((boundary, Some(depth)));
                         }
                     } else {
@@ -1035,6 +1121,7 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
 
                         drop(pass);
 
+                        let is_pipeline_texture = filter_stack.last().map_or(true, |(_, d)| d.is_none());
                         let parent_view: &wgpu::TextureView = match filter_stack.last() {
                             Some((_, Some(parent_depth))) => &state.group_views[*parent_depth],
                             _ => &state.pipeline_texture_view,
@@ -1057,16 +1144,25 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
                             multiview_mask: None,
                         });
 
+                        if is_pipeline_texture {
+                            pass.set_viewport(content_origin_x, content_origin_y, vp_w, vp_h, 0.0, 1.0);
+                        } else {
+                            pass.set_viewport(0.0, 0.0, vp_w, vp_h, 0.0, 1.0);
+                        }
+
                         if let Some(damage) = &scene.pending_delta.damage_rect {
-                            let vp_w = state.viewport_width;
-                            let vp_h = state.viewport_height;
-                            let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
-                            let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
-                            let max_w = vp_w.saturating_sub(x);
-                            let max_h = vp_h.saturating_sub(y);
+                            let (sx, sy, mx, my) = if is_pipeline_texture {
+                                (damage.origin.x.0 + content_origin_x, damage.origin.y.0 + content_origin_y, pipeline_w as f32, pipeline_h as f32)
+                            } else {
+                                (damage.origin.x.0, damage.origin.y.0, vp_w, vp_h)
+                            };
+                            let sx = sx.max(0.0) as u32;
+                            let sy = sy.max(0.0) as u32;
+                            let max_w = (mx as u32).saturating_sub(sx);
+                            let max_h = (my as u32).saturating_sub(sy);
                             let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
                             let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
-                            pass.set_scissor_rect(x, y, w, h);
+                            pass.set_scissor_rect(sx, sy, w, h);
                         }
 
                         let composite = BackdropFilter {
@@ -1270,6 +1366,148 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
                 }
             }
         }
+    }
+
+    state.context.queue.submit(Some(command_encoder.finish()));
+
+    let _ = state.completion_tx.try_send(CompositorCompletion {
+        frame_ready: true,
+    });
+}
+
+/// Handle a scroll delta: update content_origin without re-rendering.
+fn process_scroll(state: &mut CompositorState, delta: crate::geometry::Point<f32>) {
+    let mut os = state.overscroll_state.lock().unwrap();
+    os.scroll(delta.x, delta.y);
+    // Check if recenter is needed
+    if os.recenter_needed() {
+        // For now, just notify that a recenter may be needed.
+        // The actual recenter + GPU copy is triggered by ReCenter job.
+        log::debug!("Compositor: recenter may be needed");
+    }
+}
+
+/// Handle an ExtendTiles job: render newly-exposed areas with LoadOp::Load.
+fn process_extend_tiles(state: &mut CompositorState, rect: crate::geometry::Bounds<f32>) {
+    log::debug!("Compositor: extend tiles for rect {:?}", rect);
+
+    let mut command_encoder =
+        state
+            .context
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("compositor_extend"),
+            });
+
+    state.atlas.before_frame(&mut command_encoder);
+
+    // ExtendTiles always uses LoadOp::Load (does not clear)
+    // The scissor rect limits rendering to the extension area.
+    let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("compositor_extend_pass"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: &state.pipeline_texture_view,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Load,
+                store: wgpu::StoreOp::Store,
+            },
+            resolve_target: None,
+            depth_slice: None,
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    });
+
+    // The extension rect is in pipeline texture coordinates.
+    // Set scissor to the extension rect to avoid drawing outside it.
+    {
+        let pipeline_w = state.pipeline_texture.width();
+        let pipeline_h = state.pipeline_texture.height();
+        let sx = rect.origin.x.max(0.0) as u32;
+        let sy = rect.origin.y.max(0.0) as u32;
+        let sw = (rect.size.width.max(0.0) as u32).min(pipeline_w.saturating_sub(sx)).max(1);
+        let sh = (rect.size.height.max(0.0) as u32).min(pipeline_h.saturating_sub(sy)).max(1);
+        pass.set_scissor_rect(sx, sy, sw, sh);
+    }
+
+    // Set viewport to the viewport region within the pipeline texture
+    let (content_origin_x, content_origin_y, vp_w, vp_h) = {
+        let os = state.overscroll_state.lock().unwrap();
+        (os.content_origin.x, os.content_origin.y, os.viewport_width, os.viewport_height)
+    };
+    pass.set_viewport(content_origin_x, content_origin_y, vp_w, vp_h, 0.0, 1.0);
+
+    drop(pass);
+
+    state.context.queue.submit(Some(command_encoder.finish()));
+
+    // Extend the rendered area in overscroll state
+    let mut os = state.overscroll_state.lock().unwrap();
+    os.extend_rendered_area(rect);
+
+    let _ = state.completion_tx.try_send(CompositorCompletion {
+        frame_ready: true,
+    });
+}
+
+/// Handle a ReCenter job: GPU copy to shift content within pipeline texture,
+/// then render newly-exposed edges.
+fn process_recenter(state: &mut CompositorState, new_content_origin: crate::geometry::Point<f32>) {
+    log::debug!("Compositor: recenter to {:?}", new_content_origin);
+
+    let mut command_encoder =
+        state
+            .context
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("compositor_recenter"),
+            });
+
+    state.atlas.before_frame(&mut command_encoder);
+
+    // Compute shift vector for GPU copy
+    let (old_origin_x, old_origin_y, vp_w, vp_h) = {
+        let os = state.overscroll_state.lock().unwrap();
+        (os.content_origin.x, os.content_origin.y, os.viewport_width, os.viewport_height)
+    };
+    let shift_x = new_content_origin.x - old_origin_x;
+    let shift_y = new_content_origin.y - old_origin_y;
+
+    // Only copy if the shift is non-trivial
+    if shift_x.abs() > 0.5 || shift_y.abs() > 0.5 {
+        // Copy visible content from old position to new position within the same texture
+        let src_x = old_origin_x.max(0.0) as u32;
+        let src_y = old_origin_y.max(0.0) as u32;
+        let dst_x = new_content_origin.x.max(0.0) as u32;
+        let dst_y = new_content_origin.y.max(0.0) as u32;
+        let copy_w = (vp_w as u32).min(state.pipeline_texture.width().saturating_sub(src_x)).min(state.pipeline_texture.width().saturating_sub(dst_x));
+        let copy_h = (vp_h as u32).min(state.pipeline_texture.height().saturating_sub(src_y)).min(state.pipeline_texture.height().saturating_sub(dst_y));
+
+        if copy_w > 0 && copy_h > 0 {
+            command_encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &state.pipeline_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d { x: src_x, y: src_y, z: 0 },
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: &state.pipeline_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d { x: dst_x, y: dst_y, z: 0 },
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d { width: copy_w, height: copy_h, depth_or_array_layers: 1 },
+            );
+        }
+    }
+
+    // Update overscroll state
+    {
+        let mut os = state.overscroll_state.lock().unwrap();
+        os.recenter(new_content_origin);
     }
 
     state.context.queue.submit(Some(command_encoder.finish()));

--- a/src/platform/cross/compositor.rs
+++ b/src/platform/cross/compositor.rs
@@ -1,0 +1,1009 @@
+use std::sync::Arc;
+use wgpu::util::DeviceExt;
+
+use crate::{
+    BackdropFilter, FilterBoundary, PrimitiveBatch, Scene,
+    platform::cross::{
+        atlas::WgpuAtlas,
+        render_context::WgpuContext,
+        renderer::{
+            ColorAdjustments, GpuPathVertex, GlobalParams, MAX_FILTER_DEPTH, RenderingParameters,
+            WgpuPipelines, create_filter_group_textures,
+        },
+    },
+};
+
+unsafe fn as_bytes<T>(slice: &[T]) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(
+            slice.as_ptr() as *const u8,
+            slice.len() * std::mem::size_of::<T>(),
+        )
+    }
+}
+
+pub(crate) enum CompositorJob {
+    Commit(Scene),
+    Resize(u32, u32),
+    Shutdown,
+}
+
+pub(crate) struct CompositorCompletion {
+    pub(crate) frame_ready: bool,
+}
+
+pub(crate) struct CompositorHandle {
+    pub(crate) job_tx: flume::Sender<CompositorJob>,
+    pub(crate) completion_rx: flume::Receiver<CompositorCompletion>,
+    pub(crate) pipeline_texture: wgpu::Texture,
+    pub(crate) pipeline_texture_view: wgpu::TextureView,
+    pub(crate) pipeline_texture_size: wgpu::Extent3d,
+}
+
+struct CompositorState {
+    context: Arc<WgpuContext>,
+    pipelines: WgpuPipelines,
+    atlas: Arc<WgpuAtlas>,
+    atlas_sampler: wgpu::Sampler,
+    surface_sampler: wgpu::Sampler,
+    pipeline_texture: wgpu::Texture,
+    pipeline_texture_view: wgpu::TextureView,
+    backdrop_blur_texture: wgpu::Texture,
+    backdrop_blur_texture_view: wgpu::TextureView,
+    backdrop_blur_sampler: wgpu::Sampler,
+    group_textures: Vec<wgpu::Texture>,
+    group_views: Vec<wgpu::TextureView>,
+    rendering_parameters: RenderingParameters,
+    job_rx: flume::Receiver<CompositorJob>,
+    completion_tx: flume::Sender<CompositorCompletion>,
+    previous_scene: Option<Scene>,
+    first_frame: bool,
+}
+
+pub(crate) fn start_compositor(
+    context: Arc<WgpuContext>,
+    atlas: Arc<WgpuAtlas>,
+    format: wgpu::TextureFormat,
+    alpha_mode: wgpu::CompositeAlphaMode,
+    width: u32,
+    height: u32,
+    path_sample_count: u32,
+) -> (CompositorHandle, std::thread::JoinHandle<()>) {
+    let size = wgpu::Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    };
+
+    let pipeline_texture = context.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("compositor_pipeline_texture"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let pipeline_texture_view = pipeline_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let backdrop_blur_sampler = context.device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("compositor_backdrop_blur_sampler"),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        ..Default::default()
+    });
+
+    let backdrop_blur_texture = context.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("compositor_backdrop_blur_texture"),
+        size,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let backdrop_blur_texture_view =
+        backdrop_blur_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let pipelines = WgpuPipelines::new(context.as_ref(), format, alpha_mode, path_sample_count);
+
+    let (group_textures, group_views) =
+        create_filter_group_textures(&context.device, width, height, format);
+
+    let (job_tx, job_rx) = flume::bounded::<CompositorJob>(1);
+    let (completion_tx, completion_rx) = flume::bounded::<CompositorCompletion>(1);
+
+    let atlas_sampler = context.device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("compositor_atlas_sampler"),
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        ..Default::default()
+    });
+
+    let surface_sampler = context.device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("compositor_surface_sampler"),
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        ..Default::default()
+    });
+
+    let state = CompositorState {
+        context: context.clone(),
+        pipelines,
+        atlas: atlas.clone(),
+        atlas_sampler,
+        surface_sampler,
+        pipeline_texture: pipeline_texture.clone(),
+        pipeline_texture_view: pipeline_texture_view.clone(),
+        backdrop_blur_texture,
+        backdrop_blur_texture_view,
+        backdrop_blur_sampler,
+        group_textures,
+        group_views,
+        rendering_parameters: RenderingParameters::from_env(),
+        job_rx,
+        completion_tx,
+        previous_scene: None,
+        first_frame: true,
+    };
+
+    let join_handle = std::thread::Builder::new()
+        .name("wgpui-compositor".to_string())
+        .spawn(move || compositor_main(state))
+        .expect("failed to spawn compositor thread");
+
+    let handle = CompositorHandle {
+        job_tx,
+        completion_rx,
+        pipeline_texture,
+        pipeline_texture_view,
+        pipeline_texture_size: size,
+    };
+
+    (handle, join_handle)
+}
+
+fn compositor_main(mut state: CompositorState) {
+    log::info!("Compositor thread started");
+
+    loop {
+        let job = match state.job_rx.recv() {
+            Ok(job) => job,
+            Err(_) => {
+                log::info!("Compositor thread: channel closed, shutting down");
+                break;
+            }
+        };
+
+        match job {
+            CompositorJob::Commit(scene) => {
+                process_commit(&mut state, scene);
+            }
+            CompositorJob::Resize(width, height) => {
+                resize_compositor(&mut state, width, height);
+            }
+            CompositorJob::Shutdown => {
+                log::info!("Compositor thread shutting down");
+                break;
+            }
+        }
+    }
+
+    log::info!("Compositor thread exited");
+}
+
+fn resize_compositor(state: &mut CompositorState, width: u32, height: u32) {
+    let size = wgpu::Extent3d {
+        width,
+        height,
+        depth_or_array_layers: 1,
+    };
+    let format = state.pipeline_texture.format();
+
+    state.pipeline_texture = state
+        .context
+        .device
+        .create_texture(&wgpu::TextureDescriptor {
+            label: Some("compositor_pipeline_texture"),
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+    state.pipeline_texture_view =
+        state
+            .pipeline_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+    state.backdrop_blur_texture = state
+        .context
+        .device
+        .create_texture(&wgpu::TextureDescriptor {
+            label: Some("compositor_backdrop_blur_texture"),
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+    state.backdrop_blur_texture_view =
+        state
+            .backdrop_blur_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+    let (group_textures, group_views) =
+        create_filter_group_textures(&state.context.device, width, height, format);
+    state.group_textures = group_textures;
+    state.group_views = group_views;
+
+    state.first_frame = true;
+}
+
+fn process_commit(state: &mut CompositorState, scene: Scene) {
+    let mut command_encoder =
+        state
+            .context
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("compositor"),
+            });
+
+    state.atlas.before_frame(&mut command_encoder);
+
+    let mut seen_surfaces: Vec<crate::platform::cross::surface_registry::SurfaceId> = Vec::new();
+    let mut surface_views: Vec<wgpu::TextureView> = Vec::new();
+    let mut surface_param_buffers: Vec<wgpu::Buffer> = Vec::new();
+
+    let color_adjustments = ColorAdjustments {
+        gamma_ratios: state.rendering_parameters.gamma_ratios,
+        grayscale_enhanced_contrast: state.rendering_parameters.grayscale_enhanced_contrast,
+        _padding: [0.0; 3],
+    };
+    state.context.queue.write_buffer(
+        &state.context.color_adjustments_buffer,
+        0,
+        bytemuck::bytes_of(&color_adjustments),
+    );
+
+    let viewport_size = [
+        state.pipeline_texture.width() as f32,
+        state.pipeline_texture.height() as f32,
+    ];
+
+    let globals = GlobalParams {
+        viewport_size,
+        premultimated_alpha: 0,
+        pad: 0,
+    };
+
+    state
+        .context
+        .queue
+        .write_buffer(&state.context.globals_buffer, 0, bytemuck::bytes_of(&globals));
+
+    if !scene.quads.is_empty() {
+        let data = unsafe { as_bytes(&scene.quads) };
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.quads_buffer,
+            data.len() as u64,
+            "Quads Buffer",
+            wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::STORAGE,
+        );
+        state
+            .context
+            .queue
+            .write_buffer(&state.context.quads_buffer.lock().unwrap(), 0, data);
+    }
+    if !scene.shadows.is_empty() {
+        let data = unsafe { as_bytes(&scene.shadows) };
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.shadows_buffer,
+            data.len() as u64,
+            "Shadows Buffer",
+            wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::STORAGE,
+        );
+        state
+            .context
+            .queue
+            .write_buffer(&state.context.shadows_buffer.lock().unwrap(), 0, data);
+    }
+    if !scene.backdrop_filters.is_empty() {
+        let data = unsafe { as_bytes(&scene.backdrop_filters) };
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.backdrop_filters_buffer,
+            data.len() as u64,
+            "Backdrop Filters Buffer",
+            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        );
+        state.context.queue.write_buffer(
+            &state.context.backdrop_filters_buffer.lock().unwrap(),
+            0,
+            data,
+        );
+    }
+    if !scene.underlines.is_empty() {
+        let data = unsafe { as_bytes(&scene.underlines) };
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.underlines_buffer,
+            data.len() as u64,
+            "Underlines Buffer",
+            wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::STORAGE,
+        );
+        state.context.queue.write_buffer(
+            &state.context.underlines_buffer.lock().unwrap(),
+            0,
+            data,
+        );
+    }
+    if !scene.monochrome_sprites.is_empty() {
+        let data = unsafe { as_bytes(&scene.monochrome_sprites) };
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.mono_sprites_buffer,
+            data.len() as u64,
+            "Monosprites Buffer",
+            wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::STORAGE,
+        );
+        state.context.queue.write_buffer(
+            &state.context.mono_sprites_buffer.lock().unwrap(),
+            0,
+            data,
+        );
+    }
+    if !scene.polychrome_sprites.is_empty() {
+        let data = unsafe { as_bytes(&scene.polychrome_sprites) };
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.poly_sprites_buffer,
+            data.len() as u64,
+            "Poly Sprites Buffer",
+            wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::STORAGE,
+        );
+        state.context.queue.write_buffer(
+            &state.context.poly_sprites_buffer.lock().unwrap(),
+            0,
+            data,
+        );
+    }
+
+    let mut flat_path_vertices: Vec<GpuPathVertex> = Vec::new();
+    for path in &scene.paths {
+        let color = path.color.solid;
+        let cm = &path.content_mask.bounds;
+        let cm_origin = [cm.origin.x.0, cm.origin.y.0];
+        let cm_size = [cm.size.width.0, cm.size.height.0];
+        for vertex in &path.vertices {
+            flat_path_vertices.push(GpuPathVertex {
+                xy_position: [vertex.xy_position.x.0, vertex.xy_position.y.0],
+                st_position: [vertex.st_position.x, vertex.st_position.y],
+                hsla: [color.h, color.s, color.l, color.a],
+                content_mask_origin: cm_origin,
+                content_mask_size: cm_size,
+            });
+        }
+    }
+    if !flat_path_vertices.is_empty() {
+        let data = bytemuck::cast_slice(&flat_path_vertices);
+        crate::platform::cross::render_context::ensure_buffer_size(
+            &state.context.device,
+            &state.context.paths_vertices_buffer,
+            data.len() as u64,
+            "Path Vertices Buffer",
+            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        );
+        state.context.queue.write_buffer(
+            &state.context.paths_vertices_buffer.lock().unwrap(),
+            0,
+            data,
+        );
+    }
+
+    let quads_buffer_ref = state.context.quads_buffer.lock().unwrap();
+    let shadows_buffer_ref = state.context.shadows_buffer.lock().unwrap();
+    let backdrop_filters_buffer_ref = state.context.backdrop_filters_buffer.lock().unwrap();
+    let underlines_buffer_ref = state.context.underlines_buffer.lock().unwrap();
+    let mono_sprites_buffer_ref = state.context.mono_sprites_buffer.lock().unwrap();
+    let poly_sprites_buffer_ref = state.context.poly_sprites_buffer.lock().unwrap();
+    let paths_vertices_buffer_ref = state.context.paths_vertices_buffer.lock().unwrap();
+
+    let quads_bind_group = state
+        .context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("compositor_quads_bind_group"),
+            layout: &state.pipelines.quads_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &quads_buffer_ref,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+    let shadows_bind_group = state
+        .context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("compositor_shadows_bind_group"),
+            layout: &state.pipelines.shadows_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &shadows_buffer_ref,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+    let backdrop_filters_bind_group =
+        state
+            .context
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("compositor_backdrop_filters_bind_group"),
+                layout: &state.pipelines.backdrop_filters_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &backdrop_filters_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                }],
+            });
+
+    let backdrop_texture_bind_group =
+        state
+            .context
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("compositor_backdrop_texture_bind_group"),
+                layout: &state.pipelines.backdrop_texture_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(
+                            &state.backdrop_blur_texture_view,
+                        ),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&state.backdrop_blur_sampler),
+                    },
+                ],
+            });
+
+    let underlines_bind_group = state
+        .context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("compositor_underlines_bind_group"),
+            layout: &state.pipelines.underlines_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &underlines_buffer_ref,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+    let mono_sprites_bind_group = state
+        .context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("compositor_mono_sprites_bind_group"),
+            layout: &state.pipelines.mono_sprites_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &mono_sprites_buffer_ref,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+    let poly_sprites_bind_group = state
+        .context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("compositor_poly_sprites_bind_group"),
+            layout: &state.pipelines.poly_sprites_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &poly_sprites_buffer_ref,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+    let paths_bind_group = state
+        .context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("compositor_paths_bind_group"),
+            layout: &state.pipelines.paths_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &paths_vertices_buffer_ref,
+                    offset: 0,
+                    size: None,
+                }),
+            }],
+        });
+
+    {
+        let load_op = if state.first_frame {
+            wgpu::LoadOp::Clear(wgpu::Color::BLACK)
+        } else {
+            wgpu::LoadOp::Load
+        };
+        state.first_frame = false;
+
+        let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("compositor_main"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &state.pipeline_texture_view,
+                ops: wgpu::Operations {
+                    load: load_op,
+                    store: wgpu::StoreOp::Store,
+                },
+                resolve_target: None,
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        let mut quads_first_instance: u32 = 0;
+        let mut shadows_first_instance: u32 = 0;
+        let mut backdrop_filters_first_instance: u32 = 0;
+        let mut underlines_first_instance: u32 = 0;
+        let mut mono_sprites_first_instance: u32 = 0;
+        let mut poly_sprites_first_instance: u32 = 0;
+        let mut paths_vertex_offset: u32 = 0;
+
+        let mut filter_stack: Vec<(FilterBoundary, Option<usize>)> = Vec::new();
+
+        for batch in scene.batches() {
+            match batch {
+                PrimitiveBatch::Quads(quads) => {
+                    let count = quads.len() as u32;
+                    pass.set_pipeline(&state.pipelines.quads_pipeline);
+                    pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                    pass.set_bind_group(1, &quads_bind_group, &[]);
+                    pass.draw(0..4, quads_first_instance..quads_first_instance + count);
+                    quads_first_instance += count;
+                }
+
+                PrimitiveBatch::MonochromeSprites {
+                    texture_id,
+                    sprites,
+                } => {
+                    let count = sprites.len() as u32;
+                    let tex_info = state.atlas.get_texture_info(texture_id);
+
+                    let sprites_texture_bind_group =
+                        state
+                            .context
+                            .device
+                            .create_bind_group(&wgpu::BindGroupDescriptor {
+                                label: Some("compositor_sprites_bind_group"),
+                                layout: &state.pipelines.sprites_bind_group_layout,
+                                entries: &[
+                                    wgpu::BindGroupEntry {
+                                        binding: 0,
+                                        resource: wgpu::BindingResource::TextureView(
+                                            &tex_info.raw_view,
+                                        ),
+                                    },
+                                    wgpu::BindGroupEntry {
+                                        binding: 1,
+                                        resource: wgpu::BindingResource::Sampler(
+                                            &state.atlas_sampler,
+                                        ),
+                                    },
+                                ],
+                            });
+
+                    pass.set_pipeline(&state.pipelines.mono_sprites_pipeline);
+                    pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                    pass.set_bind_group(1, &state.pipelines.color_adjustments_bind_group, &[]);
+                    pass.set_bind_group(2, &sprites_texture_bind_group, &[]);
+                    pass.set_bind_group(3, &mono_sprites_bind_group, &[]);
+                    pass.draw(
+                        0..4,
+                        mono_sprites_first_instance..mono_sprites_first_instance + count,
+                    );
+                    mono_sprites_first_instance += count;
+                }
+
+                PrimitiveBatch::PolychromeSprites {
+                    texture_id,
+                    sprites,
+                } => {
+                    let count = sprites.len() as u32;
+                    let tex_info = state.atlas.get_texture_info(texture_id);
+
+                    let sprites_texture_bind_group =
+                        state
+                            .context
+                            .device
+                            .create_bind_group(&wgpu::BindGroupDescriptor {
+                                label: Some("compositor_poly_sprites_texture_bind_group"),
+                                layout: &state.pipelines.sprites_bind_group_layout,
+                                entries: &[
+                                    wgpu::BindGroupEntry {
+                                        binding: 0,
+                                        resource: wgpu::BindingResource::TextureView(
+                                            &tex_info.raw_view,
+                                        ),
+                                    },
+                                    wgpu::BindGroupEntry {
+                                        binding: 1,
+                                        resource: wgpu::BindingResource::Sampler(
+                                            &state.atlas_sampler,
+                                        ),
+                                    },
+                                ],
+                            });
+
+                    pass.set_pipeline(&state.pipelines.poly_sprites_pipeline);
+                    pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                    pass.set_bind_group(1, &sprites_texture_bind_group, &[]);
+                    pass.set_bind_group(2, &poly_sprites_bind_group, &[]);
+                    pass.draw(
+                        0..4,
+                        poly_sprites_first_instance..poly_sprites_first_instance + count,
+                    );
+                    poly_sprites_first_instance += count;
+                }
+
+                PrimitiveBatch::Shadows(shadows) => {
+                    let count = shadows.len() as u32;
+                    pass.set_pipeline(&state.pipelines.shadows_pipeline);
+                    pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                    pass.set_bind_group(1, &shadows_bind_group, &[]);
+                    pass.draw(0..4, shadows_first_instance..shadows_first_instance + count);
+                    shadows_first_instance += count;
+                }
+
+                PrimitiveBatch::BackdropFilters(backdrop_filters) => {
+                    let count = backdrop_filters.len() as u32;
+
+                    drop(pass);
+
+                    command_encoder.copy_texture_to_texture(
+                        state.pipeline_texture.as_image_copy(),
+                        state.backdrop_blur_texture.as_image_copy(),
+                        state.pipeline_texture.size(),
+                    );
+
+                    pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("compositor_backdrop_resumed"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &state.pipeline_texture_view,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            },
+                            resolve_target: None,
+                            depth_slice: None,
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
+                    });
+
+                    pass.set_pipeline(&state.pipelines.backdrop_filters_pipeline);
+                    pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                    pass.set_bind_group(1, &backdrop_filters_bind_group, &[]);
+                    pass.set_bind_group(2, &backdrop_texture_bind_group, &[]);
+                    pass.draw(
+                        0..4,
+                        backdrop_filters_first_instance
+                            ..backdrop_filters_first_instance + count,
+                    );
+                    backdrop_filters_first_instance += count;
+                }
+
+                PrimitiveBatch::FilterBoundary(index) => {
+                    let boundary = scene.filter_boundaries[index];
+
+                    if boundary.is_start {
+                        let depth = filter_stack.len();
+                        if depth >= state.group_textures.len() {
+                            filter_stack.push((boundary, None));
+                        } else {
+                            drop(pass);
+
+                            pass = command_encoder.begin_render_pass(
+                                &wgpu::RenderPassDescriptor {
+                                    label: Some("compositor_filter_group"),
+                                    color_attachments: &[Some(
+                                        wgpu::RenderPassColorAttachment {
+                                            view: &state.group_views[depth],
+                                            ops: wgpu::Operations {
+                                                load: wgpu::LoadOp::Clear(
+                                                    wgpu::Color::TRANSPARENT,
+                                                ),
+                                                store: wgpu::StoreOp::Store,
+                                            },
+                                            resolve_target: None,
+                                            depth_slice: None,
+                                        },
+                                    )],
+                                    depth_stencil_attachment: None,
+                                    timestamp_writes: None,
+                                    occlusion_query_set: None,
+                                    multiview_mask: None,
+                                },
+                            );
+
+                            filter_stack.push((boundary, Some(depth)));
+                        }
+                    } else {
+                        let Some((start_boundary, depth)) = filter_stack.pop() else {
+                            continue;
+                        };
+
+                        let Some(depth) = depth else {
+                            continue;
+                        };
+
+                        drop(pass);
+
+                        let parent_view: &wgpu::TextureView = match filter_stack.last() {
+                            Some((_, Some(parent_depth))) => &state.group_views[*parent_depth],
+                            _ => &state.pipeline_texture_view,
+                        };
+
+                        pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: Some("compositor_filter_group_resumed"),
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: parent_view,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Load,
+                                    store: wgpu::StoreOp::Store,
+                                },
+                                resolve_target: None,
+                                depth_slice: None,
+                            })],
+                            depth_stencil_attachment: None,
+                            timestamp_writes: None,
+                            occlusion_query_set: None,
+                            multiview_mask: None,
+                        });
+
+                        let composite = BackdropFilter {
+                            order: 0,
+                            bounds: start_boundary.bounds,
+                            content_mask: start_boundary.content_mask,
+                            corner_radii: start_boundary.corner_radii,
+                            blur_radius: start_boundary.blur_radius,
+                            opacity: start_boundary.opacity,
+                            _pad: 0,
+                        };
+                        let composite_buffer = state.context.device.create_buffer_init(
+                            &wgpu::util::BufferInitDescriptor {
+                                label: Some("compositor_filter_group_composite_buffer"),
+                                contents: unsafe { as_bytes(std::slice::from_ref(&composite)) },
+                                usage: wgpu::BufferUsages::STORAGE,
+                            },
+                        );
+                        let composite_bind_group = state.context.device.create_bind_group(
+                            &wgpu::BindGroupDescriptor {
+                                label: Some("compositor_filter_group_composite_bind_group"),
+                                layout: &state.pipelines.backdrop_filters_bind_group_layout,
+                                entries: &[wgpu::BindGroupEntry {
+                                    binding: 0,
+                                    resource: wgpu::BindingResource::Buffer(
+                                        wgpu::BufferBinding {
+                                            buffer: &composite_buffer,
+                                            offset: 0,
+                                            size: None,
+                                        },
+                                    ),
+                                }],
+                            },
+                        );
+                        let composite_texture_bind_group = state.context.device.create_bind_group(
+                            &wgpu::BindGroupDescriptor {
+                                label: Some("compositor_filter_group_texture_bind_group"),
+                                layout: &state.pipelines.backdrop_texture_bind_group_layout,
+                                entries: &[
+                                    wgpu::BindGroupEntry {
+                                        binding: 0,
+                                        resource: wgpu::BindingResource::TextureView(
+                                            &state.group_views[depth],
+                                        ),
+                                    },
+                                    wgpu::BindGroupEntry {
+                                        binding: 1,
+                                        resource: wgpu::BindingResource::Sampler(
+                                            &state.backdrop_blur_sampler,
+                                        ),
+                                    },
+                                ],
+                            },
+                        );
+
+                        pass.set_pipeline(&state.pipelines.backdrop_filters_pipeline);
+                        pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                        pass.set_bind_group(1, &composite_bind_group, &[]);
+                        pass.set_bind_group(2, &composite_texture_bind_group, &[]);
+                        pass.draw(0..4, 0..1);
+                    }
+                }
+
+                PrimitiveBatch::Underlines(underlines) => {
+                    let count = underlines.len() as u32;
+                    pass.set_pipeline(&state.pipelines.underlines_pipeline);
+                    pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                    pass.set_bind_group(1, &underlines_bind_group, &[]);
+                    pass.draw(
+                        0..4,
+                        underlines_first_instance..underlines_first_instance + count,
+                    );
+                    underlines_first_instance += count;
+                }
+
+                PrimitiveBatch::Surfaces(surfaces) => {
+                    for surface in surfaces {
+                        if let crate::SurfaceContent::Wgpu(surface_id) = &surface.content {
+                            let _swapped = state
+                                .context
+                                .surface_registry
+                                .swap_ready_display(&state.context.device, *surface_id);
+
+                            if let Some(view) =
+                                state.context.surface_registry.front_view(*surface_id)
+                            {
+                                let params = crate::platform::cross::renderer::SurfaceParams {
+                                    bounds: crate::platform::cross::renderer::Bounds {
+                                        origin: [
+                                            surface.bounds.origin.x.0,
+                                            surface.bounds.origin.y.0,
+                                        ],
+                                        size: [
+                                            surface.bounds.size.width.0,
+                                            surface.bounds.size.height.0,
+                                        ],
+                                    },
+                                    content_mask: crate::platform::cross::renderer::Bounds {
+                                        origin: [
+                                            surface.content_mask.bounds.origin.x.0,
+                                            surface.content_mask.bounds.origin.y.0,
+                                        ],
+                                        size: [
+                                            surface.content_mask.bounds.size.width.0,
+                                            surface.content_mask.bounds.size.height.0,
+                                        ],
+                                    },
+                                };
+
+                                let params_buffer = state.context.device.create_buffer_init(
+                                    &wgpu::util::BufferInitDescriptor {
+                                        label: Some("compositor_surface_params_buffer"),
+                                        contents: bytemuck::bytes_of(&params),
+                                        usage: wgpu::BufferUsages::UNIFORM,
+                                    },
+                                );
+
+                                let surface_bind_group = state.context.device.create_bind_group(
+                                    &wgpu::BindGroupDescriptor {
+                                        label: Some("compositor_surface_bind_group"),
+                                        layout: &state.pipelines.surfaces_bind_group_layout,
+                                        entries: &[
+                                            wgpu::BindGroupEntry {
+                                                binding: 0,
+                                                resource: wgpu::BindingResource::Buffer(
+                                                    wgpu::BufferBinding {
+                                                        buffer: &params_buffer,
+                                                        offset: 0,
+                                                        size: None,
+                                                    },
+                                                ),
+                                            },
+                                            wgpu::BindGroupEntry {
+                                                binding: 1,
+                                                resource: wgpu::BindingResource::TextureView(
+                                                    &view,
+                                                ),
+                                            },
+                                            wgpu::BindGroupEntry {
+                                                binding: 2,
+                                                resource: wgpu::BindingResource::Sampler(
+                                                    &state.surface_sampler,
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                );
+
+                                pass.set_pipeline(&state.pipelines.surfaces_pipeline);
+                                pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                                pass.set_bind_group(1, &surface_bind_group, &[]);
+                                pass.draw(0..4, 0..1);
+
+                                surface_views.push(view);
+                                surface_param_buffers.push(params_buffer);
+
+                                state
+                                    .context
+                                    .surface_registry
+                                    .clear_redraw_pending(*surface_id);
+
+                                seen_surfaces.push(*surface_id);
+                            }
+                        }
+                    }
+                }
+
+                PrimitiveBatch::Paths(paths) => {
+                    let vertex_count: u32 =
+                        paths.iter().map(|p| p.vertices.len() as u32).sum();
+                    if vertex_count > 0 {
+                        pass.set_pipeline(&state.pipelines.paths_pipeline);
+                        pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
+                        pass.set_bind_group(1, &paths_bind_group, &[]);
+                        pass.draw(
+                            paths_vertex_offset..paths_vertex_offset + vertex_count,
+                            0..1,
+                        );
+                        paths_vertex_offset += vertex_count;
+                    }
+                }
+            }
+        }
+    }
+
+    state.context.queue.submit(Some(command_encoder.finish()));
+    state.previous_scene = Some(scene);
+
+    let _ = state.completion_tx.try_send(CompositorCompletion {
+        frame_ready: true,
+    });
+}

--- a/src/platform/cross/compositor.rs
+++ b/src/platform/cross/compositor.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 use wgpu::util::DeviceExt;
 
 use crate::{
-    BackdropFilter, FilterBoundary, PrimitiveBatch, Scene,
+    BackdropFilter, FilterBoundary, MonochromeSprite, PolychromeSprite, PrimitiveBatch,
+    Quad, Scene, Shadow, Underline,
     platform::cross::{
         atlas::WgpuAtlas,
         render_context::WgpuContext,
@@ -48,16 +49,17 @@ struct CompositorState {
     surface_sampler: wgpu::Sampler,
     pipeline_texture: wgpu::Texture,
     pipeline_texture_view: wgpu::TextureView,
+    viewport_width: u32,
+    viewport_height: u32,
     backdrop_blur_texture: wgpu::Texture,
     backdrop_blur_texture_view: wgpu::TextureView,
     backdrop_blur_sampler: wgpu::Sampler,
     group_textures: Vec<wgpu::Texture>,
     group_views: Vec<wgpu::TextureView>,
     rendering_parameters: RenderingParameters,
+    first_frame: bool,
     job_rx: flume::Receiver<CompositorJob>,
     completion_tx: flume::Sender<CompositorCompletion>,
-    previous_scene: Option<Scene>,
-    first_frame: bool,
 }
 
 pub(crate) fn start_compositor(
@@ -143,16 +145,17 @@ pub(crate) fn start_compositor(
         surface_sampler,
         pipeline_texture: pipeline_texture.clone(),
         pipeline_texture_view: pipeline_texture_view.clone(),
+        viewport_width: width,
+        viewport_height: height,
         backdrop_blur_texture,
         backdrop_blur_texture_view,
         backdrop_blur_sampler,
         group_textures,
         group_views,
         rendering_parameters: RenderingParameters::from_env(),
+        first_frame: true,
         job_rx,
         completion_tx,
-        previous_scene: None,
-        first_frame: true,
     };
 
     let join_handle = std::thread::Builder::new()
@@ -253,10 +256,9 @@ fn resize_compositor(state: &mut CompositorState, width: u32, height: u32) {
     state.group_textures = group_textures;
     state.group_views = group_views;
 
-    state.first_frame = true;
 }
 
-fn process_commit(state: &mut CompositorState, scene: Scene) {
+fn process_commit(state: &mut CompositorState, mut scene: Scene) {
     let mut command_encoder =
         state
             .context
@@ -298,121 +300,174 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         .queue
         .write_buffer(&state.context.globals_buffer, 0, bytemuck::bytes_of(&globals));
 
-    if !scene.quads.is_empty() {
-        let data = unsafe { as_bytes(&scene.quads) };
-        crate::platform::cross::render_context::ensure_buffer_size(
-            &state.context.device,
-            &state.context.quads_buffer,
-            data.len() as u64,
-            "Quads Buffer",
-            wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE,
-        );
-        state
-            .context
-            .queue
-            .write_buffer(&state.context.quads_buffer.lock().unwrap(), 0, data);
-    }
-    if !scene.shadows.is_empty() {
-        let data = unsafe { as_bytes(&scene.shadows) };
-        crate::platform::cross::render_context::ensure_buffer_size(
-            &state.context.device,
-            &state.context.shadows_buffer,
-            data.len() as u64,
-            "Shadows Buffer",
-            wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE,
-        );
-        state
-            .context
-            .queue
-            .write_buffer(&state.context.shadows_buffer.lock().unwrap(), 0, data);
-    }
-    if !scene.backdrop_filters.is_empty() {
-        let data = unsafe { as_bytes(&scene.backdrop_filters) };
-        crate::platform::cross::render_context::ensure_buffer_size(
-            &state.context.device,
-            &state.context.backdrop_filters_buffer,
-            data.len() as u64,
-            "Backdrop Filters Buffer",
-            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-        );
-        state.context.queue.write_buffer(
-            &state.context.backdrop_filters_buffer.lock().unwrap(),
-            0,
-            data,
-        );
-    }
-    if !scene.underlines.is_empty() {
-        let data = unsafe { as_bytes(&scene.underlines) };
-        crate::platform::cross::render_context::ensure_buffer_size(
-            &state.context.device,
-            &state.context.underlines_buffer,
-            data.len() as u64,
-            "Underlines Buffer",
-            wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE,
-        );
-        state.context.queue.write_buffer(
-            &state.context.underlines_buffer.lock().unwrap(),
-            0,
-            data,
-        );
-    }
-    if !scene.monochrome_sprites.is_empty() {
-        let data = unsafe { as_bytes(&scene.monochrome_sprites) };
-        crate::platform::cross::render_context::ensure_buffer_size(
-            &state.context.device,
-            &state.context.mono_sprites_buffer,
-            data.len() as u64,
-            "Monosprites Buffer",
-            wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE,
-        );
-        state.context.queue.write_buffer(
-            &state.context.mono_sprites_buffer.lock().unwrap(),
-            0,
-            data,
-        );
-    }
-    if !scene.polychrome_sprites.is_empty() {
-        let data = unsafe { as_bytes(&scene.polychrome_sprites) };
-        crate::platform::cross::render_context::ensure_buffer_size(
-            &state.context.device,
-            &state.context.poly_sprites_buffer,
-            data.len() as u64,
-            "Poly Sprites Buffer",
-            wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::STORAGE,
-        );
-        state.context.queue.write_buffer(
-            &state.context.poly_sprites_buffer.lock().unwrap(),
-            0,
-            data,
-        );
-    }
+    let buffer_usage_storage = wgpu::BufferUsages::VERTEX
+        | wgpu::BufferUsages::COPY_DST
+        | wgpu::BufferUsages::STORAGE;
 
-    let mut flat_path_vertices: Vec<GpuPathVertex> = Vec::new();
-    for path in &scene.paths {
-        let color = path.color.solid;
-        let cm = &path.content_mask.bounds;
-        let cm_origin = [cm.origin.x.0, cm.origin.y.0];
-        let cm_size = [cm.size.width.0, cm.size.height.0];
-        for vertex in &path.vertices {
-            flat_path_vertices.push(GpuPathVertex {
-                xy_position: [vertex.xy_position.x.0, vertex.xy_position.y.0],
-                st_position: [vertex.st_position.x, vertex.st_position.y],
-                hsla: [color.h, color.s, color.l, color.a],
-                content_mask_origin: cm_origin,
-                content_mask_size: cm_size,
-            });
+    // Sparse uploads — only changed slots since last upload
+    // Quads
+    {
+        let elem_size = std::mem::size_of::<Quad>() as u64;
+        if !scene.quads.slots.is_empty() {
+            let total_bytes = scene.quads.slots.len() as u64 * elem_size;
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.quads_buffer,
+                total_bytes,
+                "Quads Buffer",
+                buffer_usage_storage,
+            );
+            let changed = scene.quads.drain_changes_since(scene.last_uploaded_quad_gen);
+            for &slot_idx in &changed {
+                if let Some(quad) = scene.quads.get(slot_idx) {
+                    let ptr = quad as *const Quad as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    state.context.queue.write_buffer(&state.context.quads_buffer.lock().unwrap(), slot_idx as u64 * elem_size, bytes);
+                }
+            }
+            scene.last_uploaded_quad_gen = scene.quads.generation;
         }
     }
+    // Shadows
+    {
+        let elem_size = std::mem::size_of::<Shadow>() as u64;
+        if !scene.shadows.slots.is_empty() {
+            let total_bytes = scene.shadows.slots.len() as u64 * elem_size;
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.shadows_buffer,
+                total_bytes,
+                "Shadows Buffer",
+                buffer_usage_storage,
+            );
+            let changed = scene.shadows.drain_changes_since(scene.last_uploaded_shadow_gen);
+            for &slot_idx in &changed {
+                if let Some(shadow) = scene.shadows.get(slot_idx) {
+                    let ptr = shadow as *const Shadow as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    state.context.queue.write_buffer(&state.context.shadows_buffer.lock().unwrap(), slot_idx as u64 * elem_size, bytes);
+                }
+            }
+            scene.last_uploaded_shadow_gen = scene.shadows.generation;
+        }
+    }
+    // BackdropFilters
+    {
+        let elem_size = std::mem::size_of::<BackdropFilter>() as u64;
+        if !scene.backdrop_filters.slots.is_empty() {
+            let total_bytes = scene.backdrop_filters.slots.len() as u64 * elem_size;
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.backdrop_filters_buffer,
+                total_bytes,
+                "Backdrop Filters Buffer",
+                buffer_usage_storage,
+            );
+            let changed = scene.backdrop_filters.drain_changes_since(scene.last_uploaded_backdrop_filter_gen);
+            for &slot_idx in &changed {
+                if let Some(filter) = scene.backdrop_filters.get(slot_idx) {
+                    let ptr = filter as *const BackdropFilter as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    state.context.queue.write_buffer(&state.context.backdrop_filters_buffer.lock().unwrap(), slot_idx as u64 * elem_size, bytes);
+                }
+            }
+            scene.last_uploaded_backdrop_filter_gen = scene.backdrop_filters.generation;
+        }
+    }
+    // Underlines
+    {
+        let elem_size = std::mem::size_of::<Underline>() as u64;
+        if !scene.underlines.slots.is_empty() {
+            let total_bytes = scene.underlines.slots.len() as u64 * elem_size;
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.underlines_buffer,
+                total_bytes,
+                "Underlines Buffer",
+                buffer_usage_storage,
+            );
+            let changed = scene.underlines.drain_changes_since(scene.last_uploaded_underline_gen);
+            for &slot_idx in &changed {
+                if let Some(underline) = scene.underlines.get(slot_idx) {
+                    let ptr = underline as *const Underline as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    state.context.queue.write_buffer(&state.context.underlines_buffer.lock().unwrap(), slot_idx as u64 * elem_size, bytes);
+                }
+            }
+            scene.last_uploaded_underline_gen = scene.underlines.generation;
+        }
+    }
+    // MonochromeSprites
+    {
+        let elem_size = std::mem::size_of::<MonochromeSprite>() as u64;
+        if !scene.monochrome_sprites.slots.is_empty() {
+            let total_bytes = scene.monochrome_sprites.slots.len() as u64 * elem_size;
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.mono_sprites_buffer,
+                total_bytes,
+                "Monosprites Buffer",
+                buffer_usage_storage,
+            );
+            let changed = scene.monochrome_sprites.drain_changes_since(scene.last_uploaded_mono_sprite_gen);
+            for &slot_idx in &changed {
+                if let Some(sprite) = scene.monochrome_sprites.get(slot_idx) {
+                    let ptr = sprite as *const MonochromeSprite as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    state.context.queue.write_buffer(&state.context.mono_sprites_buffer.lock().unwrap(), slot_idx as u64 * elem_size, bytes);
+                }
+            }
+            scene.last_uploaded_mono_sprite_gen = scene.monochrome_sprites.generation;
+        }
+    }
+    // PolychromeSprites
+    {
+        let elem_size = std::mem::size_of::<PolychromeSprite>() as u64;
+        if !scene.polychrome_sprites.slots.is_empty() {
+            let total_bytes = scene.polychrome_sprites.slots.len() as u64 * elem_size;
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.poly_sprites_buffer,
+                total_bytes,
+                "Poly Sprites Buffer",
+                buffer_usage_storage,
+            );
+            let changed = scene.polychrome_sprites.drain_changes_since(scene.last_uploaded_poly_sprite_gen);
+            for &slot_idx in &changed {
+                if let Some(sprite) = scene.polychrome_sprites.get(slot_idx) {
+                    let ptr = sprite as *const PolychromeSprite as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    state.context.queue.write_buffer(&state.context.poly_sprites_buffer.lock().unwrap(), slot_idx as u64 * elem_size, bytes);
+                }
+            }
+            scene.last_uploaded_poly_sprite_gen = scene.polychrome_sprites.generation;
+        }
+    }
+
+    // Paths — upload all vertex data only if paths changed
+    let flat_path_vertices: Vec<GpuPathVertex> = if scene.pending_delta.paths_changed {
+        let mut vertices = Vec::new();
+        for slot in &scene.paths.slots {
+            let Some(path) = slot.as_ref().map(|s| &s.data) else { continue };
+            let color = path.color.solid;
+            let cm = &path.content_mask.bounds;
+            let cm_origin = [cm.origin.x.0, cm.origin.y.0];
+            let cm_size = [cm.size.width.0, cm.size.height.0];
+            for vertex in &path.vertices {
+                vertices.push(GpuPathVertex {
+                    xy_position: [vertex.xy_position.x.0, vertex.xy_position.y.0],
+                    st_position: [vertex.st_position.x, vertex.st_position.y],
+                    hsla: [color.h, color.s, color.l, color.a],
+                    content_mask_origin: cm_origin,
+                    content_mask_size: cm_size,
+                });
+            }
+        }
+        vertices
+    } else {
+        Vec::new()
+    };
+
     if !flat_path_vertices.is_empty() {
         let data = bytemuck::cast_slice(&flat_path_vertices);
         crate::platform::cross::render_context::ensure_buffer_size(
@@ -429,6 +484,100 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         );
     }
 
+    // Upload indirection buffers
+    {
+        let data = bytemuck::cast_slice(&scene.sorted_quad_indices);
+        if !scene.sorted_quad_indices.is_empty() {
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.quad_indirection_buffer,
+                data.len() as u64,
+                "Quad Indirection Buffer",
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            state.context.queue.write_buffer(&state.context.quad_indirection_buffer.lock().unwrap(), 0, data);
+        }
+    }
+    {
+        let data = bytemuck::cast_slice(&scene.sorted_shadow_indices);
+        if !scene.sorted_shadow_indices.is_empty() {
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.shadow_indirection_buffer,
+                data.len() as u64,
+                "Shadow Indirection Buffer",
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            state.context.queue.write_buffer(&state.context.shadow_indirection_buffer.lock().unwrap(), 0, data);
+        }
+    }
+    {
+        let data = bytemuck::cast_slice(&scene.sorted_backdrop_filter_indices);
+        if !scene.sorted_backdrop_filter_indices.is_empty() {
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.backdrop_filter_indirection_buffer,
+                data.len() as u64,
+                "Backdrop Filter Indirection Buffer",
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            state.context.queue.write_buffer(&state.context.backdrop_filter_indirection_buffer.lock().unwrap(), 0, data);
+        }
+    }
+    {
+        let data = bytemuck::cast_slice(&scene.sorted_underline_indices);
+        if !scene.sorted_underline_indices.is_empty() {
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.underline_indirection_buffer,
+                data.len() as u64,
+                "Underline Indirection Buffer",
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            state.context.queue.write_buffer(&state.context.underline_indirection_buffer.lock().unwrap(), 0, data);
+        }
+    }
+    {
+        let data = bytemuck::cast_slice(&scene.sorted_mono_sprite_indices);
+        if !scene.sorted_mono_sprite_indices.is_empty() {
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.mono_sprite_indirection_buffer,
+                data.len() as u64,
+                "Mono Sprite Indirection Buffer",
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            state.context.queue.write_buffer(&state.context.mono_sprite_indirection_buffer.lock().unwrap(), 0, data);
+        }
+    }
+    {
+        let data = bytemuck::cast_slice(&scene.sorted_poly_sprite_indices);
+        if !scene.sorted_poly_sprite_indices.is_empty() {
+            crate::platform::cross::render_context::ensure_buffer_size(
+                &state.context.device,
+                &state.context.poly_sprite_indirection_buffer,
+                data.len() as u64,
+                "Poly Sprite Indirection Buffer",
+                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            );
+            state.context.queue.write_buffer(&state.context.poly_sprite_indirection_buffer.lock().unwrap(), 0, data);
+        }
+    }
+
+    // Skip the entire render pass if nothing changed
+    if scene.pending_delta.is_empty && !scene.pending_delta.paths_changed {
+        // Still submit the encoder (may contain atlas uploads from before_frame)
+        state.context.queue.submit(Some(command_encoder.finish()));
+        let _ = state.completion_tx.try_send(CompositorCompletion {
+            frame_ready: true,
+        });
+        return;
+    }
+
+    let has_damage_rect = scene.pending_delta.damage_rect.is_some();
+
+    {
+    // Lock all GPU buffers and create bind groups
     let quads_buffer_ref = state.context.quads_buffer.lock().unwrap();
     let shadows_buffer_ref = state.context.shadows_buffer.lock().unwrap();
     let backdrop_filters_buffer_ref = state.context.backdrop_filters_buffer.lock().unwrap();
@@ -436,6 +585,12 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
     let mono_sprites_buffer_ref = state.context.mono_sprites_buffer.lock().unwrap();
     let poly_sprites_buffer_ref = state.context.poly_sprites_buffer.lock().unwrap();
     let paths_vertices_buffer_ref = state.context.paths_vertices_buffer.lock().unwrap();
+    let quad_indirection_buffer_ref = state.context.quad_indirection_buffer.lock().unwrap();
+    let shadow_indirection_buffer_ref = state.context.shadow_indirection_buffer.lock().unwrap();
+    let backdrop_filter_indirection_buffer_ref = state.context.backdrop_filter_indirection_buffer.lock().unwrap();
+    let underline_indirection_buffer_ref = state.context.underline_indirection_buffer.lock().unwrap();
+    let mono_sprite_indirection_buffer_ref = state.context.mono_sprite_indirection_buffer.lock().unwrap();
+    let poly_sprite_indirection_buffer_ref = state.context.poly_sprite_indirection_buffer.lock().unwrap();
 
     let quads_bind_group = state
         .context
@@ -443,14 +598,24 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         .create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("compositor_quads_bind_group"),
             layout: &state.pipelines.quads_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &quads_buffer_ref,
-                    offset: 0,
-                    size: None,
-                }),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &quads_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &quad_indirection_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+            ],
         });
 
     let shadows_bind_group = state
@@ -459,14 +624,24 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         .create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("compositor_shadows_bind_group"),
             layout: &state.pipelines.shadows_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &shadows_buffer_ref,
-                    offset: 0,
-                    size: None,
-                }),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &shadows_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &shadow_indirection_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+            ],
         });
 
     let backdrop_filters_bind_group =
@@ -476,14 +651,24 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("compositor_backdrop_filters_bind_group"),
                 layout: &state.pipelines.backdrop_filters_bind_group_layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &backdrop_filters_buffer_ref,
-                        offset: 0,
-                        size: None,
-                    }),
-                }],
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &backdrop_filters_buffer_ref,
+                            offset: 0,
+                            size: None,
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &backdrop_filter_indirection_buffer_ref,
+                            offset: 0,
+                            size: None,
+                        }),
+                    },
+                ],
             });
 
     let backdrop_texture_bind_group =
@@ -513,14 +698,24 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         .create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("compositor_underlines_bind_group"),
             layout: &state.pipelines.underlines_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &underlines_buffer_ref,
-                    offset: 0,
-                    size: None,
-                }),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &underlines_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &underline_indirection_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+            ],
         });
 
     let mono_sprites_bind_group = state
@@ -529,14 +724,24 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         .create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("compositor_mono_sprites_bind_group"),
             layout: &state.pipelines.mono_sprites_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &mono_sprites_buffer_ref,
-                    offset: 0,
-                    size: None,
-                }),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &mono_sprites_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &mono_sprite_indirection_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+            ],
         });
 
     let poly_sprites_bind_group = state
@@ -545,14 +750,24 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
         .create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("compositor_poly_sprites_bind_group"),
             layout: &state.pipelines.poly_sprites_bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &poly_sprites_buffer_ref,
-                    offset: 0,
-                    size: None,
-                }),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &poly_sprites_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &poly_sprite_indirection_buffer_ref,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+            ],
         });
 
     let paths_bind_group = state
@@ -571,22 +786,23 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
             }],
         });
 
-    {
-        let load_op = if state.first_frame {
-            wgpu::LoadOp::Clear(wgpu::Color::BLACK)
-        } else {
-            wgpu::LoadOp::Load
-        };
+    let load_op = if state.first_frame {
         state.first_frame = false;
+        wgpu::LoadOp::Clear(wgpu::Color::BLACK)
+    } else if has_damage_rect {
+        wgpu::LoadOp::Load
+    } else {
+        wgpu::LoadOp::Clear(wgpu::Color::BLACK)
+    };
 
-        let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("compositor_main"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &state.pipeline_texture_view,
-                ops: wgpu::Operations {
-                    load: load_op,
-                    store: wgpu::StoreOp::Store,
-                },
+    let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("compositor_main"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: &state.pipeline_texture_view,
+            ops: wgpu::Operations {
+                load: load_op,
+                store: wgpu::StoreOp::Store,
+            },
                 resolve_target: None,
                 depth_slice: None,
             })],
@@ -595,6 +811,18 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
             occlusion_query_set: None,
             multiview_mask: None,
         });
+
+    if let Some(damage) = &scene.pending_delta.damage_rect {
+        let vp_w = state.viewport_width;
+        let vp_h = state.viewport_height;
+        let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
+        let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
+        let max_w = vp_w.saturating_sub(x);
+        let max_h = vp_h.saturating_sub(y);
+        let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
+        let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
+        pass.set_scissor_rect(x, y, w, h);
+    }
 
         let mut quads_first_instance: u32 = 0;
         let mut shadows_first_instance: u32 = 0;
@@ -619,9 +847,9 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
 
                 PrimitiveBatch::MonochromeSprites {
                     texture_id,
-                    sprites,
+                    indices,
                 } => {
-                    let count = sprites.len() as u32;
+                    let count = indices.len() as u32;
                     let tex_info = state.atlas.get_texture_info(texture_id);
 
                     let sprites_texture_bind_group =
@@ -661,9 +889,9 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
 
                 PrimitiveBatch::PolychromeSprites {
                     texture_id,
-                    sprites,
+                    indices,
                 } => {
-                    let count = sprites.len() as u32;
+                    let count = indices.len() as u32;
                     let tex_info = state.atlas.get_texture_info(texture_id);
 
                     let sprites_texture_bind_group =
@@ -736,6 +964,18 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
                         occlusion_query_set: None,
                         multiview_mask: None,
                     });
+
+                    if let Some(damage) = &scene.pending_delta.damage_rect {
+                        let vp_w = state.viewport_width;
+                        let vp_h = state.viewport_height;
+                        let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
+                        let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
+                        let max_w = vp_w.saturating_sub(x);
+                        let max_h = vp_h.saturating_sub(y);
+                        let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
+                        let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
+                        pass.set_scissor_rect(x, y, w, h);
+                    }
 
                     pass.set_pipeline(&state.pipelines.backdrop_filters_pipeline);
                     pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
@@ -817,6 +1057,18 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
                             multiview_mask: None,
                         });
 
+                        if let Some(damage) = &scene.pending_delta.damage_rect {
+                            let vp_w = state.viewport_width;
+                            let vp_h = state.viewport_height;
+                            let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
+                            let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
+                            let max_w = vp_w.saturating_sub(x);
+                            let max_h = vp_h.saturating_sub(y);
+                            let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
+                            let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
+                            pass.set_scissor_rect(x, y, w, h);
+                        }
+
                         let composite = BackdropFilter {
                             order: 0,
                             bounds: start_boundary.bounds,
@@ -833,20 +1085,39 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
                                 usage: wgpu::BufferUsages::STORAGE,
                             },
                         );
+                        let composite_indirection_buffer = state.context.device.create_buffer_init(
+                            &wgpu::util::BufferInitDescriptor {
+                                label: Some("compositor_filter_group_composite_indirection_buffer"),
+                                contents: bytemuck::cast_slice(&[0u32]),
+                                usage: wgpu::BufferUsages::STORAGE,
+                            },
+                        );
                         let composite_bind_group = state.context.device.create_bind_group(
                             &wgpu::BindGroupDescriptor {
                                 label: Some("compositor_filter_group_composite_bind_group"),
                                 layout: &state.pipelines.backdrop_filters_bind_group_layout,
-                                entries: &[wgpu::BindGroupEntry {
-                                    binding: 0,
-                                    resource: wgpu::BindingResource::Buffer(
-                                        wgpu::BufferBinding {
-                                            buffer: &composite_buffer,
-                                            offset: 0,
-                                            size: None,
-                                        },
-                                    ),
-                                }],
+                                entries: &[
+                                    wgpu::BindGroupEntry {
+                                        binding: 0,
+                                        resource: wgpu::BindingResource::Buffer(
+                                            wgpu::BufferBinding {
+                                                buffer: &composite_buffer,
+                                                offset: 0,
+                                                size: None,
+                                            },
+                                        ),
+                                    },
+                                    wgpu::BindGroupEntry {
+                                        binding: 1,
+                                        resource: wgpu::BindingResource::Buffer(
+                                            wgpu::BufferBinding {
+                                                buffer: &composite_indirection_buffer,
+                                                offset: 0,
+                                                size: None,
+                                            },
+                                        ),
+                                    },
+                                ],
                             },
                         );
                         let composite_texture_bind_group = state.context.device.create_bind_group(
@@ -890,8 +1161,9 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
                     underlines_first_instance += count;
                 }
 
-                PrimitiveBatch::Surfaces(surfaces) => {
-                    for surface in surfaces {
+                PrimitiveBatch::Surfaces(indices) => {
+                    for &slot in indices {
+                        let Some(surface) = scene.surfaces.get(slot as usize) else { continue };
                         if let crate::SurfaceContent::Wgpu(surface_id) = &surface.content {
                             let _swapped = state
                                 .context
@@ -982,9 +1254,9 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
                     }
                 }
 
-                PrimitiveBatch::Paths(paths) => {
+                PrimitiveBatch::Paths(indices) => {
                     let vertex_count: u32 =
-                        paths.iter().map(|p| p.vertices.len() as u32).sum();
+                        indices.iter().filter_map(|&slot| scene.paths.get(slot as usize)).map(|p| p.vertices.len() as u32).sum();
                     if vertex_count > 0 {
                         pass.set_pipeline(&state.pipelines.paths_pipeline);
                         pass.set_bind_group(0, &state.pipelines.globals_bind_group, &[]);
@@ -1001,7 +1273,6 @@ fn process_commit(state: &mut CompositorState, scene: Scene) {
     }
 
     state.context.queue.submit(Some(command_encoder.finish()));
-    state.previous_scene = Some(scene);
 
     let _ = state.completion_tx.try_send(CompositorCompletion {
         frame_ready: true,

--- a/src/platform/cross/compositor.rs
+++ b/src/platform/cross/compositor.rs
@@ -1368,6 +1368,20 @@ fn process_commit(state: &mut CompositorState, mut scene: Scene) {
         }
     }
 
+    // Extend the rendered area to include the viewport we just rendered.
+    {
+        let os = state.overscroll_state.lock().unwrap();
+        let render_origin = os.content_origin;
+        let render_size = crate::geometry::size(os.viewport_width, os.viewport_height);
+        drop(os);
+        state.overscroll_state.lock().unwrap().extend_rendered_area(
+            crate::geometry::Bounds {
+                origin: render_origin,
+                size: render_size,
+            },
+        );
+    }
+
     state.context.queue.submit(Some(command_encoder.finish()));
 
     let _ = state.completion_tx.try_send(CompositorCompletion {

--- a/src/platform/cross/render_context.rs
+++ b/src/platform/cross/render_context.rs
@@ -34,6 +34,14 @@ pub struct WgpuContext {
     pub(super) color_adjustments_buffer: wgpu::Buffer,
     pub(super) paths_vertices_buffer: Mutex<wgpu::Buffer>,
 
+    // Indirection buffers (mapping draw-order position → generational-vec slot)
+    pub(super) quad_indirection_buffer: Mutex<wgpu::Buffer>,
+    pub(super) shadow_indirection_buffer: Mutex<wgpu::Buffer>,
+    pub(super) backdrop_filter_indirection_buffer: Mutex<wgpu::Buffer>,
+    pub(super) underline_indirection_buffer: Mutex<wgpu::Buffer>,
+    pub(super) mono_sprite_indirection_buffer: Mutex<wgpu::Buffer>,
+    pub(super) poly_sprite_indirection_buffer: Mutex<wgpu::Buffer>,
+
     pub(crate) surface_registry: Arc<SurfaceRegistry>,
 }
 
@@ -187,6 +195,47 @@ impl WgpuContext {
             mapped_at_creation: false,
         });
 
+        // Indirection buffers (64 KB = 16384 u32 entries, enough for typical scenes)
+        let indirection_buffer_size = 64 * 1024;
+        let indirection_usage = wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST;
+
+        let quad_indirection_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Quad Indirection Buffer"),
+            size: indirection_buffer_size,
+            usage: indirection_usage,
+            mapped_at_creation: false,
+        });
+        let shadow_indirection_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Shadow Indirection Buffer"),
+            size: indirection_buffer_size,
+            usage: indirection_usage,
+            mapped_at_creation: false,
+        });
+        let backdrop_filter_indirection_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Backdrop Filter Indirection Buffer"),
+            size: indirection_buffer_size,
+            usage: indirection_usage,
+            mapped_at_creation: false,
+        });
+        let underline_indirection_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Underline Indirection Buffer"),
+            size: indirection_buffer_size,
+            usage: indirection_usage,
+            mapped_at_creation: false,
+        });
+        let mono_sprite_indirection_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Mono Sprite Indirection Buffer"),
+            size: indirection_buffer_size,
+            usage: indirection_usage,
+            mapped_at_creation: false,
+        });
+        let poly_sprite_indirection_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Poly Sprite Indirection Buffer"),
+            size: indirection_buffer_size,
+            usage: indirection_usage,
+            mapped_at_creation: false,
+        });
+
         Ok(Self {
             adapter,
             device,
@@ -203,6 +252,14 @@ impl WgpuContext {
             color_adjustments_buffer,
 
             paths_vertices_buffer: Mutex::new(paths_vertices_buffer),
+
+            quad_indirection_buffer: Mutex::new(quad_indirection_buffer),
+            shadow_indirection_buffer: Mutex::new(shadow_indirection_buffer),
+            backdrop_filter_indirection_buffer: Mutex::new(backdrop_filter_indirection_buffer),
+            underline_indirection_buffer: Mutex::new(underline_indirection_buffer),
+            mono_sprite_indirection_buffer: Mutex::new(mono_sprite_indirection_buffer),
+            poly_sprite_indirection_buffer: Mutex::new(poly_sprite_indirection_buffer),
+
             surface_registry: Arc::new(SurfaceRegistry::new()),
         })
     }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -285,6 +285,144 @@ impl geometry::Edges<ScaledPixels> {
     ];
 }
 
+/// Per-frame blit parameters for the overscroll-aware blit shader.
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub(crate) struct BlitParamsRaw {
+    uv_origin: [f32; 2],
+    uv_size: [f32; 2],
+}
+
+/// Tracks the content position within an overscroll buffer for efficient
+/// scrolling without re-rendering.
+#[derive(Clone, Debug)]
+pub struct OverscrollState {
+    pub content_origin: crate::geometry::Point<f32>,
+    pub rendered_area: crate::geometry::Bounds<f32>,
+    pub overscroll_factor: f32,
+    pub viewport_width: f32,
+    pub viewport_height: f32,
+}
+
+impl OverscrollState {
+    pub fn new(viewport_w: f32, viewport_h: f32, factor: f32) -> Self {
+        let buffer_w = viewport_w * factor;
+        let buffer_h = viewport_h * factor;
+        Self {
+            content_origin: crate::geometry::point(
+                (buffer_w - viewport_w) / 2.0,
+                (buffer_h - viewport_h) / 2.0,
+            ),
+            rendered_area: crate::geometry::Bounds {
+                origin: crate::geometry::point(0.0, 0.0),
+                size: crate::geometry::size(buffer_w, buffer_h),
+            },
+            overscroll_factor: factor,
+            viewport_width: viewport_w,
+            viewport_height: viewport_h,
+        }
+    }
+
+    /// Compute UV origin/size for the blit, given current content_origin
+    pub fn compute_blit_uvs(&self) -> ([f32; 2], [f32; 2]) {
+        let buffer_w = self.viewport_width * self.overscroll_factor;
+        let buffer_h = self.viewport_height * self.overscroll_factor;
+        let uv_origin = [
+            self.content_origin.x / buffer_w,
+            self.content_origin.y / buffer_h,
+        ];
+        let uv_size = [
+            self.viewport_width / buffer_w,
+            self.viewport_height / buffer_h,
+        ];
+        (uv_origin, uv_size)
+    }
+
+    /// Check if a given viewport rect (in content coords) is within the rendered area
+    pub fn covers(&self, viewport_origin: crate::geometry::Point<f32>) -> bool {
+        let vp_bounds = crate::geometry::Bounds {
+            origin: viewport_origin,
+            size: crate::geometry::size(self.viewport_width, self.viewport_height),
+        };
+        vp_bounds.is_contained_within(&self.rendered_area)
+    }
+
+    /// Check if the content origin is approaching the edge of the buffer
+    pub fn nearly_exceeded(&self, margin: f32) -> Option<crate::geometry::Bounds<f32>> {
+        let margin_px = margin * self.viewport_width.min(self.viewport_height);
+        let vp_right = self.content_origin.x + self.viewport_width;
+        let vp_bottom = self.content_origin.y + self.viewport_height;
+        let ra_right = self.rendered_area.origin.x + self.rendered_area.size.width;
+        let ra_bottom = self.rendered_area.origin.y + self.rendered_area.size.height;
+
+        if vp_right > ra_right - margin_px {
+            return Some(crate::geometry::Bounds {
+                origin: crate::geometry::point(ra_right, self.content_origin.y),
+                size: crate::geometry::size(self.viewport_width * 0.5, self.viewport_height),
+            });
+        }
+        if self.content_origin.x < self.rendered_area.origin.x + margin_px {
+            return Some(crate::geometry::Bounds {
+                origin: crate::geometry::point(
+                    self.content_origin.x - self.viewport_width * 0.5,
+                    self.content_origin.y,
+                ),
+                size: crate::geometry::size(self.viewport_width * 0.5, self.viewport_height),
+            });
+        }
+        if vp_bottom > ra_bottom - margin_px {
+            return Some(crate::geometry::Bounds {
+                origin: crate::geometry::point(self.content_origin.x, ra_bottom),
+                size: crate::geometry::size(self.viewport_width, self.viewport_height * 0.5),
+            });
+        }
+        if self.content_origin.y < self.rendered_area.origin.y + margin_px {
+            return Some(crate::geometry::Bounds {
+                origin: crate::geometry::point(
+                    self.content_origin.x,
+                    self.content_origin.y - self.viewport_height * 0.5,
+                ),
+                size: crate::geometry::size(self.viewport_width, self.viewport_height * 0.5),
+            });
+        }
+        None
+    }
+
+    /// Re-center: shift content_origin to the center of the buffer
+    pub fn recenter_needed(&self) -> bool {
+        let buffer_w = self.viewport_width * self.overscroll_factor;
+        let buffer_h = self.viewport_height * self.overscroll_factor;
+        let center_x = (buffer_w - self.viewport_width) / 2.0;
+        let center_y = (buffer_h - self.viewport_height) / 2.0;
+        let drift = (self.content_origin.x - center_x)
+            .abs()
+            .max((self.content_origin.y - center_y).abs());
+        drift > (buffer_w * 0.25)
+    }
+
+    /// Record a scroll delta (moves content_origin, no rendering needed)
+    pub fn scroll(&mut self, delta_x: f32, delta_y: f32) {
+        self.content_origin.x -= delta_x;
+        self.content_origin.y -= delta_y;
+    }
+
+    /// Extend the rendered area to include new bounds
+    pub fn extend_rendered_area(&mut self, new_bounds: crate::geometry::Bounds<f32>) {
+        self.rendered_area = self.rendered_area.union(&new_bounds);
+    }
+
+    /// Re-center the content within the buffer for GPU copy
+    pub fn recenter(&mut self, new_origin: crate::geometry::Point<f32>) {
+        self.content_origin = new_origin;
+        let buffer_w = self.viewport_width * self.overscroll_factor;
+        let buffer_h = self.viewport_height * self.overscroll_factor;
+        self.rendered_area = crate::geometry::Bounds {
+            origin: crate::geometry::point(0.0, 0.0),
+            size: crate::geometry::size(buffer_w, buffer_h),
+        };
+    }
+}
+
 impl Bounds {
     const VERTEX_ATTRIBUTES: &'static [wgpu::VertexAttribute; 2] = &[
         wgpu::VertexAttribute {
@@ -1562,6 +1700,7 @@ pub struct WgpuRenderer {
     blit_pipeline: wgpu::RenderPipeline,
     blit_bind_group_layout: wgpu::BindGroupLayout,
     blit_sampler: wgpu::Sampler,
+    blit_params_buffer: wgpu::Buffer,
 
     // Pipeline texture: offscreen render target (both sync and compositor modes)
     pipeline_texture: wgpu::Texture,
@@ -1732,6 +1871,16 @@ impl WgpuRenderer {
                             ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                             count: None,
                         },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 2,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
                     ],
                 });
 
@@ -1780,6 +1929,13 @@ impl WgpuRenderer {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
             ..Default::default()
+        });
+
+        let blit_params_buffer = context.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("blit_params_buffer"),
+            size: std::mem::size_of::<BlitParamsRaw>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
         });
 
         // ----- Pipeline texture (offscreen render target) -----------------------
@@ -1872,6 +2028,7 @@ impl WgpuRenderer {
             blit_pipeline,
             blit_bind_group_layout,
             blit_sampler,
+            blit_params_buffer,
             pipeline_texture,
             pipeline_texture_view,
             mode,
@@ -2924,12 +3081,33 @@ impl WgpuRenderer {
         log::debug!("Renderer::draw_sync: complete");
     }
 
-    /// Blit the pipeline_texture to the swapchain and present.
+    /// Blit the pipeline_texture to the swapchain and present (full-texture UVs).
     fn blit_to_swapchain(&self) {
+        self.blit_to_swapchain_inner([0.0, 0.0], [1.0, 1.0]);
+    }
+
+    /// Blit the pipeline_texture to the swapchain with given UV offset/size.
+    fn blit_to_swapchain_with_uvs(&self, uv_origin: [f32; 2], uv_size: [f32; 2]) {
+        self.blit_to_swapchain_inner(uv_origin, uv_size);
+    }
+
+    fn blit_to_swapchain_inner(&self, uv_origin: [f32; 2], uv_size: [f32; 2]) {
         let surface_texture = match self.acquire_swapchain() {
             Some(t) => t,
             None => return,
         };
+
+        // In compositor mode, read from the compositor's pipeline texture.
+        // In synchronous mode, read from the local pipeline texture.
+        let pipeline_view = match &self.mode {
+            WgpuRendererMode::Synchronous => &self.pipeline_texture_view,
+            WgpuRendererMode::Compositor(handle) => &handle.pipeline_texture_view,
+        };
+
+        let params = BlitParamsRaw { uv_origin, uv_size };
+        self.context
+            .queue
+            .write_buffer(&self.blit_params_buffer, 0, bytemuck::bytes_of(&params));
 
         let mut encoder =
             self.context
@@ -2950,11 +3128,19 @@ impl WgpuRenderer {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::TextureView(&self.pipeline_texture_view),
+                        resource: wgpu::BindingResource::TextureView(pipeline_view),
                     },
                     wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::Sampler(&self.blit_sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &self.blit_params_buffer,
+                            offset: 0,
+                            size: None,
+                        }),
                     },
                 ],
             });
@@ -3039,13 +3225,72 @@ impl WgpuRenderer {
         match &self.mode {
             WgpuRendererMode::Synchronous => false,
             WgpuRendererMode::Compositor(handle) => {
-                match handle.completion_rx.try_recv() {
-                    Ok(_completion) => {
-                        self.blit_to_swapchain();
-                        true
+                if let Ok(_completion) = handle.completion_rx.try_recv() {
+                    // Three-case overscroll model:
+                    // 1. Viewport within rendered area → blit with UV offset (no re-render)
+                    // 2. Near edge → send ExtendTiles, still blit current
+                    // 3. Otherwise → fall through to full blit
+
+                    let (uv_origin, uv_size, _covers, extend) = {
+                        let os = handle.overscroll_state.lock().unwrap();
+                        let vp_origin = crate::geometry::point(
+                            os.content_origin.x,
+                            os.content_origin.y,
+                        );
+                        let covers = os.covers(vp_origin);
+                        let uvs = if covers {
+                            Some(os.compute_blit_uvs())
+                        } else {
+                            None
+                        };
+                        let extend = if !covers {
+                            os.nearly_exceeded(0.1)
+                        } else {
+                            None
+                        };
+                        (uvs.map(|(u, _)| u), uvs.map(|(_, s)| s), covers, extend)
+                    };
+
+                    if let (Some(uv_origin), Some(uv_size)) = (uv_origin, uv_size) {
+                        // Case 1: viewport within rendered area
+                        self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
+                        return true;
                     }
-                    Err(_) => false,
+
+                    if let Some(extend_rect) = extend {
+                        // Case 2: near edge → request tile extension
+                        let _ = handle
+                            .job_tx
+                            .try_send(CompositorJob::ExtendTiles { rect: extend_rect });
+                        let (uv_origin, uv_size) = {
+                            let os = handle.overscroll_state.lock().unwrap();
+                            os.compute_blit_uvs()
+                        };
+                        self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
+                        return true;
+                    }
+
+                    // Case 3: fall through to full blit (will trigger a commit)
+                    self.blit_to_swapchain();
+                    true
+                } else {
+                    false
                 }
+            }
+        }
+    }
+
+    /// Record a scroll delta without triggering a full re-render.
+    /// In compositor mode this sends a Scroll job to the compositor thread.
+    pub fn record_scroll(&self, delta: crate::geometry::Point<f32>) {
+        match &self.mode {
+            WgpuRendererMode::Synchronous => {
+                // In synchronous mode, no overscroll optimization yet
+            }
+            WgpuRendererMode::Compositor(handle) => {
+                let _ = handle
+                    .job_tx
+                    .try_send(CompositorJob::Scroll(delta));
             }
         }
     }
@@ -3247,7 +3492,18 @@ impl WgpuRenderer {
     /// Used in compositor mode when no new frame is ready but we still
     /// need to refresh the display (e.g. cursor blink).
     pub fn present_framebuffer_only(&self) {
-        self.blit_to_swapchain();
+        match &self.mode {
+            WgpuRendererMode::Synchronous => {
+                self.blit_to_swapchain();
+            }
+            WgpuRendererMode::Compositor(handle) => {
+                let (uv_origin, uv_size) = {
+                    let os = handle.overscroll_state.lock().unwrap();
+                    os.compute_blit_uvs()
+                };
+                self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
+            }
+        }
     }
 
     pub fn update_drawable_size(&mut self, size: geometry::Size<DevicePixels>) {

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -10,6 +10,7 @@ use crate::{
     ScaledPixels, Scene, TransformationMatrix, color, geometry,
     platform::cross::{
         atlas::WgpuAtlas,
+        compositor::{CompositorCompletion, CompositorJob, start_compositor, CompositorHandle},
         render_context::{WgpuContext, ensure_buffer_size},
         surface_registry::SurfaceId,
     },
@@ -193,10 +194,10 @@ impl color::TextColor {
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-struct GlobalParams {
-    viewport_size: [f32; 2],
-    premultimated_alpha: u32,
-    pad: u32,
+pub(crate) struct GlobalParams {
+    pub(crate) viewport_size: [f32; 2],
+    pub(crate) premultimated_alpha: u32,
+    pub(crate) pad: u32,
 }
 
 impl GlobalParams {
@@ -221,9 +222,9 @@ impl GlobalParams {
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-struct Bounds {
-    origin: [f32; 2],
-    size: [f32; 2],
+pub(crate) struct Bounds {
+    pub(crate) origin: [f32; 2],
+    pub(crate) size: [f32; 2],
 }
 
 impl geometry::Corners<ScaledPixels> {
@@ -300,9 +301,9 @@ impl Bounds {
 
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-struct SurfaceParams {
-    bounds: Bounds,
-    content_mask: Bounds,
+pub(crate) struct SurfaceParams {
+    pub(crate) bounds: Bounds,
+    pub(crate) content_mask: Bounds,
 }
 
 impl Quad {
@@ -403,12 +404,12 @@ struct PathsData {
 /// Layout must exactly match the `GpuPathVertex` struct in `paths.wgsl`.
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-struct GpuPathVertex {
-    xy_position: [f32; 2],         // offset  0
-    st_position: [f32; 2],         // offset  8
-    hsla: [f32; 4],                // offset 16  (h, s, l, a)
-    content_mask_origin: [f32; 2], // offset 32
-    content_mask_size: [f32; 2],   // offset 40
+pub(crate) struct GpuPathVertex {
+    pub(crate) xy_position: [f32; 2],         // offset  0
+    pub(crate) st_position: [f32; 2],         // offset  8
+    pub(crate) hsla: [f32; 4],                // offset 16  (h, s, l, a)
+    pub(crate) content_mask_origin: [f32; 2], // offset 32
+    pub(crate) content_mask_size: [f32; 2],   // offset 40
 } // stride  48
 
 struct UnderlinesData {
@@ -657,43 +658,44 @@ impl MonochromeSprite {
 
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-struct ColorAdjustments {
-    gamma_ratios: [f32; 4],
-    grayscale_enhanced_contrast: f32,
-    _padding: [f32; 3],
+pub(crate) struct ColorAdjustments {
+    pub(crate) gamma_ratios: [f32; 4],
+    pub(crate) grayscale_enhanced_contrast: f32,
+    pub(crate) _padding: [f32; 3],
 }
 
-struct WgpuPipelines {
-    color_targets: Vec<Option<wgpu::ColorTargetState>>,
+pub(crate) struct WgpuPipelines {
+    pub(crate) color_targets: Vec<Option<wgpu::ColorTargetState>>,
 
-    quads_bind_group_layout: wgpu::BindGroupLayout,
-    shadows_bind_group_layout: wgpu::BindGroupLayout,
-    backdrop_filters_bind_group_layout: wgpu::BindGroupLayout,
-    backdrop_texture_bind_group_layout: wgpu::BindGroupLayout,
-    underlines_bind_group_layout: wgpu::BindGroupLayout,
-    sprites_bind_group_layout: wgpu::BindGroupLayout,
-    mono_sprites_bind_group_layout: wgpu::BindGroupLayout,
-    poly_sprites_bind_group_layout: wgpu::BindGroupLayout,
-    surfaces_bind_group_layout: wgpu::BindGroupLayout,
-    paths_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) quads_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) shadows_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) backdrop_filters_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) backdrop_texture_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) underlines_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) sprites_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) mono_sprites_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) poly_sprites_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) surfaces_bind_group_layout: wgpu::BindGroupLayout,
+    pub(crate) paths_bind_group_layout: wgpu::BindGroupLayout,
 
-    globals_bind_group: wgpu::BindGroup,
-    color_adjustments_bind_group: wgpu::BindGroup,
+    pub(crate) globals_bind_group: wgpu::BindGroup,
+    pub(crate) color_adjustments_bind_group: wgpu::BindGroup,
 
-    quads_pipeline: wgpu::RenderPipeline,
-    shadows_pipeline: wgpu::RenderPipeline,
-    backdrop_filters_pipeline: wgpu::RenderPipeline,
-    underlines_pipeline: wgpu::RenderPipeline,
-    mono_sprites_pipeline: wgpu::RenderPipeline,
-    poly_sprites_pipeline: wgpu::RenderPipeline,
-    surfaces_pipeline: wgpu::RenderPipeline,
-    paths_pipeline: wgpu::RenderPipeline,
+    pub(crate) quads_pipeline: wgpu::RenderPipeline,
+    pub(crate) shadows_pipeline: wgpu::RenderPipeline,
+    pub(crate) backdrop_filters_pipeline: wgpu::RenderPipeline,
+    pub(crate) underlines_pipeline: wgpu::RenderPipeline,
+    pub(crate) mono_sprites_pipeline: wgpu::RenderPipeline,
+    pub(crate) poly_sprites_pipeline: wgpu::RenderPipeline,
+    pub(crate) surfaces_pipeline: wgpu::RenderPipeline,
+    pub(crate) paths_pipeline: wgpu::RenderPipeline,
 }
 
 impl WgpuPipelines {
-    pub fn new(
+    pub(crate) fn new(
         context: &WgpuContext,
-        surface_configuration: &wgpu::SurfaceConfiguration,
+        format: wgpu::TextureFormat,
+        alpha_mode: wgpu::CompositeAlphaMode,
         _path_sample_count: u32,
     ) -> Self {
         let quads_shader = context
@@ -747,7 +749,7 @@ impl WgpuPipelines {
                     ),
                 });
 
-        let blend_mode = match surface_configuration.alpha_mode {
+        let blend_mode = match alpha_mode {
             wgpu::CompositeAlphaMode::PreMultiplied => {
                 wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING
             }
@@ -755,7 +757,7 @@ impl WgpuPipelines {
         };
 
         let color_targets = &[Some(wgpu::ColorTargetState {
-            format: surface_configuration.format,
+            format,
             blend: Some(blend_mode),
             write_mask: wgpu::ColorWrites::ALL,
         })];
@@ -1382,14 +1384,14 @@ impl WgpuPipelines {
     }
 }
 
-struct RenderingParameters {
-    path_sample_count: u32,
-    gamma_ratios: [f32; 4],
-    grayscale_enhanced_contrast: f32,
+pub(crate) struct RenderingParameters {
+    pub(crate) path_sample_count: u32,
+    pub(crate) gamma_ratios: [f32; 4],
+    pub(crate) grayscale_enhanced_contrast: f32,
 }
 
 impl RenderingParameters {
-    fn from_env() -> Self {
+    pub(crate) fn from_env() -> Self {
         use std::env;
 
         let path_sample_count = env::var("ZED_PATH_SAMPLE_COUNT")
@@ -1418,7 +1420,7 @@ impl RenderingParameters {
 
 /// Cached bounds information for fast surface blitting
 #[derive(Clone, Debug)]
-struct SurfaceBoundsEntry {
+pub(crate) struct SurfaceBoundsEntry {
     /// Screen-space bounds where the surface should be rendered
     screen_bounds: geometry::Bounds<Pixels>,
     /// Content mask for clipping
@@ -1430,11 +1432,11 @@ struct SurfaceBoundsEntry {
 /// Maximum nesting depth supported for CSS-style content `filter` groups
 /// (`with_filter_layer`). Groups nested deeper than this are painted inline,
 /// unisolated and unblurred, rather than allocating unbounded offscreen textures.
-const MAX_FILTER_DEPTH: usize = 4;
+pub(crate) const MAX_FILTER_DEPTH: usize = 4;
 
 /// Allocates the pool of full-surface-sized offscreen textures that
 /// content-filter groups render into, one per supported nesting depth.
-fn create_filter_group_textures(
+pub(crate) fn create_filter_group_textures(
     device: &wgpu::Device,
     width: u32,
     height: u32,
@@ -1463,6 +1465,16 @@ fn create_filter_group_textures(
         .unzip()
 }
 
+/// Operating mode for the renderer — synchronous (immediate) vs. compositor (off-thread).
+pub(crate) enum WgpuRendererMode {
+    /// Render directly to pipeline_texture, then blit to swapchain synchronously
+    /// (the current behaviour). Always available; the fallback path.
+    Synchronous,
+    /// Delegate scene rendering to a dedicated compositor thread.
+    /// The main thread only blits the compositor's output to the swapchain.
+    Compositor(CompositorHandle),
+}
+
 pub struct WgpuRenderer {
     context: Arc<WgpuContext>,
     surface: ManuallyDrop<wgpu::Surface<'static>>,
@@ -1472,6 +1484,18 @@ pub struct WgpuRenderer {
     atlas: Arc<WgpuAtlas>,
     pipelines: WgpuPipelines,
     rendering_parameters: RenderingParameters,
+
+    // Blit pipeline: copies pipeline_texture → swapchain
+    blit_pipeline: wgpu::RenderPipeline,
+    blit_bind_group_layout: wgpu::BindGroupLayout,
+    blit_sampler: wgpu::Sampler,
+
+    // Pipeline texture: offscreen render target (both sync and compositor modes)
+    pipeline_texture: wgpu::Texture,
+    pipeline_texture_view: wgpu::TextureView,
+
+    // Current renderer mode
+    mode: WgpuRendererMode,
 
     // cache bind groups for each double-buffered surface (index 0/1)
     surface_bind_groups:
@@ -1599,7 +1623,106 @@ impl WgpuRenderer {
         });
 
         let pipelines =
-            WgpuPipelines::new(context.as_ref(), &surface_configuration, path_sample_count);
+            WgpuPipelines::new(context.as_ref(), format, alpha_mode, path_sample_count);
+
+        // ----- Blit pipeline (pipeline_texture → swapchain) --------------------
+        let blit_shader = context
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("blit_shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("shaders/blit.wgsl").into()),
+            });
+
+        let blit_bind_group_layout =
+            context
+                .device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("blit_bind_group_layout"),
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Texture {
+                                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                multisampled: false,
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                            count: None,
+                        },
+                    ],
+                });
+
+        let blit_pipeline_layout =
+            context
+                .device
+                .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some("blit_pipeline_layout"),
+                    bind_group_layouts: &[Some(&blit_bind_group_layout)],
+                    immediate_size: 0,
+                });
+
+        let blit_pipeline = context.device.create_render_pipeline(
+            &wgpu::RenderPipelineDescriptor {
+                label: Some("blit"),
+                layout: Some(&blit_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &blit_shader,
+                    entry_point: Some("vs_blit"),
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    buffers: &[],
+                },
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                fragment: Some(wgpu::FragmentState {
+                    module: &blit_shader,
+                    entry_point: Some("fs_blit"),
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                multiview_mask: None,
+                cache: None,
+            },
+        );
+
+        let blit_sampler = context.device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("blit_sampler"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        // ----- Pipeline texture (offscreen render target) -----------------------
+        let pipeline_texture = context.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("pipeline_texture"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let pipeline_texture_view = pipeline_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         // Create persistent framebuffer for browser-canvas-style blitting
         let persistent_framebuffer = context.device.create_texture(&wgpu::TextureDescriptor {
@@ -1644,6 +1767,21 @@ impl WgpuRenderer {
         let (group_textures, group_views) =
             create_filter_group_textures(&context.device, width, height, format);
 
+        let mode = if std::env::var("WGPUI_COMPOSITOR").is_ok() {
+            let (handle, _join_handle) = start_compositor(
+                context.clone(),
+                atlas.clone(),
+                format,
+                alpha_mode,
+                width,
+                height,
+                path_sample_count,
+            );
+            WgpuRendererMode::Compositor(handle)
+        } else {
+            WgpuRendererMode::Synchronous
+        };
+
         Ok(Self {
             context: context.clone(),
             surface: ManuallyDrop::new(surface),
@@ -1654,6 +1792,12 @@ impl WgpuRenderer {
             backdrop_blur_sampler,
             pipelines,
             rendering_parameters: RenderingParameters::from_env(),
+            blit_pipeline,
+            blit_bind_group_layout,
+            blit_sampler,
+            pipeline_texture,
+            pipeline_texture_view,
+            mode,
             surface_bind_groups: Mutex::new(HashMap::new()),
             persistent_framebuffer: Some(persistent_framebuffer),
             persistent_framebuffer_view: Some(persistent_framebuffer_view),
@@ -1667,26 +1811,32 @@ impl WgpuRenderer {
     }
 
     pub fn draw(&mut self, scene: &Scene) {
-        log::debug!("Renderer::draw: starting frame");
+        match &self.mode {
+            WgpuRendererMode::Synchronous => {
+                self.draw_sync(scene);
+            }
+            WgpuRendererMode::Compositor(handle) => {
+                self.draw_compositor(scene, handle);
+            }
+        }
+    }
+
+    /// Synchronous rendering path: render to pipeline_texture, then blit to swapchain.
+    fn draw_sync(&mut self, scene: &Scene) {
+        log::debug!("Renderer::draw_sync: starting");
 
         let mut command_encoder =
             self.context
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("main"),
+                    label: Some("sync"),
                 });
 
         self.atlas.before_frame(&mut command_encoder);
-        log::trace!("Renderer::draw: atlas.before_frame complete");
 
-        // keep track of which surface ids we rendered this frame
         let mut seen_surfaces: Vec<crate::platform::cross::surface_registry::SurfaceId> =
             Vec::new();
-
-        // CRITICAL: Keep surface views alive until after the render pass ends
-        // The bind groups reference these views, so they must not be dropped early
         let mut surface_views: Vec<wgpu::TextureView> = Vec::new();
-        // Surface bind groups also reference per-surface params buffers.
         let mut surface_param_buffers: Vec<wgpu::Buffer> = Vec::new();
 
         let color_adjustments = ColorAdjustments {
@@ -1824,7 +1974,6 @@ impl WgpuRenderer {
             );
         }
 
-        // Build flat vertex array for all paths (color + content mask baked per-vertex)
         let mut flat_path_vertices: Vec<GpuPathVertex> = Vec::new();
         for path in &scene.paths {
             let color = path.color.solid;
@@ -1857,49 +2006,6 @@ impl WgpuRenderer {
             );
         }
 
-        // Acquire the next swapchain image.  On the first frame after window
-        // creation (or after a resize races with the GPU) the surface can be
-        // reported as `Outdated` or `Other`.  Rather than panicking we
-        // reconfigure and retry once; if the second attempt also fails we
-        // simply drop this frame.
-        let surface_texture = {
-            let first = self.surface.get_current_texture();
-            match first {
-                Ok(t) => t,
-                Err(wgpu::SurfaceError::Outdated)
-                | Err(wgpu::SurfaceError::Lost)
-                | Err(wgpu::SurfaceError::Other) => {
-                    // Reconfigure with the current known size and retry.
-                    self.surface
-                        .configure(&self.context.device, &self.surface_configuration);
-                    match self.surface.get_current_texture() {
-                        Ok(t) => t,
-                        Err(e) => {
-                            log::warn!(
-                                "Skipping frame: failed to acquire swap chain texture after reconfigure: {:?}",
-                                e
-                            );
-                            return;
-                        }
-                    }
-                }
-                Err(wgpu::SurfaceError::Timeout) => {
-                    log::warn!("Skipping frame: swap chain acquire timed out");
-                    return;
-                }
-                Err(wgpu::SurfaceError::OutOfMemory) => {
-                    log::warn!("Skipping frame: out of memory");
-                    return;
-                }
-            }
-        };
-
-        // Increment layout version - all bounds caches are now fresh
-        // IMPORTANT: Only increment after successful swapchain acquisition
-        // If we skip the frame, bounds remain valid
-        self.layout_version.fetch_add(1, Ordering::Release);
-
-        // Borrow buffers for bind group creation - these borrows must live until bind groups are done
         let quads_buffer_ref = self.context.quads_buffer.lock().unwrap();
         let shadows_buffer_ref = self.context.shadows_buffer.lock().unwrap();
         let backdrop_filters_buffer_ref = self.context.backdrop_filters_buffer.lock().unwrap();
@@ -2041,13 +2147,10 @@ impl WgpuRenderer {
             });
 
         {
-            // Render to swapchain directly for now (TODO: render to framebuffer, then blit)
             let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("main"),
+                label: Some("sync_pipeline"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &surface_texture
-                        .texture
-                        .create_view(&wgpu::TextureViewDescriptor::default()),
+                    view: &self.pipeline_texture_view,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
                         store: wgpu::StoreOp::Store,
@@ -2069,10 +2172,6 @@ impl WgpuRenderer {
             let mut poly_sprites_first_instance: u32 = 0;
             let mut paths_vertex_offset: u32 = 0;
 
-            // Stack of active content-filter groups. Each entry pairs the group's
-            // `FilterBoundary` start marker with the `group_textures`/`group_views`
-            // slot its content is being rendered into (`None` if the group exceeded
-            // `MAX_FILTER_DEPTH` and is being painted inline, unisolated).
             let mut filter_stack: Vec<(FilterBoundary, Option<usize>)> = Vec::new();
 
             for batch in scene.batches() {
@@ -2176,33 +2275,25 @@ impl WgpuRenderer {
                     PrimitiveBatch::BackdropFilters(backdrop_filters) => {
                         let count = backdrop_filters.len() as u32;
 
-                        // End the current render pass to copy texture
                         drop(pass);
 
-                        // Copy surface texture to backdrop_blur_texture for sampling
                         if let Some(ref blur_texture) = self.backdrop_blur_texture {
-                            // Use actual surface texture size (may differ from configured size)
-                            let surface_size = surface_texture.texture.size();
-
-                            // Only copy if sizes match (otherwise skip to avoid validation error)
-                            if surface_size.width == blur_texture.width()
-                                && surface_size.height == blur_texture.height()
+                            let pipeline_size = self.pipeline_texture.size();
+                            if pipeline_size.width == blur_texture.width()
+                                && pipeline_size.height == blur_texture.height()
                             {
                                 command_encoder.copy_texture_to_texture(
-                                    surface_texture.texture.as_image_copy(),
+                                    self.pipeline_texture.as_image_copy(),
                                     blur_texture.as_image_copy(),
-                                    surface_size,
+                                    pipeline_size,
                                 );
                             }
                         }
 
-                        // Begin new render pass with Load to preserve existing content
                         pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                            label: Some("main_resumed"),
+                            label: Some("sync_backdrop_resumed"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                view: &surface_texture
-                                    .texture
-                                    .create_view(&wgpu::TextureViewDescriptor::default()),
+                                view: &self.pipeline_texture_view,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Load,
                                     store: wgpu::StoreOp::Store,
@@ -2216,7 +2307,6 @@ impl WgpuRenderer {
                             multiview_mask: None,
                         });
 
-                        // Now render the backdrop blur quads
                         pass.set_pipeline(&self.pipelines.backdrop_filters_pipeline);
                         pass.set_bind_group(0, &self.pipelines.globals_bind_group, &[]);
                         pass.set_bind_group(1, &backdrop_filters_bind_group, &[]);
@@ -2233,14 +2323,12 @@ impl WgpuRenderer {
                         if boundary.is_start {
                             let depth = filter_stack.len();
                             if depth >= self.group_textures.len() {
-                                // Exceeded the supported nesting depth: paint the group's
-                                // content inline (unisolated/unblurred) rather than dropping it.
                                 filter_stack.push((boundary, None));
                             } else {
                                 drop(pass);
 
                                 pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                    label: Some("filter_group"),
+                                    label: Some("sync_filter_group"),
                                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                         view: &self.group_views[depth],
                                         ops: wgpu::Operations {
@@ -2264,24 +2352,18 @@ impl WgpuRenderer {
                             };
 
                             let Some(depth) = depth else {
-                                // The group was painted inline; nothing to composite.
                                 continue;
                             };
 
-                            // End the group's pass: its content is now baked into
-                            // `group_textures[depth]`.
                             drop(pass);
 
-                            let surface_view = surface_texture
-                                .texture
-                                .create_view(&wgpu::TextureViewDescriptor::default());
                             let parent_view: &wgpu::TextureView = match filter_stack.last() {
                                 Some((_, Some(parent_depth))) => &self.group_views[*parent_depth],
-                                _ => &surface_view,
+                                _ => &self.pipeline_texture_view,
                             };
 
                             pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                label: Some("filter_group_resumed"),
+                                label: Some("sync_filter_group_resumed"),
                                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                     view: parent_view,
                                     ops: wgpu::Operations {
@@ -2297,9 +2379,6 @@ impl WgpuRenderer {
                                 multiview_mask: None,
                             });
 
-                            // Composite the blurred group content back over the parent using
-                            // the same backdrop-filter pipeline, sampling from the group's
-                            // offscreen texture instead of a surface snapshot.
                             let composite = BackdropFilter {
                                 order: 0,
                                 bounds: start_boundary.bounds,
@@ -2372,10 +2451,8 @@ impl WgpuRenderer {
                         underlines_first_instance += count;
                     }
                     PrimitiveBatch::Surfaces(surfaces) => {
-                        log::debug!("Renderer: processing {} surface(s)", surfaces.len());
                         for surface in surfaces {
                             if let crate::SurfaceContent::Wgpu(surface_id) = &surface.content {
-                                // Atomically swap ready ↔ display buffers with GPU sync
                                 let _swapped = self
                                     .context
                                     .surface_registry
@@ -2407,8 +2484,6 @@ impl WgpuRenderer {
                                         },
                                     };
 
-                                    // Cache bounds for fast surface blitting
-                                    // Surface bounds are in ScaledPixels (f32), store as Pixels for caching
                                     self.surface_bounds_cache.lock().unwrap().insert(
                                         *surface_id,
                                         SurfaceBoundsEntry {
@@ -2490,14 +2565,9 @@ impl WgpuRenderer {
                                     pass.set_bind_group(1, &surface_bind_group, &[]);
                                     pass.draw(0..4, 0..1);
 
-                                    // CRITICAL: Keep view alive until after render pass ends
-                                    // The bind_group holds a reference to it
                                     surface_views.push(view);
                                     surface_param_buffers.push(params_buffer);
 
-                                    // Clear redraw pending AFTER we're done with the view
-                                    // This prevents the external thread from triggering another compositor
-                                    // pass while we're still using this view
                                     self.context
                                         .surface_registry
                                         .clear_redraw_pending(*surface_id);
@@ -2507,7 +2577,6 @@ impl WgpuRenderer {
                             }
                         }
                     }
-                    // TODO(mdeand): Implement paths rendering.
                     PrimitiveBatch::Paths(paths) => {
                         let vertex_count: u32 = paths.iter().map(|p| p.vertices.len() as u32).sum();
                         if vertex_count > 0 {
@@ -2525,13 +2594,137 @@ impl WgpuRenderer {
             }
         }
 
-        // TODO: Blit persistent framebuffer to swapchain (needs proper pipeline)
-
-        log::debug!("Renderer::draw: submitting command buffer");
+        // Submit the render commands, then blit to swapchain and present
         self.context.queue.submit(Some(command_encoder.finish()));
-        log::debug!("Renderer::draw: presenting surface");
+
+        self.blit_to_swapchain();
+        log::debug!("Renderer::draw_sync: complete");
+    }
+
+    /// Blit the pipeline_texture to the swapchain and present.
+    fn blit_to_swapchain(&self) {
+        let surface_texture = match self.acquire_swapchain() {
+            Some(t) => t,
+            None => return,
+        };
+
+        let mut encoder =
+            self.context
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("blit_to_swapchain"),
+                });
+
+        let swapchain_view = surface_texture
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let blit_bind_group = self
+            .context
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("blit_bind_group"),
+                layout: &self.blit_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&self.pipeline_texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&self.blit_sampler),
+                    },
+                ],
+            });
+
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("blit_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &swapchain_view,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+                resolve_target: None,
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        pass.set_pipeline(&self.blit_pipeline);
+        pass.set_bind_group(0, &blit_bind_group, &[]);
+        pass.draw(0..4, 0..1);
+        drop(pass);
+
+        self.context.queue.submit(Some(encoder.finish()));
         surface_texture.present();
-        log::debug!("Renderer::draw: frame complete");
+    }
+
+    /// Acquire the swapchain texture with error handling.
+    fn acquire_swapchain(&self) -> Option<wgpu::SurfaceTexture> {
+        let first = self.surface.get_current_texture();
+        match first {
+            Ok(t) => Some(t),
+            Err(wgpu::SurfaceError::Outdated)
+            | Err(wgpu::SurfaceError::Lost)
+            | Err(wgpu::SurfaceError::Other) => {
+                self.surface
+                    .configure(&self.context.device, &self.surface_configuration);
+                match self.surface.get_current_texture() {
+                    Ok(t) => Some(t),
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to acquire swapchain after reconfigure: {:?}",
+                            e
+                        );
+                        None
+                    }
+                }
+            }
+            Err(wgpu::SurfaceError::Timeout) => {
+                log::warn!("Swapchain acquire timed out");
+                None
+            }
+            Err(wgpu::SurfaceError::OutOfMemory) => {
+                log::warn!("Swapchain acquire: out of memory");
+                None
+            }
+        }
+    }
+
+    /// Compositor path: send the scene to the compositor thread.
+    /// Returns immediately. The main thread polls `try_present()` to blit the
+    /// completed frame to the swapchain on a subsequent `RedrawRequested`.
+    fn draw_compositor(&self, scene: &Scene, handle: &CompositorHandle) {
+        // Clone the scene to send across threads.
+        // The compositor thread takes ownership.
+        let scene = scene.clone();
+
+        if let Err(e) = handle.job_tx.try_send(CompositorJob::Commit(scene)) {
+            log::warn!(
+                "Compositor: channel full, dropping frame: {:?}",
+                e
+            );
+        }
+    }
+
+    /// Try to present a completed compositor frame.
+    /// Returns `true` if a frame was blitted to the swapchain.
+    pub fn try_present(&self) -> bool {
+        match &self.mode {
+            WgpuRendererMode::Synchronous => false,
+            WgpuRendererMode::Compositor(handle) => {
+                match handle.completion_rx.try_recv() {
+                    Ok(_completion) => {
+                        self.blit_to_swapchain();
+                        true
+                    }
+                    Err(_) => false,
+                }
+            }
+        }
     }
 
     /// Fast path: blit all visible surfaces in a single swapchain pass.
@@ -2727,11 +2920,11 @@ impl WgpuRenderer {
         }
     }
 
-    /// Present without running compositor (fast blit already updated swapchain)
+    /// Present the last good frame from pipeline_texture to swapchain.
+    /// Used in compositor mode when no new frame is ready but we still
+    /// need to refresh the display (e.g. cursor blink).
     pub fn present_framebuffer_only(&self) {
-        // NOTE: Fast blit already presented to swapchain, so this is a no-op
-        // When we implement persistent framebuffer properly, this will blit framebuffer → swapchain
-        log::debug!("Present framebuffer only (no compositor) - fast blit already presented");
+        self.blit_to_swapchain();
     }
 
     pub fn update_drawable_size(&mut self, size: geometry::Size<DevicePixels>) {
@@ -2739,6 +2932,33 @@ impl WgpuRenderer {
         self.surface_configuration.height = size.height.0 as u32;
         self.surface
             .configure(&self.context.device, &self.surface_configuration);
+
+        // Recreate pipeline texture at new size
+        let format = self.surface_configuration.format;
+        let new_size = wgpu::Extent3d {
+            width: self.surface_configuration.width,
+            height: self.surface_configuration.height,
+            depth_or_array_layers: 1,
+        };
+        let pipeline_texture = self
+            .context
+            .device
+            .create_texture(&wgpu::TextureDescriptor {
+                label: Some("pipeline_texture"),
+                size: new_size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            });
+        let pipeline_texture_view =
+            pipeline_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        self.pipeline_texture = pipeline_texture;
+        self.pipeline_texture_view = pipeline_texture_view;
 
         // Recreate persistent framebuffer at new size
         let persistent_framebuffer = self
@@ -2754,7 +2974,7 @@ impl WgpuRenderer {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: self.surface_configuration.format,
+                format,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                     | wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
@@ -2781,7 +3001,7 @@ impl WgpuRenderer {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: self.surface_configuration.format,
+                format,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                     | wgpu::TextureUsages::TEXTURE_BINDING
                     | wgpu::TextureUsages::COPY_DST,
@@ -2799,7 +3019,7 @@ impl WgpuRenderer {
             &self.context.device,
             self.surface_configuration.width,
             self.surface_configuration.height,
-            self.surface_configuration.format,
+            format,
         );
         self.group_textures = group_textures;
         self.group_views = group_views;

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -2000,7 +2000,9 @@ impl WgpuRenderer {
         let (group_textures, group_views) =
             create_filter_group_textures(&context.device, width, height, format);
 
-        let mode = if std::env::var("WGPUI_COMPOSITOR").is_ok() {
+        let mode = if std::env::var("WGPUI_SYNCHRONOUS").is_ok() {
+            WgpuRendererMode::Synchronous
+        } else {
             let (handle, _join_handle) = start_compositor(
                 context.clone(),
                 atlas.clone(),
@@ -2011,8 +2013,6 @@ impl WgpuRenderer {
                 path_sample_count,
             );
             WgpuRendererMode::Compositor(handle)
-        } else {
-            WgpuRendererMode::Synchronous
         };
 
         Ok(Self {

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -314,11 +314,8 @@ impl OverscrollState {
                 (buffer_h - viewport_h) / 2.0,
             ),
             rendered_area: crate::geometry::Bounds {
-                origin: crate::geometry::point(
-                    (buffer_w - viewport_w) / 2.0,
-                    (buffer_h - viewport_h) / 2.0,
-                ),
-                size: crate::geometry::size(viewport_w, viewport_h),
+                origin: crate::geometry::point(0.0, 0.0),
+                size: crate::geometry::size(buffer_w, buffer_h),
             },
             overscroll_factor: factor,
             viewport_width: viewport_w,
@@ -3228,72 +3225,90 @@ impl WgpuRenderer {
         match &self.mode {
             WgpuRendererMode::Synchronous => false,
             WgpuRendererMode::Compositor(handle) => {
-                if let Ok(_completion) = handle.completion_rx.try_recv() {
-                    // Three-case overscroll model:
-                    // 1. Viewport within rendered area → blit with UV offset (no re-render)
-                    // 2. Near edge → send ExtendTiles, still blit current
-                    // 3. Otherwise → fall through to full blit
-
-                    let (uv_origin, uv_size, _covers, extend) = {
-                        let os = handle.overscroll_state.lock().unwrap();
-                        let vp_origin = crate::geometry::point(
-                            os.content_origin.x,
-                            os.content_origin.y,
-                        );
-                        let covers = os.covers(vp_origin);
-                        let uvs = if covers {
-                            Some(os.compute_blit_uvs())
-                        } else {
-                            None
-                        };
-                        let extend = if !covers {
-                            os.nearly_exceeded(0.1)
-                        } else {
-                            None
-                        };
-                        (uvs.map(|(u, _)| u), uvs.map(|(_, s)| s), covers, extend)
-                    };
-
-                    if let (Some(uv_origin), Some(uv_size)) = (uv_origin, uv_size) {
-                        // Case 1: viewport within rendered area
+                // Always try overscroll blit first — this handles pure scroll
+                // events where no Commit was sent to the compositor.
+                {
+                    let os = handle.overscroll_state.lock().unwrap();
+                    let vp_origin = crate::geometry::point(
+                        os.content_origin.x,
+                        os.content_origin.y,
+                    );
+                    if os.covers(vp_origin) {
+                        let (uv_origin, uv_size) = os.compute_blit_uvs();
+                        drop(os);
                         self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
                         return true;
                     }
-
-                    if let Some(extend_rect) = extend {
-                        // Case 2: near edge → request tile extension
-                        let _ = handle
-                            .job_tx
-                            .try_send(CompositorJob::ExtendTiles { rect: extend_rect });
-                        let (uv_origin, uv_size) = {
-                            let os = handle.overscroll_state.lock().unwrap();
-                            os.compute_blit_uvs()
-                        };
-                        self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
-                        return true;
-                    }
-
-                    // Case 3: fall through to full blit (will trigger a commit)
-                    self.blit_to_swapchain();
-                    true
-                } else {
-                    false
                 }
+
+                // Viewport not covered by cached content — need a commit.
+                // Poll for a completed one and try to blit it.
+                let _completion = match handle.completion_rx.try_recv() {
+                    Ok(c) => c,
+                    Err(_) => return false,
+                };
+
+                // Three-case overscroll model for newly committed frames:
+                // 1. Viewport within rendered area → blit with UV offset
+                // 2. Near edge → send ExtendTiles, still blit current
+                // 3. Otherwise → full blit
+                let (uv_origin, uv_size, _covers, extend) = {
+                    let os = handle.overscroll_state.lock().unwrap();
+                    let vp_origin = crate::geometry::point(
+                        os.content_origin.x,
+                        os.content_origin.y,
+                    );
+                    let covers = os.covers(vp_origin);
+                    let uvs = if covers {
+                        Some(os.compute_blit_uvs())
+                    } else {
+                        None
+                    };
+                    let extend = if !covers {
+                        os.nearly_exceeded(0.1)
+                    } else {
+                        None
+                    };
+                    (uvs.map(|(u, _)| u), uvs.map(|(_, s)| s), covers, extend)
+                };
+
+                if let (Some(uv_origin), Some(uv_size)) = (uv_origin, uv_size) {
+                    self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
+                    return true;
+                }
+
+                if let Some(extend_rect) = extend {
+                    let _ = handle
+                        .job_tx
+                        .try_send(CompositorJob::ExtendTiles { rect: extend_rect });
+                    let (uv_origin, uv_size) = {
+                        let os = handle.overscroll_state.lock().unwrap();
+                        os.compute_blit_uvs()
+                    };
+                    self.blit_to_swapchain_with_uvs(uv_origin, uv_size);
+                    return true;
+                }
+
+                self.blit_to_swapchain();
+                true
             }
         }
     }
 
     /// Record a scroll delta without triggering a full re-render.
-    /// In compositor mode this sends a Scroll job to the compositor thread.
+    /// Updates overscroll state synchronously and notifies the compositor.
     pub fn record_scroll(&self, delta: crate::geometry::Point<f32>) {
         match &self.mode {
-            WgpuRendererMode::Synchronous => {
-                // In synchronous mode, no overscroll optimization yet
-            }
+            WgpuRendererMode::Synchronous => {}
             WgpuRendererMode::Compositor(handle) => {
-                let _ = handle
-                    .job_tx
-                    .try_send(CompositorJob::Scroll(delta));
+                // Update overscroll state synchronously so try_present
+                // immediately sees the new content_origin.
+                {
+                    let mut os = handle.overscroll_state.lock().unwrap();
+                    os.scroll(delta.x, delta.y);
+                }
+                // Notify compositor thread so future commits use the right origin.
+                let _ = handle.job_tx.try_send(CompositorJob::Scroll(delta));
             }
         }
     }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -5,9 +5,10 @@ use std::sync::{Arc, Mutex};
 use wgpu::util::DeviceExt;
 
 use crate::{
-    AtlasTextureId, AtlasTile, BackdropFilter, DevicePixels, FilterBoundary, GpuSpecs,
-    GradientStop, LinearColorStop, MonochromeSprite, Pixels, PlatformAtlas, PrimitiveBatch, Quad,
-    ScaledPixels, Scene, TransformationMatrix, color, geometry,
+    as_bytes, AtlasTextureId, AtlasTile, BackdropFilter, DevicePixels, FilterBoundary, GpuSpecs,
+    GradientStop, LinearColorStop, MonochromeSprite, Pixels, PlatformAtlas, PrimitiveBatch,
+    PolychromeSprite, Quad, ScaledPixels, Scene, Shadow,
+    Underline, TransformationMatrix, color, geometry,
     platform::cross::{
         atlas::WgpuAtlas,
         compositor::{CompositorCompletion, CompositorJob, start_compositor, CompositorHandle},
@@ -826,16 +827,28 @@ impl WgpuPipelines {
                 .device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("quads_bind_group_layout"),
-                    entries: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
                         },
-                        count: None,
-                    }],
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
                 });
 
         let quads_pipeline_layout =
@@ -855,16 +868,28 @@ impl WgpuPipelines {
                 .device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("shadows_bind_group_layout"),
-                    entries: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
                         },
-                        count: None,
-                    }],
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
                 });
 
         let shadows_pipeline_layout =
@@ -884,16 +909,28 @@ impl WgpuPipelines {
                 .device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("backdrop_filters_bind_group_layout"),
-                    entries: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
                         },
-                        count: None,
-                    }],
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
                 });
 
         let backdrop_texture_bind_group_layout =
@@ -939,16 +976,28 @@ impl WgpuPipelines {
                 .device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("underlines_bind_group_layout"),
-                    entries: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
                         },
-                        count: None,
-                    }],
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
                 });
 
         let underlines_pipeline_layout =
@@ -968,16 +1017,28 @@ impl WgpuPipelines {
                 .device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("Mono sprites bind group layout"),
-                    entries: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
                         },
-                        count: None,
-                    }],
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
                 });
 
         let mono_sprites_pipeline_layout =
@@ -999,16 +1060,28 @@ impl WgpuPipelines {
                 .device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("Poly sprites bind group layout"),
-                    entries: &[wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
                         },
-                        count: None,
-                    }],
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::VERTEX,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
                 });
 
         let poly_sprites_pipeline_layout =
@@ -1497,6 +1570,9 @@ pub struct WgpuRenderer {
     // Current renderer mode
     mode: WgpuRendererMode,
 
+    // First frame tracking: use Clear on first render, Load+scissor thereafter
+    first_frame: bool,
+
     // cache bind groups for each double-buffered surface (index 0/1)
     surface_bind_groups:
         Mutex<HashMap<crate::platform::cross::surface_registry::SurfaceId, [wgpu::BindGroup; 2]>>,
@@ -1521,6 +1597,7 @@ pub struct WgpuRenderer {
 
     // Layout version counter (incremented when compositor runs)
     layout_version: Arc<AtomicU64>,
+
 }
 
 impl WgpuRenderer {
@@ -1807,6 +1884,7 @@ impl WgpuRenderer {
             group_views,
             surface_bounds_cache: Arc::new(Mutex::new(HashMap::new())),
             layout_version: Arc::new(AtomicU64::new(0)),
+            first_frame: true,
         })
     }
 
@@ -1868,128 +1946,155 @@ impl WgpuRenderer {
             bytemuck::bytes_of(&globals),
         );
 
-        unsafe fn as_bytes<T>(slice: &[T]) -> &[u8] {
-            unsafe {
-                std::slice::from_raw_parts(
-                    slice.as_ptr() as *const u8,
-                    slice.len() * std::mem::size_of::<T>(),
-                )
+        let buffer_usage = wgpu::BufferUsages::VERTEX
+            | wgpu::BufferUsages::COPY_DST
+            | wgpu::BufferUsages::STORAGE;
+
+        // Sparse uploads — only changed slots (from pending_delta)
+        // Quads
+        {
+            let elem_size = std::mem::size_of::<Quad>() as u64;
+            for changed in &scene.pending_delta.changed_quads {
+                if let Some(quad) = scene.quads.get(changed.slot) {
+                    if scene.quads.slots.len() as u64 * elem_size > 0 {
+                        ensure_buffer_size(
+                            &self.context.device,
+                            &self.context.quads_buffer,
+                            scene.quads.slots.len() as u64 * elem_size,
+                            "Quads Buffer",
+                            buffer_usage,
+                        );
+                    }
+                    let ptr = quad as *const Quad as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    self.context.queue.write_buffer(&self.context.quads_buffer.lock().unwrap(), changed.byte_offset, bytes);
+                }
+            }
+        }
+        // Shadows
+        {
+            let elem_size = std::mem::size_of::<Shadow>() as u64;
+            for changed in &scene.pending_delta.changed_shadows {
+                if let Some(shadow) = scene.shadows.get(changed.slot) {
+                    if scene.shadows.slots.len() as u64 * elem_size > 0 {
+                        ensure_buffer_size(
+                            &self.context.device,
+                            &self.context.shadows_buffer,
+                            scene.shadows.slots.len() as u64 * elem_size,
+                            "Shadows Buffer",
+                            buffer_usage,
+                        );
+                    }
+                    let ptr = shadow as *const Shadow as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    self.context.queue.write_buffer(&self.context.shadows_buffer.lock().unwrap(), changed.byte_offset, bytes);
+                }
+            }
+        }
+        // BackdropFilters
+        {
+            let elem_size = std::mem::size_of::<BackdropFilter>() as u64;
+            for changed in &scene.pending_delta.changed_backdrop_filters {
+                if let Some(filter) = scene.backdrop_filters.get(changed.slot) {
+                    if scene.backdrop_filters.slots.len() as u64 * elem_size > 0 {
+                        ensure_buffer_size(
+                            &self.context.device,
+                            &self.context.backdrop_filters_buffer,
+                            scene.backdrop_filters.slots.len() as u64 * elem_size,
+                            "Backdrop Filters Buffer",
+                            buffer_usage,
+                        );
+                    }
+                    let ptr = filter as *const BackdropFilter as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    self.context.queue.write_buffer(&self.context.backdrop_filters_buffer.lock().unwrap(), changed.byte_offset, bytes);
+                }
+            }
+        }
+        // Underlines
+        {
+            let elem_size = std::mem::size_of::<Underline>() as u64;
+            for changed in &scene.pending_delta.changed_underlines {
+                if let Some(underline) = scene.underlines.get(changed.slot) {
+                    if scene.underlines.slots.len() as u64 * elem_size > 0 {
+                        ensure_buffer_size(
+                            &self.context.device,
+                            &self.context.underlines_buffer,
+                            scene.underlines.slots.len() as u64 * elem_size,
+                            "Underlines Buffer",
+                            buffer_usage,
+                        );
+                    }
+                    let ptr = underline as *const Underline as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    self.context.queue.write_buffer(&self.context.underlines_buffer.lock().unwrap(), changed.byte_offset, bytes);
+                }
+            }
+        }
+        // MonochromeSprites
+        {
+            let elem_size = std::mem::size_of::<MonochromeSprite>() as u64;
+            for changed in &scene.pending_delta.changed_monochrome_sprites {
+                if let Some(sprite) = scene.monochrome_sprites.get(changed.slot) {
+                    if scene.monochrome_sprites.slots.len() as u64 * elem_size > 0 {
+                        ensure_buffer_size(
+                            &self.context.device,
+                            &self.context.mono_sprites_buffer,
+                            scene.monochrome_sprites.slots.len() as u64 * elem_size,
+                            "Monosprites Buffer",
+                            buffer_usage,
+                        );
+                    }
+                    let ptr = sprite as *const MonochromeSprite as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    self.context.queue.write_buffer(&self.context.mono_sprites_buffer.lock().unwrap(), changed.byte_offset, bytes);
+                }
+            }
+        }
+        // PolychromeSprites
+        {
+            let elem_size = std::mem::size_of::<PolychromeSprite>() as u64;
+            for changed in &scene.pending_delta.changed_polychrome_sprites {
+                if let Some(sprite) = scene.polychrome_sprites.get(changed.slot) {
+                    if scene.polychrome_sprites.slots.len() as u64 * elem_size > 0 {
+                        ensure_buffer_size(
+                            &self.context.device,
+                            &self.context.poly_sprites_buffer,
+                            scene.polychrome_sprites.slots.len() as u64 * elem_size,
+                            "Poly Sprites Buffer",
+                            buffer_usage,
+                        );
+                    }
+                    let ptr = sprite as *const PolychromeSprite as *const u8;
+                    let bytes = unsafe { std::slice::from_raw_parts(ptr, elem_size as usize) };
+                    self.context.queue.write_buffer(&self.context.poly_sprites_buffer.lock().unwrap(), changed.byte_offset, bytes);
+                }
             }
         }
 
-        if !scene.quads.is_empty() {
-            let data = unsafe { as_bytes(&scene.quads) };
-            ensure_buffer_size(
-                &self.context.device,
-                &self.context.quads_buffer,
-                data.len() as u64,
-                "Quads Buffer",
-                wgpu::BufferUsages::VERTEX
-                    | wgpu::BufferUsages::COPY_DST
-                    | wgpu::BufferUsages::STORAGE,
-            );
-            self.context
-                .queue
-                .write_buffer(&self.context.quads_buffer.lock().unwrap(), 0, data);
-        }
-        if !scene.shadows.is_empty() {
-            let data = unsafe { as_bytes(&scene.shadows) };
-            ensure_buffer_size(
-                &self.context.device,
-                &self.context.shadows_buffer,
-                data.len() as u64,
-                "Shadows Buffer",
-                wgpu::BufferUsages::VERTEX
-                    | wgpu::BufferUsages::COPY_DST
-                    | wgpu::BufferUsages::STORAGE,
-            );
-            self.context
-                .queue
-                .write_buffer(&self.context.shadows_buffer.lock().unwrap(), 0, data);
-        }
-        if !scene.backdrop_filters.is_empty() {
-            let data = unsafe { as_bytes(&scene.backdrop_filters) };
-            ensure_buffer_size(
-                &self.context.device,
-                &self.context.backdrop_filters_buffer,
-                data.len() as u64,
-                "Backdrop Filters Buffer",
-                wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            );
-            self.context.queue.write_buffer(
-                &self.context.backdrop_filters_buffer.lock().unwrap(),
-                0,
-                data,
-            );
-        }
-        if !scene.underlines.is_empty() {
-            let data = unsafe { as_bytes(&scene.underlines) };
-            ensure_buffer_size(
-                &self.context.device,
-                &self.context.underlines_buffer,
-                data.len() as u64,
-                "Underlines Buffer",
-                wgpu::BufferUsages::VERTEX
-                    | wgpu::BufferUsages::COPY_DST
-                    | wgpu::BufferUsages::STORAGE,
-            );
-            self.context.queue.write_buffer(
-                &self.context.underlines_buffer.lock().unwrap(),
-                0,
-                data,
-            );
-        }
-        if !scene.monochrome_sprites.is_empty() {
-            let data = unsafe { as_bytes(&scene.monochrome_sprites) };
-            ensure_buffer_size(
-                &self.context.device,
-                &self.context.mono_sprites_buffer,
-                data.len() as u64,
-                "Monosprites Buffer",
-                wgpu::BufferUsages::VERTEX
-                    | wgpu::BufferUsages::COPY_DST
-                    | wgpu::BufferUsages::STORAGE,
-            );
-            self.context.queue.write_buffer(
-                &self.context.mono_sprites_buffer.lock().unwrap(),
-                0,
-                data,
-            );
-        }
-        if !scene.polychrome_sprites.is_empty() {
-            let data = unsafe { as_bytes(&scene.polychrome_sprites) };
-            ensure_buffer_size(
-                &self.context.device,
-                &self.context.poly_sprites_buffer,
-                data.len() as u64,
-                "Poly Sprites Buffer",
-                wgpu::BufferUsages::VERTEX
-                    | wgpu::BufferUsages::COPY_DST
-                    | wgpu::BufferUsages::STORAGE,
-            );
-            self.context.queue.write_buffer(
-                &self.context.poly_sprites_buffer.lock().unwrap(),
-                0,
-                data,
-            );
-        }
-
-        let mut flat_path_vertices: Vec<GpuPathVertex> = Vec::new();
-        for path in &scene.paths {
-            let color = path.color.solid;
-            let cm = &path.content_mask.bounds;
-            let cm_origin = [cm.origin.x.0, cm.origin.y.0];
-            let cm_size = [cm.size.width.0, cm.size.height.0];
-            for vertex in &path.vertices {
-                flat_path_vertices.push(GpuPathVertex {
-                    xy_position: [vertex.xy_position.x.0, vertex.xy_position.y.0],
-                    st_position: [vertex.st_position.x, vertex.st_position.y],
-                    hsla: [color.h, color.s, color.l, color.a],
-                    content_mask_origin: cm_origin,
-                    content_mask_size: cm_size,
-                });
+        // Paths — upload all vertex data only if paths changed
+        let flat_path_vertices: Vec<GpuPathVertex> = if scene.pending_delta.paths_changed {
+            let mut vertices = Vec::new();
+            for slot in &scene.paths.slots {
+                let Some(path) = slot.as_ref().map(|s| &s.data) else { continue };
+                let color = path.color.solid;
+                let cm = &path.content_mask.bounds;
+                let cm_origin = [cm.origin.x.0, cm.origin.y.0];
+                let cm_size = [cm.size.width.0, cm.size.height.0];
+                for vertex in &path.vertices {
+                    vertices.push(GpuPathVertex {
+                        xy_position: [vertex.xy_position.x.0, vertex.xy_position.y.0],
+                        st_position: [vertex.st_position.x, vertex.st_position.y],
+                        hsla: [color.h, color.s, color.l, color.a],
+                        content_mask_origin: cm_origin,
+                        content_mask_size: cm_size,
+                    });
+                }
             }
-        }
+            vertices
+        } else {
+            Vec::new()
+        };
         if !flat_path_vertices.is_empty() {
             let data = bytemuck::cast_slice(&flat_path_vertices);
             ensure_buffer_size(
@@ -2006,6 +2111,86 @@ impl WgpuRenderer {
             );
         }
 
+        // Upload indirection buffers
+        {
+            let data = bytemuck::cast_slice(&scene.sorted_quad_indices);
+            if !scene.sorted_quad_indices.is_empty() {
+                ensure_buffer_size(
+                    &self.context.device,
+                    &self.context.quad_indirection_buffer,
+                    data.len() as u64,
+                    "Quad Indirection Buffer",
+                    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                );
+                self.context.queue.write_buffer(&self.context.quad_indirection_buffer.lock().unwrap(), 0, data);
+            }
+        }
+        {
+            let data = bytemuck::cast_slice(&scene.sorted_shadow_indices);
+            if !scene.sorted_shadow_indices.is_empty() {
+                ensure_buffer_size(
+                    &self.context.device,
+                    &self.context.shadow_indirection_buffer,
+                    data.len() as u64,
+                    "Shadow Indirection Buffer",
+                    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                );
+                self.context.queue.write_buffer(&self.context.shadow_indirection_buffer.lock().unwrap(), 0, data);
+            }
+        }
+        {
+            let data = bytemuck::cast_slice(&scene.sorted_backdrop_filter_indices);
+            if !scene.sorted_backdrop_filter_indices.is_empty() {
+                ensure_buffer_size(
+                    &self.context.device,
+                    &self.context.backdrop_filter_indirection_buffer,
+                    data.len() as u64,
+                    "Backdrop Filter Indirection Buffer",
+                    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                );
+                self.context.queue.write_buffer(&self.context.backdrop_filter_indirection_buffer.lock().unwrap(), 0, data);
+            }
+        }
+        {
+            let data = bytemuck::cast_slice(&scene.sorted_underline_indices);
+            if !scene.sorted_underline_indices.is_empty() {
+                ensure_buffer_size(
+                    &self.context.device,
+                    &self.context.underline_indirection_buffer,
+                    data.len() as u64,
+                    "Underline Indirection Buffer",
+                    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                );
+                self.context.queue.write_buffer(&self.context.underline_indirection_buffer.lock().unwrap(), 0, data);
+            }
+        }
+        {
+            let data = bytemuck::cast_slice(&scene.sorted_mono_sprite_indices);
+            if !scene.sorted_mono_sprite_indices.is_empty() {
+                ensure_buffer_size(
+                    &self.context.device,
+                    &self.context.mono_sprite_indirection_buffer,
+                    data.len() as u64,
+                    "Mono Sprite Indirection Buffer",
+                    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                );
+                self.context.queue.write_buffer(&self.context.mono_sprite_indirection_buffer.lock().unwrap(), 0, data);
+            }
+        }
+        {
+            let data = bytemuck::cast_slice(&scene.sorted_poly_sprite_indices);
+            if !scene.sorted_poly_sprite_indices.is_empty() {
+                ensure_buffer_size(
+                    &self.context.device,
+                    &self.context.poly_sprite_indirection_buffer,
+                    data.len() as u64,
+                    "Poly Sprite Indirection Buffer",
+                    wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                );
+                self.context.queue.write_buffer(&self.context.poly_sprite_indirection_buffer.lock().unwrap(), 0, data);
+            }
+        }
+
         let quads_buffer_ref = self.context.quads_buffer.lock().unwrap();
         let shadows_buffer_ref = self.context.shadows_buffer.lock().unwrap();
         let backdrop_filters_buffer_ref = self.context.backdrop_filters_buffer.lock().unwrap();
@@ -2013,6 +2198,12 @@ impl WgpuRenderer {
         let mono_sprites_buffer_ref = self.context.mono_sprites_buffer.lock().unwrap();
         let poly_sprites_buffer_ref = self.context.poly_sprites_buffer.lock().unwrap();
         let paths_vertices_buffer_ref = self.context.paths_vertices_buffer.lock().unwrap();
+        let quad_indirection_buffer_ref = self.context.quad_indirection_buffer.lock().unwrap();
+        let shadow_indirection_buffer_ref = self.context.shadow_indirection_buffer.lock().unwrap();
+        let backdrop_filter_indirection_buffer_ref = self.context.backdrop_filter_indirection_buffer.lock().unwrap();
+        let underline_indirection_buffer_ref = self.context.underline_indirection_buffer.lock().unwrap();
+        let mono_sprite_indirection_buffer_ref = self.context.mono_sprite_indirection_buffer.lock().unwrap();
+        let poly_sprite_indirection_buffer_ref = self.context.poly_sprite_indirection_buffer.lock().unwrap();
 
         let quads_bind_group = self
             .context
@@ -2020,14 +2211,24 @@ impl WgpuRenderer {
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("quads_bind_group"),
                 layout: &self.pipelines.quads_bind_group_layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &quads_buffer_ref,
-                        offset: 0,
-                        size: None,
-                    }),
-                }],
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &quads_buffer_ref,
+                            offset: 0,
+                            size: None,
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &quad_indirection_buffer_ref,
+                            offset: 0,
+                            size: None,
+                        }),
+                    },
+                ],
             });
 
         let shadows_bind_group =
@@ -2036,14 +2237,24 @@ impl WgpuRenderer {
                 .create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("shadows_bind_group"),
                     layout: &self.pipelines.shadows_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: &shadows_buffer_ref,
-                            offset: 0,
-                            size: None,
-                        }),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &shadows_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &shadow_indirection_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                    ],
                 });
 
         let backdrop_filters_bind_group =
@@ -2052,14 +2263,24 @@ impl WgpuRenderer {
                 .create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("backdrop_filters_bind_group"),
                     layout: &self.pipelines.backdrop_filters_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: &backdrop_filters_buffer_ref,
-                            offset: 0,
-                            size: None,
-                        }),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &backdrop_filters_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &backdrop_filter_indirection_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                    ],
                 });
 
         let backdrop_texture_bind_group =
@@ -2088,14 +2309,24 @@ impl WgpuRenderer {
                 .create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("underlines_bind_group"),
                     layout: &self.pipelines.underlines_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: &underlines_buffer_ref,
-                            offset: 0,
-                            size: None,
-                        }),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &underlines_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &underline_indirection_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                    ],
                 });
 
         let mono_sprites_bind_group =
@@ -2104,14 +2335,24 @@ impl WgpuRenderer {
                 .create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("mono_sprites_bind_group"),
                     layout: &self.pipelines.mono_sprites_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: &mono_sprites_buffer_ref,
-                            offset: 0,
-                            size: None,
-                        }),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &mono_sprites_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &mono_sprite_indirection_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                    ],
                 });
 
         let poly_sprites_bind_group =
@@ -2120,14 +2361,24 @@ impl WgpuRenderer {
                 .create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("poly_sprites_bind_group"),
                     layout: &self.pipelines.poly_sprites_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                            buffer: &poly_sprites_buffer_ref,
-                            offset: 0,
-                            size: None,
-                        }),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &poly_sprites_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                buffer: &poly_sprite_indirection_buffer_ref,
+                                offset: 0,
+                                size: None,
+                            }),
+                        },
+                    ],
                 });
 
         let paths_bind_group = self
@@ -2146,13 +2397,35 @@ impl WgpuRenderer {
                 }],
             });
 
+        // Skip the entire render pass if nothing changed
+        if scene.pending_delta.is_empty && !scene.pending_delta.paths_changed {
+            // Still submit the encoder (may contain atlas uploads from before_frame)
+            self.context.queue.submit(Some(command_encoder.finish()));
+            self.blit_to_swapchain();
+            log::debug!("Renderer::draw_sync: complete (empty delta)");
+            return;
+        }
+
+        let has_damage_rect = scene.pending_delta.damage_rect.is_some();
+
+        let vp_w = self.surface_configuration.width;
+        let vp_h = self.surface_configuration.height;
+        let load_op = if self.first_frame {
+            self.first_frame = false;
+            wgpu::LoadOp::Clear(wgpu::Color::BLACK)
+        } else if has_damage_rect {
+            wgpu::LoadOp::Load
+        } else {
+            wgpu::LoadOp::Clear(wgpu::Color::BLACK)
+        };
+
         {
             let mut pass = command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("sync_pipeline"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &self.pipeline_texture_view,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        load: load_op,
                         store: wgpu::StoreOp::Store,
                     },
                     resolve_target: None,
@@ -2163,6 +2436,16 @@ impl WgpuRenderer {
                 occlusion_query_set: None,
                 multiview_mask: None,
             });
+
+        if let Some(damage) = &scene.pending_delta.damage_rect {
+            let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
+            let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
+            let max_w = vp_w.saturating_sub(x);
+            let max_h = vp_h.saturating_sub(y);
+            let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
+            let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
+            pass.set_scissor_rect(x, y, w, h);
+        }
 
             let mut quads_first_instance: u32 = 0;
             let mut shadows_first_instance: u32 = 0;
@@ -2187,9 +2470,9 @@ impl WgpuRenderer {
 
                     PrimitiveBatch::MonochromeSprites {
                         texture_id,
-                        sprites,
+                        indices,
                     } => {
-                        let count = sprites.len() as u32;
+                        let count = indices.len() as u32;
                         let tex_info = self.atlas.get_texture_info(texture_id);
 
                         let sprites_texture_bind_group =
@@ -2227,9 +2510,9 @@ impl WgpuRenderer {
                     }
                     PrimitiveBatch::PolychromeSprites {
                         texture_id,
-                        sprites,
+                        indices,
                     } => {
-                        let count = sprites.len() as u32;
+                        let count = indices.len() as u32;
                         let tex_info = self.atlas.get_texture_info(texture_id);
 
                         let sprites_texture_bind_group =
@@ -2307,6 +2590,16 @@ impl WgpuRenderer {
                             multiview_mask: None,
                         });
 
+                        if let Some(damage) = &scene.pending_delta.damage_rect {
+                            let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
+                            let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
+                            let max_w = vp_w.saturating_sub(x);
+                            let max_h = vp_h.saturating_sub(y);
+                            let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
+                            let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
+                            pass.set_scissor_rect(x, y, w, h);
+                        }
+
                         pass.set_pipeline(&self.pipelines.backdrop_filters_pipeline);
                         pass.set_bind_group(0, &self.pipelines.globals_bind_group, &[]);
                         pass.set_bind_group(1, &backdrop_filters_bind_group, &[]);
@@ -2379,6 +2672,16 @@ impl WgpuRenderer {
                                 multiview_mask: None,
                             });
 
+                            if let Some(damage) = &scene.pending_delta.damage_rect {
+                                let x = (damage.origin.x.0.max(0.0) as u32).min(vp_w);
+                                let y = (damage.origin.y.0.max(0.0) as u32).min(vp_h);
+                                let max_w = vp_w.saturating_sub(x);
+                                let max_h = vp_h.saturating_sub(y);
+                                let w = (damage.size.width.0.max(0.0) as u32).min(max_w).max(1);
+                                let h = (damage.size.height.0.max(0.0) as u32).min(max_h).max(1);
+                                pass.set_scissor_rect(x, y, w, h);
+                            }
+
                             let composite = BackdropFilter {
                                 order: 0,
                                 bounds: start_boundary.bounds,
@@ -2395,20 +2698,39 @@ impl WgpuRenderer {
                                     usage: wgpu::BufferUsages::STORAGE,
                                 },
                             );
+                            let composite_indirection_buffer = self.context.device.create_buffer_init(
+                                &wgpu::util::BufferInitDescriptor {
+                                    label: Some("filter_group_composite_indirection_buffer"),
+                                    contents: bytemuck::cast_slice(&[0u32]),
+                                    usage: wgpu::BufferUsages::STORAGE,
+                                },
+                            );
                             let composite_bind_group = self.context.device.create_bind_group(
                                 &wgpu::BindGroupDescriptor {
                                     label: Some("filter_group_composite_bind_group"),
                                     layout: &self.pipelines.backdrop_filters_bind_group_layout,
-                                    entries: &[wgpu::BindGroupEntry {
-                                        binding: 0,
-                                        resource: wgpu::BindingResource::Buffer(
-                                            wgpu::BufferBinding {
-                                                buffer: &composite_buffer,
-                                                offset: 0,
-                                                size: None,
-                                            },
-                                        ),
-                                    }],
+                                    entries: &[
+                                        wgpu::BindGroupEntry {
+                                            binding: 0,
+                                            resource: wgpu::BindingResource::Buffer(
+                                                wgpu::BufferBinding {
+                                                    buffer: &composite_buffer,
+                                                    offset: 0,
+                                                    size: None,
+                                                },
+                                            ),
+                                        },
+                                        wgpu::BindGroupEntry {
+                                            binding: 1,
+                                            resource: wgpu::BindingResource::Buffer(
+                                                wgpu::BufferBinding {
+                                                    buffer: &composite_indirection_buffer,
+                                                    offset: 0,
+                                                    size: None,
+                                                },
+                                            ),
+                                        },
+                                    ],
                                 },
                             );
                             let composite_texture_bind_group = self.context.device.create_bind_group(
@@ -2450,8 +2772,9 @@ impl WgpuRenderer {
                         );
                         underlines_first_instance += count;
                     }
-                    PrimitiveBatch::Surfaces(surfaces) => {
-                        for surface in surfaces {
+                    PrimitiveBatch::Surfaces(indices) => {
+                        for &slot in indices {
+                            let Some(surface) = scene.surfaces.get(slot as usize) else { continue };
                             if let crate::SurfaceContent::Wgpu(surface_id) = &surface.content {
                                 let _swapped = self
                                     .context
@@ -2577,8 +2900,8 @@ impl WgpuRenderer {
                             }
                         }
                     }
-                    PrimitiveBatch::Paths(paths) => {
-                        let vertex_count: u32 = paths.iter().map(|p| p.vertices.len() as u32).sum();
+                    PrimitiveBatch::Paths(indices) => {
+                        let vertex_count: u32 = indices.iter().filter_map(|&slot| scene.paths.get(slot as usize)).map(|p| p.vertices.len() as u32).sum();
                         if vertex_count > 0 {
                             pass.set_pipeline(&self.pipelines.paths_pipeline);
                             pass.set_bind_group(0, &self.pipelines.globals_bind_group, &[]);

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -314,8 +314,11 @@ impl OverscrollState {
                 (buffer_h - viewport_h) / 2.0,
             ),
             rendered_area: crate::geometry::Bounds {
-                origin: crate::geometry::point(0.0, 0.0),
-                size: crate::geometry::size(buffer_w, buffer_h),
+                origin: crate::geometry::point(
+                    (buffer_w - viewport_w) / 2.0,
+                    (buffer_h - viewport_h) / 2.0,
+                ),
+                size: crate::geometry::size(viewport_w, viewport_h),
             },
             overscroll_factor: factor,
             viewport_width: viewport_w,

--- a/src/platform/cross/shaders/backdrop_blur.wgsl
+++ b/src/platform/cross/shaders/backdrop_blur.wgsl
@@ -39,6 +39,7 @@ struct BackdropFilterVarying {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<storage, read> b_backdrop_filters: array<BackdropFilter>;
+@group(1) @binding(1) var<storage, read> b_backdrop_filter_instances: array<u32>;
 @group(2) @binding(0) var backdrop_texture: texture_2d<f32>;
 @group(2) @binding(1) var backdrop_sampler: sampler;
 
@@ -78,7 +79,8 @@ fn quad_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners) -> f32 {
 @vertex
 fn vs_backdrop_filter(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> BackdropFilterVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    let backdrop_filter = b_backdrop_filters[instance_id];
+    let slot = b_backdrop_filter_instances[instance_id];
+    let backdrop_filter = b_backdrop_filters[slot];
 
     let position = to_device_position(unit_vertex, backdrop_filter.bounds);
 
@@ -90,7 +92,7 @@ fn vs_backdrop_filter(@builtin(vertex_index) vertex_id: u32, @builtin(instance_i
     clip_distances.z = content_mask.origin.x + content_mask.size.x - pixel_position.x;
     clip_distances.w = content_mask.origin.y + content_mask.size.y - pixel_position.y;
 
-    return BackdropFilterVarying(position, instance_id, clip_distances);
+    return BackdropFilterVarying(position, slot, clip_distances);
 }
 
 @fragment

--- a/src/platform/cross/shaders/blit.wgsl
+++ b/src/platform/cross/shaders/blit.wgsl
@@ -1,7 +1,16 @@
+struct BlitParams {
+    uv_origin: vec2f,
+    uv_size: vec2f,
+}
+
 struct VertexOutput {
     @builtin(position) position: vec4f,
     @location(0) uv: vec2f,
 };
+
+@group(0) @binding(0) var pipeline_texture: texture_2d<f32>;
+@group(0) @binding(1) var sampler_: sampler;
+@group(0) @binding(2) var<uniform> blit_params: BlitParams;
 
 @vertex
 fn vs_blit(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
@@ -17,11 +26,11 @@ fn vs_blit(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
         vec2f(0.0, 0.0),
         vec2f(1.0, 0.0),
     );
-    return VertexOutput(positions[vertex_index], uvs[vertex_index]);
+    var out: VertexOutput;
+    out.position = positions[vertex_index];
+    out.uv = blit_params.uv_origin + uvs[vertex_index] * blit_params.uv_size;
+    return out;
 }
-
-@group(0) @binding(0) var pipeline_texture: texture_2d<f32>;
-@group(0) @binding(1) var sampler_: sampler;
 
 @fragment
 fn fs_blit(@location(0) uv: vec2f) -> @location(0) vec4f {

--- a/src/platform/cross/shaders/blit.wgsl
+++ b/src/platform/cross/shaders/blit.wgsl
@@ -1,0 +1,29 @@
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(0) uv: vec2f,
+};
+
+@vertex
+fn vs_blit(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    let positions = array<vec4f, 4>(
+        vec4f(-1.0, -1.0, 0.0, 1.0),
+        vec4f( 1.0, -1.0, 0.0, 1.0),
+        vec4f(-1.0,  1.0, 0.0, 1.0),
+        vec4f( 1.0,  1.0, 0.0, 1.0),
+    );
+    let uvs = array<vec2f, 4>(
+        vec2f(0.0, 1.0),
+        vec2f(1.0, 1.0),
+        vec2f(0.0, 0.0),
+        vec2f(1.0, 0.0),
+    );
+    return VertexOutput(positions[vertex_index], uvs[vertex_index]);
+}
+
+@group(0) @binding(0) var pipeline_texture: texture_2d<f32>;
+@group(0) @binding(1) var sampler_: sampler;
+
+@fragment
+fn fs_blit(@location(0) uv: vec2f) -> @location(0) vec4f {
+    return textureSample(pipeline_texture, sampler_, uv);
+}

--- a/src/platform/cross/shaders/mono_sprites.wgsl
+++ b/src/platform/cross/shaders/mono_sprites.wgsl
@@ -232,6 +232,7 @@ fn blend_color(color: vec4<f32>, alpha_factor: f32) -> vec4<f32> {
 @group(2) @binding(1) var s_sprite: sampler;
 
 @group(3) @binding(0) var<storage, read> b_mono_sprites: array<MonochromeSprite>;
+@group(3) @binding(1) var<storage, read> b_mono_sprite_instances: array<u32>;
 
 struct MonoSpriteVarying {
     @builtin(position) position: vec4<f32>,
@@ -243,7 +244,8 @@ struct MonoSpriteVarying {
 @vertex
 fn vs_mono_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> MonoSpriteVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    let sprite = b_mono_sprites[instance_id];
+    let slot = b_mono_sprite_instances[instance_id];
+    let sprite = b_mono_sprites[slot];
 
     var out = MonoSpriteVarying();
     out.position = to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation);

--- a/src/platform/cross/shaders/poly_sprites.wgsl
+++ b/src/platform/cross/shaders/poly_sprites.wgsl
@@ -57,6 +57,7 @@ struct PolySpriteVarying {
 @group(1) @binding(0) var t_sprite: texture_2d<f32>;
 @group(1) @binding(1) var s_sprite: sampler;
 @group(2) @binding(0) var<storage, read> b_poly_sprites: array<PolychromeSprite>;
+@group(2) @binding(1) var<storage, read> b_poly_sprite_instances: array<u32>;
 
 fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
     let device_position = position / globals.viewport_size * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0);
@@ -130,12 +131,13 @@ fn quad_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners) -> f32 {
 @vertex
 fn vs_poly_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> PolySpriteVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    let sprite = b_poly_sprites[instance_id];
+    let slot = b_poly_sprite_instances[instance_id];
+    let sprite = b_poly_sprites[slot];
 
     var out = PolySpriteVarying();
     out.position = to_device_position(unit_vertex, sprite.bounds);
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
-    out.sprite_id = instance_id;
+    out.sprite_id = slot;
     out.clip_distances = distance_from_clip_rect(unit_vertex, sprite.bounds, sprite.content_mask);
     return out;
 }

--- a/src/platform/cross/shaders/quads.wgsl
+++ b/src/platform/cross/shaders/quads.wgsl
@@ -79,6 +79,7 @@ struct QuadVarying {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<storage, read> b_quads: array<Quad>;
+@group(1) @binding(1) var<storage, read> b_quad_instances: array<u32>;
 
 /// Convert an Oklab color to linear sRGB space.
 fn oklab_to_linear_srgb(color: vec4<f32>) -> vec4<f32> {
@@ -457,7 +458,8 @@ fn over(below: vec4<f32>, above: vec4<f32>) -> vec4<f32> {
 @vertex
 fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> QuadVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    let quad = b_quads[instance_id];
+    let slot = b_quad_instances[instance_id];
+    let quad = b_quads[slot];
 
     var out = QuadVarying();
     out.position = to_device_position(unit_vertex, quad.bounds);
@@ -474,7 +476,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     out.background_color0 = gradient.color0;
     out.background_color1 = gradient.color1;
     out.border_color = hsla_to_rgba(quad.border_color);
-    out.quad_id = instance_id;
+    out.quad_id = slot;
     out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
     return out;
 }

--- a/src/platform/cross/shaders/shadows.wgsl
+++ b/src/platform/cross/shaders/shadows.wgsl
@@ -43,6 +43,7 @@ struct ShadowVarying {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<storage, read> b_shadows: array<Shadow>;
+@group(1) @binding(1) var<storage, read> b_shadow_instances: array<u32>;
 
 fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
     let device_position = position / globals.viewport_size * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0);
@@ -143,7 +144,8 @@ fn blur_along_x(x: f32, y: f32, sigma: f32, corner: f32, half_size: vec2<f32>) -
 @vertex
 fn vs_shadow(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> ShadowVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    var shadow = b_shadows[instance_id];
+    let slot = b_shadow_instances[instance_id];
+    var shadow = b_shadows[slot];
 
     let margin = 3.0 * shadow.blur_radius;
     shadow.bounds.origin -= vec2<f32>(margin);
@@ -152,7 +154,7 @@ fn vs_shadow(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) ins
     var out = ShadowVarying();
     out.position = to_device_position(unit_vertex, shadow.bounds);
     out.color = hsla_to_rgba(shadow.color);
-    out.shadow_id = instance_id;
+    out.shadow_id = slot;
     out.clip_distances = distance_from_clip_rect(unit_vertex, shadow.bounds, shadow.content_mask);
     return out;
 }

--- a/src/platform/cross/shaders/underlines.wgsl
+++ b/src/platform/cross/shaders/underlines.wgsl
@@ -37,6 +37,7 @@ struct UnderlineVarying {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 @group(1) @binding(0) var<storage, read> b_underlines: array<Underline>;
+@group(1) @binding(1) var<storage, read> b_underline_instances: array<u32>;
 
 fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
     let device_position = position / globals.viewport_size * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0);
@@ -102,12 +103,13 @@ fn blend_color(color: vec4<f32>, alpha_factor: f32) -> vec4<f32> {
 @vertex
 fn vs_underline(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> UnderlineVarying {
     let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
-    let underline = b_underlines[instance_id];
+    let slot = b_underline_instances[instance_id];
+    let underline = b_underlines[slot];
 
     var out = UnderlineVarying();
     out.position = to_device_position(unit_vertex, underline.bounds);
     out.color = hsla_to_rgba(underline.color);
-    out.underline_id = instance_id;
+    out.underline_id = slot;
     out.clip_distances = distance_from_clip_rect(unit_vertex, underline.bounds, underline.content_mask);
     return out;
 }

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -407,6 +407,14 @@ impl PlatformWindow for CrossWindow {
         }
     }
 
+    fn try_present(&self) -> bool {
+        if let Some(renderer) = self.0.renderer.get() {
+            renderer.borrow().try_present()
+        } else {
+            false
+        }
+    }
+
     fn present_framebuffer_only(&self) {
         if let Some(renderer) = self.0.renderer.get() {
             renderer.borrow().present_framebuffer_only();

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -407,6 +407,12 @@ impl PlatformWindow for CrossWindow {
         }
     }
 
+    fn record_scroll(&self, delta: Point<Pixels>) {
+        if let Some(renderer) = self.0.renderer.get() {
+            renderer.borrow().record_scroll(crate::geometry::point(delta.x.0, delta.y.0));
+        }
+    }
+
     fn try_present(&self) -> bool {
         if let Some(renderer) = self.0.renderer.get() {
             renderer.borrow().try_present()

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -18,7 +18,7 @@ pub(crate) type PathVertex_ScaledPixels = PathVertex<ScaledPixels>;
 
 pub(crate) type DrawOrder = u32;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct Scene {
     pub(crate) paint_operations: Vec<PaintOperation>,
     primitive_bounds: BoundsTree<ScaledPixels>,
@@ -231,6 +231,7 @@ pub(crate) enum PrimitiveKind {
     FilterBoundaryEnd,
 }
 
+#[derive(Clone)]
 pub(crate) enum PaintOperation {
     Primitive(Primitive),
     StartLayer(Bounds<ScaledPixels>),

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -8,9 +8,7 @@ use crate::{
 };
 use std::{
     fmt::Debug,
-    iter::Peekable,
-    ops::{Add, Range, Sub},
-    slice,
+    ops::{Add, Sub},
 };
 
 #[allow(non_camel_case_types, unused)]
@@ -18,36 +16,230 @@ pub(crate) type PathVertex_ScaledPixels = PathVertex<ScaledPixels>;
 
 pub(crate) type DrawOrder = u32;
 
+/// A persistent slot in a generational arena.
+#[derive(Clone)]
+pub(crate) struct GenSlot<T> {
+    pub data: T,
+    pub version: u64,
+}
+
+/// Persistent generational arena for GPU buffer data.
+#[derive(Clone)]
+pub(crate) struct GenerationalVec<T> {
+    pub slots: Vec<Option<GenSlot<T>>>,
+    pub free: Vec<usize>,
+    pub generation: u64,
+}
+
+impl<T: Clone> GenerationalVec<T> {
+    pub fn new() -> Self {
+        Self { slots: Vec::new(), free: Vec::new(), generation: 0 }
+    }
+
+    pub fn allocate(&mut self) -> usize {
+        if let Some(idx) = self.free.pop() {
+            self.slots[idx] = Some(GenSlot {
+                data: unsafe { std::mem::zeroed() },
+                version: 0,
+            });
+            idx
+        } else {
+            let idx = self.slots.len();
+            self.slots.push(Some(GenSlot {
+                data: unsafe { std::mem::zeroed() },
+                version: 0,
+            }));
+            idx
+        }
+    }
+
+    pub fn free(&mut self, idx: usize) {
+        if idx < self.slots.len() {
+            self.slots[idx] = None;
+            self.free.push(idx);
+        }
+    }
+
+    pub fn write(&mut self, idx: usize, data: T) {
+        if let Some(Some(slot)) = self.slots.get_mut(idx) {
+            slot.data = data;
+            self.generation += 1;
+            slot.version = self.generation;
+        }
+    }
+
+    pub fn get(&self, idx: usize) -> Option<&T> {
+        self.slots.get(idx).and_then(|s| s.as_ref().map(|s| &s.data))
+    }
+
+    pub fn get_mut(&mut self, idx: usize) -> Option<&mut T> {
+        self.slots.get_mut(idx).and_then(|s| s.as_mut().map(|s| &mut s.data))
+    }
+
+    pub fn drain_changes_since(&self, since_generation: u64) -> Vec<usize> {
+        self.slots.iter().enumerate()
+            .filter_map(|(idx, slot)| {
+                slot.as_ref()
+                    .filter(|s| s.version > since_generation)
+                    .map(|_| idx)
+            })
+            .collect()
+    }
+
+    pub fn allocated_count(&self) -> usize {
+        self.slots.iter().filter(|s| s.is_some()).count()
+    }
+
+    pub fn clear(&mut self) {
+        self.slots.clear();
+        self.free.clear();
+    }
+}
+
+impl<T: Clone> Default for GenerationalVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Records one changed slot for the GPU upload path
+#[derive(Clone, Debug)]
+pub(crate) struct ChangedSlot {
+    pub slot: usize,
+    pub byte_offset: u64,
+    pub byte_length: u64,
+    pub bounds: Bounds<ScaledPixels>,
+}
+
+/// Accumulated changes during a single frame's paint phase.
+#[derive(Clone, Debug)]
+pub(crate) struct SceneDelta {
+    pub changed_quads: Vec<ChangedSlot>,
+    pub changed_shadows: Vec<ChangedSlot>,
+    pub changed_backdrop_filters: Vec<ChangedSlot>,
+    pub changed_underlines: Vec<ChangedSlot>,
+    pub changed_monochrome_sprites: Vec<ChangedSlot>,
+    pub changed_polychrome_sprites: Vec<ChangedSlot>,
+    pub changed_surfaces: Vec<ChangedSlot>,
+    pub paths_changed: bool,
+    pub damage_rect: Option<Bounds<ScaledPixels>>,
+    pub is_empty: bool,
+}
+
+impl SceneDelta {
+    pub fn new() -> Self {
+        Self {
+            changed_quads: Vec::new(),
+            changed_shadows: Vec::new(),
+            changed_backdrop_filters: Vec::new(),
+            changed_underlines: Vec::new(),
+            changed_monochrome_sprites: Vec::new(),
+            changed_polychrome_sprites: Vec::new(),
+            changed_surfaces: Vec::new(),
+            paths_changed: false,
+            damage_rect: None,
+            is_empty: true,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.changed_quads.clear();
+        self.changed_shadows.clear();
+        self.changed_backdrop_filters.clear();
+        self.changed_underlines.clear();
+        self.changed_monochrome_sprites.clear();
+        self.changed_polychrome_sprites.clear();
+        self.changed_surfaces.clear();
+        self.paths_changed = false;
+        self.damage_rect = None;
+        self.is_empty = true;
+    }
+
+    pub fn add_damage(&mut self, bounds: Bounds<ScaledPixels>) {
+        self.damage_rect = Some(match self.damage_rect {
+            Some(existing) => existing.union(&bounds),
+            None => bounds,
+        });
+    }
+}
+
+impl Default for SceneDelta {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Tracks which generational-vec slots each primitive type occupies for a paint operation.
+#[derive(Clone, Debug)]
+pub(crate) struct PaintOperationSlots {
+    pub quad_slot: Option<usize>,
+    pub shadow_slot: Option<usize>,
+    pub backdrop_filter_slot: Option<usize>,
+    pub underline_slot: Option<usize>,
+    pub mono_sprite_slot: Option<usize>,
+    pub poly_sprite_slot: Option<usize>,
+    pub surface_slot: Option<usize>,
+    pub path_slot: Option<usize>,
+}
+
 #[derive(Default, Clone)]
 pub(crate) struct Scene {
     pub(crate) paint_operations: Vec<PaintOperation>,
+    pub(crate) paint_slots: Vec<Option<PaintOperationSlots>>,
     primitive_bounds: BoundsTree<ScaledPixels>,
     layer_stack: Vec<DrawOrder>,
-    pub(crate) shadows: Vec<Shadow>,
-    pub(crate) backdrop_filters: Vec<BackdropFilter>,
+
+    // === PERSISTENT GENERATIONAL ARENAS (NOT cleared per frame) ===
+    pub(crate) quads: GenerationalVec<Quad>,
+    pub(crate) shadows: GenerationalVec<Shadow>,
+    pub(crate) backdrop_filters: GenerationalVec<BackdropFilter>,
+    pub(crate) underlines: GenerationalVec<Underline>,
+    pub(crate) monochrome_sprites: GenerationalVec<MonochromeSprite>,
+    pub(crate) polychrome_sprites: GenerationalVec<PolychromeSprite>,
+    pub(crate) surfaces: GenerationalVec<PaintSurface>,
+    pub(crate) paths: GenerationalVec<Path<ScaledPixels>>,
+
+    // Filter boundaries (always rebuilt — NOT in a generational vec)
     pub(crate) filter_boundaries: Vec<FilterBoundary>,
-    pub(crate) quads: Vec<Quad>,
-    pub(crate) paths: Vec<Path<ScaledPixels>>,
-    pub(crate) underlines: Vec<Underline>,
-    pub(crate) monochrome_sprites: Vec<MonochromeSprite>,
-    pub(crate) polychrome_sprites: Vec<PolychromeSprite>,
-    pub(crate) surfaces: Vec<PaintSurface>,
+
+    // === SORTED DRAW-ORDER INDICES (indirection buffers) ===
+    pub(crate) sorted_quad_indices: Vec<u32>,
+    pub(crate) sorted_shadow_indices: Vec<u32>,
+    pub(crate) sorted_backdrop_filter_indices: Vec<u32>,
+    pub(crate) sorted_underline_indices: Vec<u32>,
+    pub(crate) sorted_mono_sprite_indices: Vec<u32>,
+    pub(crate) sorted_poly_sprite_indices: Vec<u32>,
+    pub(crate) sorted_surface_indices: Vec<u32>,
+    pub(crate) sorted_path_indices: Vec<u32>,
+
+    // === DELTA ACCUMULATION ===
+    pub(crate) pending_delta: SceneDelta,
+    pub(crate) last_uploaded_quad_gen: u64,
+    pub(crate) last_uploaded_shadow_gen: u64,
+    pub(crate) last_uploaded_backdrop_filter_gen: u64,
+    pub(crate) last_uploaded_underline_gen: u64,
+    pub(crate) last_uploaded_mono_sprite_gen: u64,
+    pub(crate) last_uploaded_poly_sprite_gen: u64,
+    pub(crate) last_uploaded_surface_gen: u64,
+    pub(crate) last_uploaded_path_gen: u64,
 }
 
 impl Scene {
     pub fn clear(&mut self) {
         self.paint_operations.clear();
+        self.paint_slots.clear();
         self.primitive_bounds.clear();
         self.layer_stack.clear();
-        self.paths.clear();
-        self.shadows.clear();
-        self.backdrop_filters.clear();
         self.filter_boundaries.clear();
-        self.quads.clear();
-        self.underlines.clear();
-        self.monochrome_sprites.clear();
-        self.polychrome_sprites.clear();
-        self.surfaces.clear();
+        self.sorted_quad_indices.clear();
+        self.sorted_shadow_indices.clear();
+        self.sorted_backdrop_filter_indices.clear();
+        self.sorted_underline_indices.clear();
+        self.sorted_mono_sprite_indices.clear();
+        self.sorted_poly_sprite_indices.clear();
+        self.sorted_surface_indices.clear();
+        self.sorted_path_indices.clear();
+        self.pending_delta.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -57,12 +249,14 @@ impl Scene {
     pub fn push_layer(&mut self, bounds: Bounds<ScaledPixels>) {
         let order = self.primitive_bounds.insert(bounds);
         self.layer_stack.push(order);
+        self.paint_slots.push(None);
         self.paint_operations
             .push(PaintOperation::StartLayer(bounds));
     }
 
     pub fn pop_layer(&mut self) {
         self.layer_stack.pop();
+        self.paint_slots.push(None);
         self.paint_operations.push(PaintOperation::EndLayer);
     }
 
@@ -81,18 +275,13 @@ impl Scene {
             .bounds()
             .intersect(&primitive.content_mask().bounds);
 
-        // Content-filter boundaries must always be inserted as matched pairs — dropping one
-        // (e.g. for an empty clipped region) would orphan its partner and corrupt the renderer's
-        // target stack. Each marker takes an order strictly above ALL prior content, so the start
-        // sorts after everything painted before it and the element's own children (which overlap
-        // the marker bounds) sort strictly above the start. This keeps a marker's order range from
-        // colliding with unrelated non-overlapping content that reuses low orderings (e.g. a
-        // background grid), which would otherwise sweep that content into the group.
         let is_filter_boundary = matches!(primitive, Primitive::FilterBoundary(_));
 
         if clipped_bounds.is_empty() && !is_filter_boundary {
             return;
         }
+
+        self.pending_delta.is_empty = false;
 
         let order = if is_filter_boundary {
             let order_bounds = if clipped_bounds.is_empty() {
@@ -107,14 +296,39 @@ impl Scene {
                 .copied()
                 .unwrap_or_else(|| self.primitive_bounds.insert(clipped_bounds))
         };
+
+        let mut slots = PaintOperationSlots {
+            quad_slot: None, shadow_slot: None, backdrop_filter_slot: None,
+            underline_slot: None, mono_sprite_slot: None, poly_sprite_slot: None,
+            surface_slot: None, path_slot: None,
+        };
+
         match &mut primitive {
             Primitive::Shadow(shadow) => {
                 shadow.order = order;
-                self.shadows.push(shadow.clone());
+                let slot = self.shadows.allocate();
+                self.shadows.write(slot, shadow.clone());
+                slots.shadow_slot = Some(slot);
+                self.pending_delta.changed_shadows.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<Shadow>() as u64,
+                    byte_length: std::mem::size_of::<Shadow>() as u64,
+                    bounds: shadow.bounds,
+                });
+                self.pending_delta.add_damage(shadow.bounds);
             }
             Primitive::BackdropFilter(filter) => {
                 filter.order = order;
-                self.backdrop_filters.push(*filter);
+                let slot = self.backdrop_filters.allocate();
+                self.backdrop_filters.write(slot, *filter);
+                slots.backdrop_filter_slot = Some(slot);
+                self.pending_delta.changed_backdrop_filters.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<BackdropFilter>() as u64,
+                    byte_length: std::mem::size_of::<BackdropFilter>() as u64,
+                    bounds: filter.bounds,
+                });
+                self.pending_delta.add_damage(filter.bounds);
             }
             Primitive::FilterBoundary(boundary) => {
                 boundary.order = order;
@@ -122,92 +336,286 @@ impl Scene {
             }
             Primitive::Quad(quad) => {
                 quad.order = order;
-                self.quads.push(quad.clone());
+                let slot = self.quads.allocate();
+                self.quads.write(slot, quad.clone());
+                slots.quad_slot = Some(slot);
+                self.pending_delta.changed_quads.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<Quad>() as u64,
+                    byte_length: std::mem::size_of::<Quad>() as u64,
+                    bounds: quad.bounds,
+                });
+                self.pending_delta.add_damage(quad.bounds);
             }
             Primitive::Path(path) => {
                 path.order = order;
-                path.id = PathId(self.paths.len());
-                self.paths.push(path.clone());
+                let slot = self.paths.allocate();
+                self.paths.write(slot, path.clone());
+                slots.path_slot = Some(slot);
+                self.pending_delta.paths_changed = true;
+                self.pending_delta.add_damage(path.bounds);
             }
             Primitive::Underline(underline) => {
                 underline.order = order;
-                self.underlines.push(underline.clone());
+                let slot = self.underlines.allocate();
+                self.underlines.write(slot, underline.clone());
+                slots.underline_slot = Some(slot);
+                self.pending_delta.changed_underlines.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<Underline>() as u64,
+                    byte_length: std::mem::size_of::<Underline>() as u64,
+                    bounds: underline.bounds,
+                });
+                self.pending_delta.add_damage(underline.bounds);
             }
             Primitive::MonochromeSprite(sprite) => {
                 sprite.order = order;
-                self.monochrome_sprites.push(sprite.clone());
+                let slot = self.monochrome_sprites.allocate();
+                self.monochrome_sprites.write(slot, sprite.clone());
+                slots.mono_sprite_slot = Some(slot);
+                self.pending_delta.changed_monochrome_sprites.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<MonochromeSprite>() as u64,
+                    byte_length: std::mem::size_of::<MonochromeSprite>() as u64,
+                    bounds: sprite.bounds,
+                });
+                self.pending_delta.add_damage(sprite.bounds);
             }
             Primitive::PolychromeSprite(sprite) => {
                 sprite.order = order;
-                self.polychrome_sprites.push(sprite.clone());
+                let slot = self.polychrome_sprites.allocate();
+                self.polychrome_sprites.write(slot, sprite.clone());
+                slots.poly_sprite_slot = Some(slot);
+                self.pending_delta.changed_polychrome_sprites.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<PolychromeSprite>() as u64,
+                    byte_length: std::mem::size_of::<PolychromeSprite>() as u64,
+                    bounds: sprite.bounds,
+                });
+                self.pending_delta.add_damage(sprite.bounds);
             }
             Primitive::Surface(surface) => {
                 surface.order = order;
-                self.surfaces.push(surface.clone());
+                let slot = self.surfaces.allocate();
+                self.surfaces.write(slot, surface.clone());
+                slots.surface_slot = Some(slot);
+                self.pending_delta.changed_surfaces.push(ChangedSlot {
+                    slot,
+                    byte_offset: slot as u64 * std::mem::size_of::<PaintSurface>() as u64,
+                    byte_length: std::mem::size_of::<PaintSurface>() as u64,
+                    bounds: surface.bounds,
+                });
+                self.pending_delta.add_damage(surface.bounds);
             }
         }
-        self.paint_operations
-            .push(PaintOperation::Primitive(primitive));
-    }
 
-    pub fn replay(&mut self, range: Range<usize>, prev_scene: &Scene) {
-        for operation in &prev_scene.paint_operations[range] {
-            match operation {
-                PaintOperation::Primitive(primitive) => self.insert_primitive(primitive.clone()),
-                PaintOperation::StartLayer(bounds) => self.push_layer(*bounds),
-                PaintOperation::EndLayer => self.pop_layer(),
-            }
+        if is_filter_boundary {
+            self.paint_slots.push(None);
+        } else {
+            self.paint_slots.push(Some(slots));
         }
+        self.paint_operations.push(PaintOperation::Primitive(primitive));
     }
 
-    pub fn finish(&mut self) {
-        self.shadows.sort_by_key(|shadow| shadow.order);
-        self.quads.sort_by_key(|quad| quad.order);
-        self.paths.sort_by_key(|path| path.order);
-        self.underlines.sort_by_key(|underline| underline.order);
-        self.monochrome_sprites
-            .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
-        self.polychrome_sprites
-            .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
-        self.surfaces.sort_by_key(|surface| surface.order);
-        self.backdrop_filters.sort_by_key(|filter| filter.order);
-        // Markers normally get distinct, monotonically-increasing orders (children overlap
-        // their group bounds and so sort strictly between the start and end). The `!is_start`
-        // tiebreak only matters for a degenerate empty group whose start and end tie: it keeps
-        // the start (false = 0) ahead of the end (true = 1) so the pair stays well-formed.
+    pub fn replay(&mut self, operation: &PaintOperation, slot_info: &Option<PaintOperationSlots>) {
+        self.paint_operations.push(operation.clone());
+        self.paint_slots.push(slot_info.clone());
+    }
+
+    pub fn sort(&mut self) {
         self.filter_boundaries
             .sort_by_key(|boundary| (boundary.order, !boundary.is_start));
+        self.build_indirection_buffers();
+        self.free_orphaned_slots();
+    }
+
+    pub fn free_orphaned_slots(&mut self) {
+        let used_quads: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.quad_slot).collect();
+        let used_shadows: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.shadow_slot).collect();
+        let used_backdrop_filters: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.backdrop_filter_slot).collect();
+        let used_underlines: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.underline_slot).collect();
+        let used_mono_sprites: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.mono_sprite_slot).collect();
+        let used_poly_sprites: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.poly_sprite_slot).collect();
+        let used_surfaces: std::collections::HashSet<usize> = self.paint_slots.iter()
+            .filter_map(|s| s.as_ref()?.surface_slot).collect();
+
+        for idx in 0..self.quads.slots.len() {
+            if self.quads.slots[idx].is_some() && !used_quads.contains(&idx) {
+                self.quads.free(idx);
+            }
+        }
+        for idx in 0..self.shadows.slots.len() {
+            if self.shadows.slots[idx].is_some() && !used_shadows.contains(&idx) {
+                self.shadows.free(idx);
+            }
+        }
+        for idx in 0..self.backdrop_filters.slots.len() {
+            if self.backdrop_filters.slots[idx].is_some() && !used_backdrop_filters.contains(&idx) {
+                self.backdrop_filters.free(idx);
+            }
+        }
+        for idx in 0..self.underlines.slots.len() {
+            if self.underlines.slots[idx].is_some() && !used_underlines.contains(&idx) {
+                self.underlines.free(idx);
+            }
+        }
+        for idx in 0..self.monochrome_sprites.slots.len() {
+            if self.monochrome_sprites.slots[idx].is_some() && !used_mono_sprites.contains(&idx) {
+                self.monochrome_sprites.free(idx);
+            }
+        }
+        for idx in 0..self.polychrome_sprites.slots.len() {
+            if self.polychrome_sprites.slots[idx].is_some() && !used_poly_sprites.contains(&idx) {
+                self.polychrome_sprites.free(idx);
+            }
+        }
+        for idx in 0..self.surfaces.slots.len() {
+            if self.surfaces.slots[idx].is_some() && !used_surfaces.contains(&idx) {
+                self.surfaces.free(idx);
+            }
+        }
+    }
+
+    fn build_indirection_buffers(&mut self) {
+        let mut quad_pairs: Vec<(u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::Quad(quad)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.quad_slot {
+                        quad_pairs.push((quad.order, slot as u32));
+                    }
+                }
+            }
+        }
+        quad_pairs.sort_by_key(|(order, _)| *order);
+        self.sorted_quad_indices = quad_pairs.into_iter().map(|(_, slot)| slot).collect();
+
+        let mut shadow_pairs: Vec<(u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::Shadow(shadow)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.shadow_slot {
+                        shadow_pairs.push((shadow.order, slot as u32));
+                    }
+                }
+            }
+        }
+        shadow_pairs.sort_by_key(|(order, _)| *order);
+        self.sorted_shadow_indices = shadow_pairs.into_iter().map(|(_, slot)| slot).collect();
+
+        let mut bf_pairs: Vec<(u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::BackdropFilter(bf)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.backdrop_filter_slot {
+                        bf_pairs.push((bf.order, slot as u32));
+                    }
+                }
+            }
+        }
+        bf_pairs.sort_by_key(|(order, _)| *order);
+        self.sorted_backdrop_filter_indices = bf_pairs.into_iter().map(|(_, slot)| slot).collect();
+
+        let mut ul_pairs: Vec<(u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::Underline(ul)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.underline_slot {
+                        ul_pairs.push((ul.order, slot as u32));
+                    }
+                }
+            }
+        }
+        ul_pairs.sort_by_key(|(order, _)| *order);
+        self.sorted_underline_indices = ul_pairs.into_iter().map(|(_, slot)| slot).collect();
+
+        let mut mono_pairs: Vec<(u32, u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::MonochromeSprite(sprite)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.mono_sprite_slot {
+                        mono_pairs.push((sprite.order, sprite.tile.texture_id.index, slot as u32));
+                    }
+                }
+            }
+        }
+        mono_pairs.sort_by_key(|(order, _, _)| *order);
+        self.sorted_mono_sprite_indices = mono_pairs.into_iter().map(|(_, _, slot)| slot).collect();
+
+        let mut poly_pairs: Vec<(u32, u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::PolychromeSprite(sprite)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.poly_sprite_slot {
+                        poly_pairs.push((sprite.order, sprite.tile.texture_id.index, slot as u32));
+                    }
+                }
+            }
+        }
+        poly_pairs.sort_by_key(|(order, _, _)| *order);
+        self.sorted_poly_sprite_indices = poly_pairs.into_iter().map(|(_, _, slot)| slot).collect();
+
+        let mut surface_pairs: Vec<(u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::Surface(surface)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.surface_slot {
+                        surface_pairs.push((surface.order, slot as u32));
+                    }
+                }
+            }
+        }
+        surface_pairs.sort_by_key(|(order, _)| *order);
+        self.sorted_surface_indices = surface_pairs.into_iter().map(|(_, slot)| slot).collect();
+
+        let mut path_pairs: Vec<(u32, u32)> = Vec::new();
+        for (op, slots) in self.paint_operations.iter().zip(self.paint_slots.iter()) {
+            if let PaintOperation::Primitive(Primitive::Path(path)) = op {
+                if let Some(slots) = slots {
+                    if let Some(slot) = slots.path_slot {
+                        path_pairs.push((path.order, slot as u32));
+                    }
+                }
+            }
+        }
+        path_pairs.sort_by_key(|(order, _)| *order);
+        self.sorted_path_indices = path_pairs.into_iter().map(|(_, slot)| slot).collect();
     }
 
     pub(crate) fn batches(&self) -> impl Iterator<Item = PrimitiveBatch<'_>> {
         BatchIterator {
-            shadows: &self.shadows,
-            shadows_start: 0,
-            shadows_iter: self.shadows.iter().peekable(),
-            quads: &self.quads,
-            quads_start: 0,
-            quads_iter: self.quads.iter().peekable(),
-            paths: &self.paths,
-            paths_start: 0,
-            paths_iter: self.paths.iter().peekable(),
-            underlines: &self.underlines,
-            underlines_start: 0,
-            underlines_iter: self.underlines.iter().peekable(),
-            monochrome_sprites: &self.monochrome_sprites,
-            monochrome_sprites_start: 0,
-            monochrome_sprites_iter: self.monochrome_sprites.iter().peekable(),
-            polychrome_sprites: &self.polychrome_sprites,
-            polychrome_sprites_start: 0,
-            polychrome_sprites_iter: self.polychrome_sprites.iter().peekable(),
-            surfaces: &self.surfaces,
-            surfaces_start: 0,
-            surfaces_iter: self.surfaces.iter().peekable(),
-            backdrop_filters: &self.backdrop_filters,
-            backdrop_filters_start: 0,
-            backdrop_filters_iter: self.backdrop_filters.iter().peekable(),
+            quad_indices: &self.sorted_quad_indices,
+            quad_data: &self.quads,
+            quad_cursor: 0,
+            shadow_indices: &self.sorted_shadow_indices,
+            shadow_data: &self.shadows,
+            shadow_cursor: 0,
+            path_indices: &self.sorted_path_indices,
+            path_data: &self.paths,
+            path_cursor: 0,
+            underline_indices: &self.sorted_underline_indices,
+            underline_data: &self.underlines,
+            underline_cursor: 0,
+            mono_sprite_indices: &self.sorted_mono_sprite_indices,
+            mono_sprite_data: &self.monochrome_sprites,
+            mono_sprite_cursor: 0,
+            poly_sprite_indices: &self.sorted_poly_sprite_indices,
+            poly_sprite_data: &self.polychrome_sprites,
+            poly_sprite_cursor: 0,
+            surface_indices: &self.sorted_surface_indices,
+            surface_data: &self.surfaces,
+            surface_cursor: 0,
+            backdrop_filter_indices: &self.sorted_backdrop_filter_indices,
+            backdrop_filter_data: &self.backdrop_filters,
+            backdrop_filter_cursor: 0,
             filter_boundaries: &self.filter_boundaries,
-            filter_boundaries_start: 0,
-            filter_boundaries_iter: self.filter_boundaries.iter().peekable(),
+            filter_boundaries_cursor: 0,
         }
     }
 }
@@ -281,34 +689,97 @@ impl Primitive {
     }
 }
 
+pub(crate) unsafe fn as_bytes<T>(slice: &[T]) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(
+            slice.as_ptr() as *const u8,
+            slice.len() * std::mem::size_of::<T>(),
+        )
+    }
+}
+
+/// Flatten a GenerationalVec into a byte buffer with zero-padding for free slots.
+/// Each live slot's data occupies `sizeof<T>()` bytes at `slot_index * sizeof<T>()`.
+pub(crate) fn flatten_generational_vec<T: Clone>(gv: &GenerationalVec<T>) -> Vec<u8> {
+    let elem_size = std::mem::size_of::<T>();
+    let mut bytes = Vec::with_capacity(gv.slots.len() * elem_size);
+    for slot in &gv.slots {
+        match slot {
+            Some(s) => {
+                let ptr = &s.data as *const T as *const u8;
+                let slice = unsafe { std::slice::from_raw_parts(ptr, elem_size) };
+                bytes.extend_from_slice(slice);
+            }
+            None => {
+                bytes.extend(std::iter::repeat(0u8).take(elem_size));
+            }
+        }
+    }
+    bytes
+}
+
 struct BatchIterator<'a> {
-    shadows: &'a [Shadow],
-    shadows_start: usize,
-    shadows_iter: Peekable<slice::Iter<'a, Shadow>>,
-    quads: &'a [Quad],
-    quads_start: usize,
-    quads_iter: Peekable<slice::Iter<'a, Quad>>,
-    paths: &'a [Path<ScaledPixels>],
-    paths_start: usize,
-    paths_iter: Peekable<slice::Iter<'a, Path<ScaledPixels>>>,
-    underlines: &'a [Underline],
-    underlines_start: usize,
-    underlines_iter: Peekable<slice::Iter<'a, Underline>>,
-    monochrome_sprites: &'a [MonochromeSprite],
-    monochrome_sprites_start: usize,
-    monochrome_sprites_iter: Peekable<slice::Iter<'a, MonochromeSprite>>,
-    polychrome_sprites: &'a [PolychromeSprite],
-    polychrome_sprites_start: usize,
-    polychrome_sprites_iter: Peekable<slice::Iter<'a, PolychromeSprite>>,
-    surfaces: &'a [PaintSurface],
-    surfaces_start: usize,
-    surfaces_iter: Peekable<slice::Iter<'a, PaintSurface>>,
-    backdrop_filters: &'a [BackdropFilter],
-    backdrop_filters_start: usize,
-    backdrop_filters_iter: Peekable<slice::Iter<'a, BackdropFilter>>,
+    quad_indices: &'a [u32],
+    quad_data: &'a GenerationalVec<Quad>,
+    quad_cursor: usize,
+    shadow_indices: &'a [u32],
+    shadow_data: &'a GenerationalVec<Shadow>,
+    shadow_cursor: usize,
+    path_indices: &'a [u32],
+    path_data: &'a GenerationalVec<Path<ScaledPixels>>,
+    path_cursor: usize,
+    underline_indices: &'a [u32],
+    underline_data: &'a GenerationalVec<Underline>,
+    underline_cursor: usize,
+    mono_sprite_indices: &'a [u32],
+    mono_sprite_data: &'a GenerationalVec<MonochromeSprite>,
+    mono_sprite_cursor: usize,
+    poly_sprite_indices: &'a [u32],
+    poly_sprite_data: &'a GenerationalVec<PolychromeSprite>,
+    poly_sprite_cursor: usize,
+    surface_indices: &'a [u32],
+    surface_data: &'a GenerationalVec<PaintSurface>,
+    surface_cursor: usize,
+    backdrop_filter_indices: &'a [u32],
+    backdrop_filter_data: &'a GenerationalVec<BackdropFilter>,
+    backdrop_filter_cursor: usize,
     filter_boundaries: &'a [FilterBoundary],
-    filter_boundaries_start: usize,
-    filter_boundaries_iter: Peekable<slice::Iter<'a, FilterBoundary>>,
+    filter_boundaries_cursor: usize,
+}
+
+impl<'a> BatchIterator<'a> {
+    fn peek_shadow_order(&self) -> Option<u32> {
+        let slot = *self.shadow_indices.get(self.shadow_cursor)?;
+        self.shadow_data.get(slot as usize).map(|s| s.order)
+    }
+    fn peek_quad_order(&self) -> Option<u32> {
+        let slot = *self.quad_indices.get(self.quad_cursor)?;
+        self.quad_data.get(slot as usize).map(|q| q.order)
+    }
+    fn peek_path_order(&self) -> Option<u32> {
+        let slot = *self.path_indices.get(self.path_cursor)?;
+        self.path_data.get(slot as usize).map(|p| p.order)
+    }
+    fn peek_underline_order(&self) -> Option<u32> {
+        let slot = *self.underline_indices.get(self.underline_cursor)?;
+        self.underline_data.get(slot as usize).map(|u| u.order)
+    }
+    fn peek_mono_sprite_order(&self) -> Option<u32> {
+        let slot = *self.mono_sprite_indices.get(self.mono_sprite_cursor)?;
+        self.mono_sprite_data.get(slot as usize).map(|s| s.order)
+    }
+    fn peek_poly_sprite_order(&self) -> Option<u32> {
+        let slot = *self.poly_sprite_indices.get(self.poly_sprite_cursor)?;
+        self.poly_sprite_data.get(slot as usize).map(|s| s.order)
+    }
+    fn peek_surface_order(&self) -> Option<u32> {
+        let slot = *self.surface_indices.get(self.surface_cursor)?;
+        self.surface_data.get(slot as usize).map(|s| s.order)
+    }
+    fn peek_backdrop_filter_order(&self) -> Option<u32> {
+        let slot = *self.backdrop_filter_indices.get(self.backdrop_filter_cursor)?;
+        self.backdrop_filter_data.get(slot as usize).map(|f| f.order)
+    }
 }
 
 impl<'a> Iterator for BatchIterator<'a> {
@@ -316,38 +787,17 @@ impl<'a> Iterator for BatchIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut orders_and_kinds = [
+            (self.peek_shadow_order(), PrimitiveKind::Shadow),
+            (self.peek_quad_order(), PrimitiveKind::Quad),
+            (self.peek_path_order(), PrimitiveKind::Path),
+            (self.peek_underline_order(), PrimitiveKind::Underline),
+            (self.peek_mono_sprite_order(), PrimitiveKind::MonochromeSprite),
+            (self.peek_poly_sprite_order(), PrimitiveKind::PolychromeSprite),
+            (self.peek_surface_order(), PrimitiveKind::Surface),
+            (self.peek_backdrop_filter_order(), PrimitiveKind::BackdropFilter),
             (
-                self.shadows_iter.peek().map(|s| s.order),
-                PrimitiveKind::Shadow,
-            ),
-            (self.quads_iter.peek().map(|q| q.order), PrimitiveKind::Quad),
-            (self.paths_iter.peek().map(|q| q.order), PrimitiveKind::Path),
-            (
-                self.underlines_iter.peek().map(|u| u.order),
-                PrimitiveKind::Underline,
-            ),
-            (
-                self.monochrome_sprites_iter.peek().map(|s| s.order),
-                PrimitiveKind::MonochromeSprite,
-            ),
-            (
-                self.polychrome_sprites_iter.peek().map(|s| s.order),
-                PrimitiveKind::PolychromeSprite,
-            ),
-            (
-                self.surfaces_iter.peek().map(|s| s.order),
-                PrimitiveKind::Surface,
-            ),
-            (
-                self.backdrop_filters_iter.peek().map(|f| f.order),
-                PrimitiveKind::BackdropFilter,
-            ),
-            (
-                self.filter_boundaries_iter.peek().map(|b| b.order),
-                // The same vec yields both start and end markers; the discriminant decides
-                // where the next marker sorts relative to draw batches at an equal order
-                // (start before content, end after).
-                match self.filter_boundaries_iter.peek() {
+                self.filter_boundaries.get(self.filter_boundaries_cursor).map(|b| b.order),
+                match self.filter_boundaries.get(self.filter_boundaries_cursor) {
                     Some(boundary) if boundary.is_start => PrimitiveKind::FilterBoundaryStart,
                     _ => PrimitiveKind::FilterBoundaryEnd,
                 },
@@ -365,145 +815,118 @@ impl<'a> Iterator for BatchIterator<'a> {
 
         match batch_kind {
             PrimitiveKind::Shadow => {
-                let shadows_start = self.shadows_start;
-                let mut shadows_end = shadows_start + 1;
-                self.shadows_iter.next();
-                while self
-                    .shadows_iter
-                    .next_if(|shadow| (shadow.order, batch_kind) < max_order_and_kind)
-                    .is_some()
-                {
-                    shadows_end += 1;
+                let start = self.shadow_cursor;
+                self.shadow_cursor += 1;
+                while let Some(order) = self.peek_shadow_order() {
+                    if (order, batch_kind) < max_order_and_kind {
+                        self.shadow_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.shadows_start = shadows_end;
-                Some(PrimitiveBatch::Shadows(
-                    &self.shadows[shadows_start..shadows_end],
-                ))
+                Some(PrimitiveBatch::Shadows(&self.shadow_indices[start..self.shadow_cursor]))
             }
             PrimitiveKind::Quad => {
-                let quads_start = self.quads_start;
-                let mut quads_end = quads_start + 1;
-                self.quads_iter.next();
-                while self
-                    .quads_iter
-                    .next_if(|quad| (quad.order, batch_kind) < max_order_and_kind)
-                    .is_some()
-                {
-                    quads_end += 1;
+                let start = self.quad_cursor;
+                self.quad_cursor += 1;
+                while let Some(order) = self.peek_quad_order() {
+                    if (order, batch_kind) < max_order_and_kind {
+                        self.quad_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.quads_start = quads_end;
-                Some(PrimitiveBatch::Quads(&self.quads[quads_start..quads_end]))
+                Some(PrimitiveBatch::Quads(&self.quad_indices[start..self.quad_cursor]))
             }
             PrimitiveKind::Path => {
-                let paths_start = self.paths_start;
-                let mut paths_end = paths_start + 1;
-                self.paths_iter.next();
-                while self
-                    .paths_iter
-                    .next_if(|path| (path.order, batch_kind) < max_order_and_kind)
-                    .is_some()
-                {
-                    paths_end += 1;
+                let start = self.path_cursor;
+                self.path_cursor += 1;
+                while let Some(order) = self.peek_path_order() {
+                    if (order, batch_kind) < max_order_and_kind {
+                        self.path_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.paths_start = paths_end;
-                Some(PrimitiveBatch::Paths(&self.paths[paths_start..paths_end]))
+                Some(PrimitiveBatch::Paths(&self.path_indices[start..self.path_cursor]))
             }
             PrimitiveKind::Underline => {
-                let underlines_start = self.underlines_start;
-                let mut underlines_end = underlines_start + 1;
-                self.underlines_iter.next();
-                while self
-                    .underlines_iter
-                    .next_if(|underline| (underline.order, batch_kind) < max_order_and_kind)
-                    .is_some()
-                {
-                    underlines_end += 1;
+                let start = self.underline_cursor;
+                self.underline_cursor += 1;
+                while let Some(order) = self.peek_underline_order() {
+                    if (order, batch_kind) < max_order_and_kind {
+                        self.underline_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.underlines_start = underlines_end;
-                Some(PrimitiveBatch::Underlines(
-                    &self.underlines[underlines_start..underlines_end],
-                ))
+                Some(PrimitiveBatch::Underlines(&self.underline_indices[start..self.underline_cursor]))
             }
             PrimitiveKind::MonochromeSprite => {
-                let texture_id = self.monochrome_sprites_iter.peek().unwrap().tile.texture_id;
-                let sprites_start = self.monochrome_sprites_start;
-                let mut sprites_end = sprites_start + 1;
-                self.monochrome_sprites_iter.next();
-                while self
-                    .monochrome_sprites_iter
-                    .next_if(|sprite| {
-                        (sprite.order, batch_kind) < max_order_and_kind
-                            && sprite.tile.texture_id == texture_id
-                    })
-                    .is_some()
-                {
-                    sprites_end += 1;
+                let slot = self.mono_sprite_indices[self.mono_sprite_cursor] as usize;
+                let texture_id = self.mono_sprite_data.get(slot).unwrap().tile.texture_id;
+                let start = self.mono_sprite_cursor;
+                self.mono_sprite_cursor += 1;
+                while let Some(order) = self.peek_mono_sprite_order() {
+                    let current_slot = self.mono_sprite_indices[self.mono_sprite_cursor] as usize;
+                    let current_texture_id = self.mono_sprite_data.get(current_slot).unwrap().tile.texture_id;
+                    if (order, batch_kind) < max_order_and_kind && current_texture_id == texture_id {
+                        self.mono_sprite_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.monochrome_sprites_start = sprites_end;
                 Some(PrimitiveBatch::MonochromeSprites {
                     texture_id,
-                    sprites: &self.monochrome_sprites[sprites_start..sprites_end],
+                    indices: &self.mono_sprite_indices[start..self.mono_sprite_cursor],
                 })
             }
             PrimitiveKind::PolychromeSprite => {
-                let texture_id = self.polychrome_sprites_iter.peek().unwrap().tile.texture_id;
-                let sprites_start = self.polychrome_sprites_start;
-                let mut sprites_end = self.polychrome_sprites_start + 1;
-                self.polychrome_sprites_iter.next();
-                while self
-                    .polychrome_sprites_iter
-                    .next_if(|sprite| {
-                        (sprite.order, batch_kind) < max_order_and_kind
-                            && sprite.tile.texture_id == texture_id
-                    })
-                    .is_some()
-                {
-                    sprites_end += 1;
+                let slot = self.poly_sprite_indices[self.poly_sprite_cursor] as usize;
+                let texture_id = self.poly_sprite_data.get(slot).unwrap().tile.texture_id;
+                let start = self.poly_sprite_cursor;
+                self.poly_sprite_cursor += 1;
+                while let Some(order) = self.peek_poly_sprite_order() {
+                    let current_slot = self.poly_sprite_indices[self.poly_sprite_cursor] as usize;
+                    let current_texture_id = self.poly_sprite_data.get(current_slot).unwrap().tile.texture_id;
+                    if (order, batch_kind) < max_order_and_kind && current_texture_id == texture_id {
+                        self.poly_sprite_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.polychrome_sprites_start = sprites_end;
                 Some(PrimitiveBatch::PolychromeSprites {
                     texture_id,
-                    sprites: &self.polychrome_sprites[sprites_start..sprites_end],
+                    indices: &self.poly_sprite_indices[start..self.poly_sprite_cursor],
                 })
             }
             PrimitiveKind::Surface => {
-                let surfaces_start = self.surfaces_start;
-                let mut surfaces_end = surfaces_start + 1;
-                self.surfaces_iter.next();
-                while self
-                    .surfaces_iter
-                    .next_if(|surface| (surface.order, batch_kind) < max_order_and_kind)
-                    .is_some()
-                {
-                    surfaces_end += 1;
+                let start = self.surface_cursor;
+                self.surface_cursor += 1;
+                while let Some(order) = self.peek_surface_order() {
+                    if (order, batch_kind) < max_order_and_kind {
+                        self.surface_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.surfaces_start = surfaces_end;
-                Some(PrimitiveBatch::Surfaces(
-                    &self.surfaces[surfaces_start..surfaces_end],
-                ))
+                Some(PrimitiveBatch::Surfaces(&self.surface_indices[start..self.surface_cursor]))
             }
             PrimitiveKind::BackdropFilter => {
-                let backdrop_filters_start = self.backdrop_filters_start;
-                let mut backdrop_filters_end = backdrop_filters_start + 1;
-                self.backdrop_filters_iter.next();
-                while self
-                    .backdrop_filters_iter
-                    .next_if(|filter| (filter.order, batch_kind) < max_order_and_kind)
-                    .is_some()
-                {
-                    backdrop_filters_end += 1;
+                let start = self.backdrop_filter_cursor;
+                self.backdrop_filter_cursor += 1;
+                while let Some(order) = self.peek_backdrop_filter_order() {
+                    if (order, batch_kind) < max_order_and_kind {
+                        self.backdrop_filter_cursor += 1;
+                    } else {
+                        break;
+                    }
                 }
-                self.backdrop_filters_start = backdrop_filters_end;
-                Some(PrimitiveBatch::BackdropFilters(
-                    &self.backdrop_filters[backdrop_filters_start..backdrop_filters_end],
-                ))
+                Some(PrimitiveBatch::BackdropFilters(&self.backdrop_filter_indices[start..self.backdrop_filter_cursor]))
             }
-            // Boundaries are emitted one at a time (never merged) so the renderer can switch
-            // render targets at exactly the right point in the batch stream.
             PrimitiveKind::FilterBoundaryStart | PrimitiveKind::FilterBoundaryEnd => {
-                let index = self.filter_boundaries_start;
-                self.filter_boundaries_iter.next();
-                self.filter_boundaries_start = index + 1;
+                let index = self.filter_boundaries_cursor;
+                self.filter_boundaries_cursor += 1;
                 Some(PrimitiveBatch::FilterBoundary(index))
             }
         }
@@ -512,23 +935,20 @@ impl<'a> Iterator for BatchIterator<'a> {
 
 #[derive(Debug)]
 pub(crate) enum PrimitiveBatch<'a> {
-    Shadows(&'a [Shadow]),
-    Quads(&'a [Quad]),
-    Paths(&'a [Path<ScaledPixels>]),
-    Underlines(&'a [Underline]),
+    Shadows(&'a [u32]),
+    Quads(&'a [u32]),
+    Paths(&'a [u32]),
+    Underlines(&'a [u32]),
     MonochromeSprites {
         texture_id: AtlasTextureId,
-        sprites: &'a [MonochromeSprite],
+        indices: &'a [u32],
     },
     PolychromeSprites {
         texture_id: AtlasTextureId,
-        sprites: &'a [PolychromeSprite],
+        indices: &'a [u32],
     },
-    Surfaces(&'a [PaintSurface]),
-    BackdropFilters(&'a [BackdropFilter]),
-    /// A single content-filter group boundary; index into [`Scene::filter_boundaries`]. Read
-    /// `is_start` to tell whether this opens the group (switch render target) or closes it
-    /// (filter the offscreen target and composite it back).
+    Surfaces(&'a [u32]),
+    BackdropFilters(&'a [u32]),
     FilterBoundary(usize),
 }
 
@@ -1039,7 +1459,7 @@ mod tests {
     }
 
     fn batch_kinds(scene: &mut Scene) -> Vec<&'static str> {
-        scene.finish();
+        scene.sort();
         scene
             .batches()
             .map(|batch| match batch {

--- a/src/window.rs
+++ b/src/window.rs
@@ -926,7 +926,7 @@ impl Frame {
             }
         }
 
-        self.scene.finish();
+        self.scene.sort();
     }
 }
 
@@ -2748,10 +2748,12 @@ impl Window {
 
         self.text_system
             .reuse_layouts(range.start.line_layout_index..range.end.line_layout_index);
-        self.next_frame.scene.replay(
-            range.start.scene_index..range.end.scene_index,
-            &self.rendered_frame.scene,
-        );
+        let prev_scene = &self.rendered_frame.scene;
+        for i in range.start.scene_index..range.end.scene_index {
+            let operation = &prev_scene.paint_operations[i];
+            let slot_info = prev_scene.paint_slots.get(i).and_then(|s| s.clone());
+            self.next_frame.scene.replay(operation, &slot_info);
+        }
     }
 
     /// Push a text style onto the stack, and call a function with that style active.

--- a/src/window.rs
+++ b/src/window.rs
@@ -2226,6 +2226,11 @@ impl Window {
     /// the contents of the new [`Scene`], use [`Self::present`].
     #[profiling::function]
     pub fn draw<'app>(&mut self, cx: &'app mut App) -> ArenaClearNeeded<'app> {
+        // Try to present any completed compositor frame before starting a new one.
+        if self.platform_window.try_present() {
+            self.needs_present.set(false);
+        }
+
         // Set up the per-App arena for element allocation during this draw.
         // This ensures that multiple test Apps have isolated arenas.
         let _arena_scope = ElementArenaScope::enter(&cx.element_arena);

--- a/src/window.rs
+++ b/src/window.rs
@@ -2367,6 +2367,16 @@ impl Window {
         profiling::finish_frame!();
     }
 
+    /// Record a scroll delta without triggering a full re-render.
+    /// This uses the overscroll buffer fast path: the blit UV offset is adjusted
+    /// to show the scrolled viewport within the larger pipeline texture.
+    /// A full commit cycle is only needed when the viewport scrolls outside
+    /// the rendered area.
+    pub fn record_scroll(&self, delta: Point<Pixels>) {
+        self.platform_window.record_scroll(delta);
+        self.needs_present.set(true);
+    }
+
     /// Present only the cached framebuffer (fast path - no compositor)
     #[profiling::function]
     fn present_framebuffer_only(&self) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -984,6 +984,7 @@ pub struct Window {
     active: Rc<Cell<bool>>,
     hovered: Rc<Cell<bool>>,
     pub(crate) needs_present: Rc<Cell<bool>>,
+    pub(crate) pending_scroll_delta: Rc<Cell<Point<Pixels>>>,
     pub(crate) last_input_timestamp: Rc<Cell<Instant>>,
     pub(crate) resizing_window: Rc<Cell<bool>>,
     last_input_modality: InputModality,
@@ -1156,6 +1157,7 @@ impl Window {
         let active = Rc::new(Cell::new(platform_window.is_active()));
         let hovered = Rc::new(Cell::new(platform_window.is_hovered()));
         let needs_present = Rc::new(Cell::new(false));
+        let pending_scroll_delta = Rc::new(Cell::new(Point::default()));
         let next_frame_callbacks: Rc<RefCell<Vec<FrameCallback>>> = Default::default();
         let last_input_timestamp = Rc::new(Cell::new(Instant::now()));
 
@@ -1418,6 +1420,7 @@ impl Window {
             active,
             hovered,
             needs_present,
+            pending_scroll_delta,
             last_input_timestamp,
             resizing_window: Rc::new(Cell::new(false)),
             last_input_modality: InputModality::Mouse,
@@ -2231,6 +2234,10 @@ impl Window {
             self.needs_present.set(false);
         }
 
+        // Reset pending scroll delta after it has been consumed by the
+        // overscroll buffer fast path during presentation.
+        self.pending_scroll_delta.set(Point::default());
+
         // Set up the per-App arena for element allocation during this draw.
         // This ensures that multiple test Apps have isolated arenas.
         let _arena_scope = ElementArenaScope::enter(&cx.element_arena);
@@ -2373,6 +2380,9 @@ impl Window {
     /// A full commit cycle is only needed when the viewport scrolls outside
     /// the rendered area.
     pub fn record_scroll(&self, delta: Point<Pixels>) {
+        let mut pending = self.pending_scroll_delta.get();
+        pending += delta;
+        self.pending_scroll_delta.set(pending);
         self.platform_window.record_scroll(delta);
         self.needs_present.set(true);
     }


### PR DESCRIPTION
## Done:
- Phase 1: Dedicated compositor thread with channel protocol, pipeline texture, blit pipeline
- Phase 0 (Delta): GenerationalVec persistent slots, shader indirection buffers, sparse VRAM uploads, scissor rect from damage_rect, orphan slot recycling, view slot carry-forward via paint_slots
- Phase 2 — Overscroll Buffer: Texture scaled 2-3× viewport, three-case scroll model (covers / extend tiles / re-center), Window::record_scroll() to avoid cx.notify() on scroll-only events, List/UniformList scroll opt-in, hit-test adjustment for skipped frames. 
 
## Remaining:

- Phase 3a — Indirect Dispatch (CPU): Replace per-batch pass.draw(0..4, range) with a single multi_draw_indirect per pipeline — build an indirect command buffer on the CPU, upload once, issue one draw call per primitive type
- Phase 3b — Indirect Dispatch (GPU): Compute shader that reads primitive arrays and emits indirect draw commands — zero CPU involvement in draw call generation
- Polish: Benchmarks, edge case fuzzing, removal of compat stubs from Phase 1