### PR TITLE
Restore the current external surface submission contract

### DIFF
--- a/src/elements/wgpu_surface.rs
+++ b/src/elements/wgpu_surface.rs
@@ -21,6 +21,8 @@ struct WgpuSurfaceHandleInner {
     /// us call `request_redraw()` from another thread without touching the
     /// event bus.
     winit_window: Option<Arc<winit::window::Window>>,
+    /// Device-level guard shared with the renderer. See `WgpuContext::gpu_submit_lock`.
+    gpu_submit_lock: Arc<parking_lot::RwLock<()>>,
     size: Mutex<(u32, u32)>,
     pending_resize: Mutex<Option<(u32, u32)>>,
     deferred_resize: Mutex<Option<(u32, u32)>>,
@@ -62,6 +64,7 @@ impl WgpuSurfaceHandle {
         registry: Arc<SurfaceRegistry>,
         present_trigger: Arc<dyn Fn() + Send + Sync>,
         winit_window: Option<Arc<winit::window::Window>>,
+        gpu_submit_lock: Arc<parking_lot::RwLock<()>>,
         width: u32,
         height: u32,
         format: wgpu::TextureFormat,
@@ -74,6 +77,7 @@ impl WgpuSurfaceHandle {
                 queue,
                 present_trigger,
                 winit_window,
+                gpu_submit_lock,
                 size: Mutex::new((width, height)),
                 pending_resize: Mutex::new(None),
                 deferred_resize: Mutex::new(None),
@@ -86,6 +90,33 @@ impl WgpuSurfaceHandle {
     /// The wgpu `Device` for creating GPU resources and command encoders.
     pub fn device(&self) -> &wgpu::Device {
         &self.inner.device
+    }
+
+    /// Acquire permission to submit GPU work on this surface's device.
+    ///
+    /// **External render threads must hold this across encoding, `queue.submit()`
+    /// and present.** The device and queue handed out by [`device()`](Self::device)
+    /// and [`queue()`](Self::queue) are shared with the compositor, and
+    /// `Surface::configure` (window resize) must observe an idle queue — wgpu
+    /// aborts the process with `GpuWaitTimeout` if anything submits while it waits.
+    ///
+    /// This is a **read** guard: any number of surfaces may hold one simultaneously
+    /// and none of them block each other, so each render thread keeps its own frame
+    /// pacing. Only a resize takes the exclusive side, and only for as long as the
+    /// swapchain takes to reconfigure.
+    ///
+    /// # Example
+    /// ```no_run
+    /// loop {
+    ///     let guard = surface.submit_guard();
+    ///     let (view, (w, h)) = surface.back_view_with_size()?;
+    ///     // ... encode and submit ...
+    ///     surface.present_synced_silent(submission_idx);
+    ///     drop(guard);
+    /// }
+    /// ```
+    pub fn submit_guard(&self) -> parking_lot::RwLockReadGuard<'_, ()> {
+        self.inner.gpu_submit_lock.read()
     }
 
     /// The wgpu `Queue` for submitting command buffers.
@@ -150,6 +181,17 @@ impl WgpuSurfaceHandle {
         }
 
         // Return immediately - no blocking
+    }
+
+    /// Publish a GPU-synchronized frame without requesting a separate redraw.
+    ///
+    /// Use this when an already-continuous GPUI animation frame loop drives
+    /// compositing. It avoids routing every external renderer submission
+    /// through the fast-blit redraw path while preserving GPU completion data.
+    pub fn present_synced_silent(&self, submission_index: wgpu::SubmissionIndex) {
+        self.inner
+            .registry
+            .swap_rendering_ready(self.inner.surface_id, submission_index);
     }
 
     /// Present the rendered frame without GPU synchronization (deprecated).

--- a/src/platform/cross/render_context.rs
+++ b/src/platform/cross/render_context.rs
@@ -35,6 +35,23 @@ pub struct WgpuContext {
     pub(super) paths_vertices_buffer: Mutex<wgpu::Buffer>,
 
     pub(crate) surface_registry: Arc<SurfaceRegistry>,
+
+    /// Guards swapchain reconfiguration against concurrent queue submission.
+    ///
+    /// `Surface::configure` waits for the device to go idle and fails with
+    /// `GpuWaitTimeout` if anything submits while it waits — wgpu-core treats a
+    /// non-empty queue after the wait as proof that "another thread is submitting
+    /// at the same time". Because `WgpuSurfaceHandle` hands out clones of this
+    /// device and queue, every external render thread is such a submitter.
+    ///
+    /// External render threads hold a **read** guard across render + submit;
+    /// `Surface::configure` call sites hold the **write** guard. Read guards do
+    /// not block each other, so any number of surfaces keep rendering at
+    /// independent rates; only reconfiguration (resize) serializes against them.
+    ///
+    /// The renderer's own submits deliberately do NOT take a read guard: they run
+    /// on the same thread as `configure`, so guarding them would self-deadlock.
+    pub(crate) gpu_submit_lock: Arc<parking_lot::RwLock<()>>,
 }
 
 impl WgpuContext {
@@ -225,6 +242,7 @@ impl WgpuContext {
 
             paths_vertices_buffer: Mutex::new(paths_vertices_buffer),
             surface_registry: Arc::new(SurfaceRegistry::new()),
+            gpu_submit_lock: Arc::new(parking_lot::RwLock::new(())),
         })
     }
 }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -1678,6 +1678,16 @@ impl WgpuRenderer {
         })
     }
 
