### PR TITLE
Adapt Helio surface example to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,21 +2007,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
 name = "glam"
-version = "0.29.3"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 dependencies = [
  "bytemuck",
 ]
@@ -2040,27 +2038,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "glow"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
-dependencies = [
- "gl_generator",
 ]
 
 [[package]]
@@ -2127,6 +2104,7 @@ dependencies = [
  "gpui_util",
  "gpui_util_macros",
  "helio",
+ "helio-default-graphs",
  "image",
  "inventory",
  "itertools",
@@ -2393,41 +2371,20 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helio"
-version = "0.17.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+version = "0.18.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "arrayvec",
  "bytemuck",
  "glam",
- "helio-pass-billboard",
- "helio-pass-debug",
- "helio-pass-deferred-light",
- "helio-pass-depth-prepass",
- "helio-pass-fxaa",
- "helio-pass-gbuffer",
- "helio-pass-hiz",
- "helio-pass-hlfs",
- "helio-pass-indirect-dispatch",
- "helio-pass-light-cull",
- "helio-pass-occlusion-cull",
- "helio-pass-perf-overlay",
- "helio-pass-shadow",
- "helio-pass-shadow-dirty",
- "helio-pass-shadow-matrix",
- "helio-pass-simple-cube",
- "helio-pass-sky",
- "helio-pass-sky-lut",
- "helio-pass-smaa",
- "helio-pass-ssao",
- "helio-pass-taa",
- "helio-pass-transparent",
- "helio-pass-virtual-geometry",
- "helio-pass-water-sim",
- "helio-v3",
+ "helio-core",
+ "helio-pass-postprocess",
+ "helio-voxel-core",
  "image",
  "libhelio",
  "log",
- "pollster 0.3.0",
+ "meshopt",
+ "pollster 0.4.0",
  "quark",
  "thiserror 2.0.18",
  "web-time",
@@ -2436,23 +2393,82 @@ dependencies = [
 ]
 
 [[package]]
-name = "helio-pass-billboard"
+name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "glam",
+ "helio-voxel-core",
+ "libhelio",
+ "thiserror 2.0.18",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-default-graphs"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
+dependencies = [
+ "helio",
+ "helio-core",
+ "helio-pass-billboard",
+ "helio-pass-corona",
+ "helio-pass-debug-overlay",
+ "helio-pass-deferred-light",
+ "helio-pass-fxaa",
+ "helio-pass-gbuffer",
+ "helio-pass-hiz",
+ "helio-pass-hlfs",
+ "helio-pass-indirect-dispatch",
+ "helio-pass-light-cull",
+ "helio-pass-occlusion-cull",
+ "helio-pass-perf-overlay",
+ "helio-pass-postprocess",
+ "helio-pass-shadow",
+ "helio-pass-shadow-cull",
+ "helio-pass-shadow-dirty",
+ "helio-pass-shadow-matrix",
+ "helio-pass-simple-cube",
+ "helio-pass-sky",
+ "helio-pass-sky-lut",
+ "helio-pass-taa",
+ "helio-pass-transparent",
+ "helio-pass-virtual-geometry",
+ "helio-pass-water-sim",
+ "image",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-pass-billboard"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
+dependencies = [
+ "bytemuck",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
 
 [[package]]
-name = "helio-pass-debug"
+name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-pass-debug-overlay"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
+dependencies = [
+ "bytemuck",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2460,33 +2476,21 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-depth-prepass"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
-dependencies = [
- "bytemuck",
- "helio-v3",
- "libhelio",
- "log",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2494,10 +2498,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "log",
  "wgpu",
@@ -2506,10 +2510,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
  "log",
  "wgpu",
 ]
@@ -2517,11 +2522,11 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
  "glam",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2529,20 +2534,21 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2550,20 +2556,32 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-pass-postprocess"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
+dependencies = [
+ "bytemuck",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2571,42 +2589,56 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "log",
  "wgpu",
 ]
 
 [[package]]
-name = "helio-pass-shadow-dirty"
+name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
+ "wgpu",
+]
+
+[[package]]
+name = "helio-pass-shadow-dirty"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
+dependencies = [
+ "bytemuck",
+ "helio-core",
+ "libhelio",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
  "wgpu",
 ]
 
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
+ "libhelio",
  "log",
  "wgpu",
 ]
@@ -2614,10 +2646,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2625,32 +2657,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
- "libhelio",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-smaa"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
-dependencies = [
- "bytemuck",
- "helio-v3",
- "libhelio",
- "wgpu",
-]
-
-[[package]]
-name = "helio-pass-ssao"
-version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
-dependencies = [
- "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2658,10 +2668,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-taa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2669,10 +2679,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
@@ -2680,10 +2690,10 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "log",
  "wgpu",
@@ -2692,24 +2702,21 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
- "helio-v3",
+ "helio-core",
  "libhelio",
  "wgpu",
 ]
 
 [[package]]
-name = "helio-v3"
+name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
  "glam",
- "libhelio",
- "thiserror 2.0.18",
- "wgpu",
 ]
 
 [[package]]
@@ -3157,23 +3164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
-]
-
-[[package]]
-name = "khronos_api"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
 name = "kurbo"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=f124aeac0057c8f11c159931ea0c57d4c3b7fef9#f124aeac0057c8f11c159931ea0c57d4c3b7fef9"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=c779383cf4f8b02261de52334209562933117624#c779383cf4f8b02261de52334209562933117624"
 dependencies = [
  "bytemuck",
  "glam",
@@ -3486,6 +3476,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meshopt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01e77ead21976b3a9f01ec1724f766923da74f0726364e2b0f425658935d71a"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "float-cmp 0.10.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4284,12 +4286,6 @@ name = "pollster"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
-
-[[package]]
-name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "pollster"
@@ -5585,7 +5581,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
- "float-cmp",
+ "float-cmp 0.9.0",
 ]
 
 [[package]]
