### PR TITLE
Align Helio dev dependencies with current v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1150,7 +1150,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1340,7 +1340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2262,7 +2262,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helio"
 version = "0.18.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "arrayvec",
  "bytemuck",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "helio-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "glam",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "helio-default-graphs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "helio",
  "helio-core",
@@ -2339,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-billboard"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-corona"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-debug-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2372,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-decal"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2384,7 +2384,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-deferred-light"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-fxaa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-gbuffer"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hiz"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-hlfs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "glam",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-indirect-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-light-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-occlusion-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-perf-overlay"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-planar-reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-radiance-cascades"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2521,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-cull"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-dirty"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-shadow-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-simple-cube"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-sky-lut"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-ssr"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-taa"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-transparent"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-virtual-geometry"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-volumetric-fog"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-voxel-mesh"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "glam",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "helio-pass-water-sim"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "helio-core",
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "glam",
@@ -3188,7 +3188,7 @@ dependencies = [
 [[package]]
 name = "libhelio"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=04a38328c6d1329272072ade89d07098737df6b8#04a38328c6d1329272072ade89d07098737df6b8"
+source = "git+https://github.com/Far-Beyond-Pulsar/Helio?rev=6f1fbd070ddd43d78607cb4e2758803ba1558d5a#6f1fbd070ddd43d78607cb4e2758803ba1558d5a"
 dependencies = [
  "bytemuck",
  "glam",
@@ -4833,7 +4833,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5605,7 +5605,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5930,7 +5930,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6640,7 +6640,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,8 @@ objc2-foundation = { version = "0.2", features = ["NSData"] }
 
 [dev-dependencies]
 backtrace = "0.3"
-helio = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "04a38328c6d1329272072ade89d07098737df6b8" }
-helio-default-graphs = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "04a38328c6d1329272072ade89d07098737df6b8" }
+helio = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "6f1fbd070ddd43d78607cb4e2758803ba1558d5a" }
+helio-default-graphs = { git = "https://github.com/Far-Beyond-Pulsar/Helio", rev = "6f1fbd070ddd43d78607cb4e2758803ba1558d5a" }
 glam = "0.33"
 env_logger = "0.11"
 collections = { package = "gpui_collections", version = "0.2.2", features = [


### PR DESCRIPTION
## Summary

- align WGPUI's standalone `helio` and `helio-default-graphs` dev dependencies with Helio v4 compatibility PR Far-Beyond-Pulsar/Helio#130
- replace the obsolete `04a38328...` render graph in WGPUI's lockfile with `6f1fbd07...`
- keep WGPUI standalone-compatible while allowing Pulsar to consume one Helio package identity

Closes #66.

## Validation

- `cargo check --lib --tests --examples --locked`
- no `04a38328...` references remain in `Cargo.toml` or `Cargo.lock`
- all Helio dev packages resolve from `6f1fbd070ddd43d78607cb4e2758803ba1558d5a`

## Stack

Depends on Far-Beyond-Pulsar/Helio#130. Pulsar consumption and a recurrence guard belong in Far-Beyond-Pulsar/Pulsar-Native#410.