+    /// Reconfigure the swapchain while excluding external render-thread
+    /// submissions that share this device and queue.
+    ///
+    /// All `Surface::configure` calls must go through here.
+    fn reconfigure_surface(&self) {
+        let _exclusive = self.context.gpu_submit_lock.write();
+        self.surface
+            .configure(&self.context.device, &self.surface_configuration);
+    }
+
     /// Reserve a timestamp-write pair against the current flamegraph GPU
     /// capture generation, if one is active and actively recording a frame.
     /// Returns `None` (cheaply, no wgpu resource allocation) otherwise, e.g.
@@ -1929,8 +1939,7 @@ impl WgpuRenderer {
                 | CurrentSurfaceTexture::Lost
                 | CurrentSurfaceTexture::Validation => {
                     // Reconfigure with the current known size and retry.
-                    self.surface
-                        .configure(&self.context.device, &self.surface_configuration);
+                    self.reconfigure_surface();
                     match self.surface.get_current_texture() {
                         CurrentSurfaceTexture::Success(t)
                         | CurrentSurfaceTexture::Suboptimal(t) => t,
@@ -2707,8 +2716,7 @@ impl WgpuRenderer {
             CurrentSurfaceTexture::Outdated
             | CurrentSurfaceTexture::Lost
             | CurrentSurfaceTexture::Validation => {
-                self.surface
-                    .configure(&self.context.device, &self.surface_configuration);
+                self.reconfigure_surface();
                 match self.surface.get_current_texture() {
                     CurrentSurfaceTexture::Success(t)
                     | CurrentSurfaceTexture::Suboptimal(t) => t,
@@ -2873,8 +2881,7 @@ impl WgpuRenderer {
     pub fn update_drawable_size(&mut self, size: geometry::Size<DevicePixels>) {
         self.surface_configuration.width = size.width.0 as u32;
         self.surface_configuration.height = size.height.0 as u32;
-        self.surface
-            .configure(&self.context.device, &self.surface_configuration);
+        self.reconfigure_surface();
 
         // Recreate persistent framebuffer at new size
         let persistent_framebuffer = self
@@ -2967,8 +2974,7 @@ impl WgpuRenderer {
             // wgpu::CompositeAlphaMode::Opaque
             wgpu::CompositeAlphaMode::Inherit
         };
-        self.surface
-            .configure(&self.context.device, &self.surface_configuration);
+        self.reconfigure_surface();
     }
 
     pub fn viewport_size(&self) -> geometry::Size<DevicePixels> {

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -442,6 +442,7 @@ impl PlatformWindow for CrossWindow {
             registry,
             present_trigger,
             winit_arc,
+            ctx.gpu_submit_lock.clone(),
             width,
             height,
             format,


### PR DESCRIPTION
## Summary

- restore the device-wide read/write submission guard required by off-thread `WgpuSurfaceHandle` renderers
- route every `Surface::configure` call through the exclusive side of that guard
- restore `present_synced_silent` for continuously animated embedded surfaces without forcing the fast-blit redraw path
- preserve the newly merged feature-gated flamegraph implementation

Closes #56.

## Deliberate scope

This does **not** restore the reverted persistent-framebuffer, fast-blit, idle-sweep, force-render, or legacy `render_stats` changes. WGPUI #55 remains open for the stale-swapchain fast path. This PR restores only the external-renderer synchronization contract Pulsar needs on current WGPUI `main`.

## Validation

- `cargo check --lib --tests --examples --locked`
- all four `Surface::configure` call sites route through `reconfigure_surface`
- current flamegraph-enabled WGPUI sources compile with the restored contract

## Stack

Depends on #67 for the current Helio dev dependency graph. Pulsar consumption is tracked by Far-Beyond-Pulsar/Pulsar-Native#463.