@@ -6651,7 +6647,6 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
@@ -6690,7 +6685,6 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
@@ -6698,14 +6692,6 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "28.0.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/wgpu?rev=fce5b80e8017304449124b12637ec324417e40c8#fce5b80e8017304449124b12637ec324417e40c8"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-emscripten"
 version = "28.0.0"
 source = "git+https://github.com/Far-Beyond-Pulsar/wgpu?rev=fce5b80e8017304449124b12637ec324417e40c8#fce5b80e8017304449124b12637ec324417e40c8"
 dependencies = [
@@ -6734,18 +6720,13 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "glow",
- "glutin_wgl_sys",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
- "js-sys",
- "khronos-egl",
  "libc",
  "libloading",
  "log",
  "naga",
- "ndk-sys",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -6763,9 +6744,6 @@ dependencies = [
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
- "wasm-bindgen",
- "wayland-sys",
- "web-sys",
  "wgpu-types",
  "windows 0.62.2",
  "windows-core",
@@ -7523,12 +7501,6 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,9 @@ objc2-foundation = { version = "0.2", features = ["NSData"] }
 
 [dev-dependencies]
 backtrace = "0.3"
-helio = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "f124aeac0057c8f11c159931ea0c57d4c3b7fef9" }
-glam = "0.29"
+helio = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c779383cf4f8b02261de52334209562933117624" }
+helio-default-graphs = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "c779383cf4f8b02261de52334209562933117624" }
+glam = "0.33.2"
 env_logger = "0.11"
 collections = { package = "gpui_collections", version = "0.2.2", features = [
     "test-support",

--- a/examples/learn/wgpu_surface.rs
+++ b/examples/learn/wgpu_surface.rs
@@ -4,12 +4,14 @@ use gpui::{
     App, Application, Context, Render, WgpuSurfaceHandle, Window, WindowOptions, div, prelude::*,
     rgb, wgpu_surface,
 };
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use helio::{
-    Camera, GpuLight, GpuMaterial, LightId, LightType, MaterialId, MeshId, MeshUpload,
-    ObjectDescriptor, ObjectId, PackedVertex, Renderer, RendererConfig, SceneActor,
+    Camera, DebugCameraUniform, DebugDrawState, GpuLight, GpuMaterial, LightId, LightType,
+    MaterialId, MeshId, MeshUpload, ObjectDescriptor, ObjectId, PackedVertex, Renderer,
+    RendererConfig, Scene, SceneActor,
 };
+use helio_default_graphs::build_default_graph_external;
 
 // ── Mesh helpers ────────────────────────────────────────────────────────────
 
@@ -124,6 +126,7 @@ fn insert_object(
             flags: 0,
             groups: helio::GroupMask::NONE,
             movability: Some(helio::Movability::Movable),
+            user_tag: 0,
         }))
         .as_object()
         .ok_or(helio::SceneError::InvalidHandle { resource: "object" })
@@ -313,10 +316,46 @@ fn build_helio_state(
     height: u32,
     format: wgpu::TextureFormat,
 ) -> HelioRenderState {
+    let config = RendererConfig::new(width, height, format);
+    let scene = Scene::new(Arc::clone(&device), Arc::clone(&queue));
+    let debug_state = Arc::new(Mutex::new(DebugDrawState::default()));
+    let debug_camera_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("WGPUI Helio Debug Camera"),
+        size: std::mem::size_of::<DebugCameraUniform>() as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let cull_stats_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("WGPUI Helio Cull Stats"),
+        size: 32,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let graph = build_default_graph_external(
+        &device,
+        &queue,
+        &scene,
+        config,
+        Arc::clone(&debug_state),
+        &debug_camera_buffer,
+        &cull_stats_buffer,
+        None,
+    );
     let mut renderer = Renderer::new_with_external_device(
         device,
         queue,
-        RendererConfig::new(width, height, format),
+        format,
+        width,
+        height,
+        config.render_scale,
+        config,
+        scene,
+        graph,
+        debug_state,
+        debug_camera_buffer,
+        cull_stats_buffer,
     );
 
     let mat = renderer.scene_mut().insert_material(make_material(


### PR DESCRIPTION
## Summary

- update the Helio surface example from Helio 0.17 to the merged v4 revision
- construct the external-device renderer with its explicit scene, graph, debug state, and buffers
- align glam and `ObjectDescriptor` with the current Helio API

## Verification

- `cargo check --example wgpu_surface`
- `git diff --check`

The check passes. Existing `gpui-ce` warnings remain unchanged.

Closes #47