### PR TITLE
Flamegraph memory profiling (phase 3)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1649,6 +1649,19 @@ impl App {
         &self.text_system
     }
 
+    /// Total reserved capacity of the per-frame element arena
+    /// (`Window::draw`'s `ElementArenaScope`), in bytes. This is `Arena`'s
+    /// total chunk capacity, not live bytes in use: the arena is a bump
+    /// allocator cleared once per frame, so "capacity" (the high-water mark
+    /// of chunks it grew to) is the number worth reporting, matching how
+    /// `Arena::capacity` is already used for its `log::trace!` growth
+    /// message. Used by `Window::memory_snapshot` (Phase 3 of the profiling
+    /// epic, issue #59).
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn element_arena_capacity_bytes(&self) -> u64 {
+        self.element_arena.borrow().capacity() as u64
+    }
+
     /// Check whether a global of the given type has been assigned.
     pub fn has_global<G: Global>(&self) -> bool {
         self.globals_by_type.contains_key(&TypeId::of::<G>())

--- a/src/elements/image_cache.rs
+++ b/src/elements/image_cache.rs
@@ -4,6 +4,8 @@ use crate::{
     ParentElement, Pixels, RenderImage, Resource, Style, StyleRefinement, Styled, Task, Window,
     hash,
 };
+#[cfg(feature = "flamegraph")]
+use crate::WeakEntity;
 
 use futures::{FutureExt, future::Shared};
 use refineable::Refineable;
@@ -224,6 +226,40 @@ impl<T: ImageCache> ImageCacheProvider for Entity<T> {
     }
 }
 
+/// Global registry of every `RetainAllImageCache` that has ever been
+/// created, weak so registration never keeps a cache alive past its last
+/// strong reference. Phase 3 of the profiling epic (issue #59): summing
+/// image cache memory needs to reach every cache instance scattered across
+/// however many windows/elements created one, and none of those creation
+/// call sites have a natural path to "the current `MemorySnapshot`" -- the
+/// same "no natural path to the object that needs the data" constraint
+/// phase 1/2 solved with a thread-local accumulator and a weak recorder
+/// list (see `flamegraph.rs`'s `GLOBAL_THREAD_RECORDERS`); this is that same
+/// shape of fix applied here. Only the built-in `RetainAllImageCache` is
+/// registered -- a custom `ImageCache` implementation has no comparable
+/// registration hook, so it stays outside this profiler's visibility (see
+/// `MemorySnapshot::image_cache_bytes`'s doc comment).
+#[cfg(feature = "flamegraph")]
+static RETAINED_IMAGE_CACHE_REGISTRY: parking_lot::Mutex<Vec<WeakEntity<RetainAllImageCache>>> =
+    parking_lot::Mutex::new(Vec::new());
+
+/// Sum of every registered [`RetainAllImageCache`]'s current image bytes,
+/// for [`crate::MemorySnapshot::image_cache_bytes`]. Opportunistically prunes
+/// entries whose cache has since been dropped.
+#[cfg(feature = "flamegraph")]
+pub(crate) fn total_retained_image_cache_memory_usage(cx: &App) -> u64 {
+    let mut registry = RETAINED_IMAGE_CACHE_REGISTRY.lock();
+    let mut total_bytes = 0u64;
+    registry.retain(|weak_cache| match weak_cache.upgrade() {
+        Some(cache) => {
+            total_bytes += cache.read(cx).memory_usage();
+            true
+        }
+        None => false,
+    });
+    total_bytes
+}
+
 /// An implementation of ImageCache, that uses an LRU caching strategy to unload images when the cache is full
 pub struct RetainAllImageCache(HashMap<u64, ImageCacheItem>);
 
@@ -240,6 +276,8 @@ impl RetainAllImageCache {
     #[inline]
     pub fn new(cx: &mut App) -> Entity<Self> {
         let e = cx.new(|_cx| RetainAllImageCache(HashMap::new()));
+        #[cfg(feature = "flamegraph")]
+        RETAINED_IMAGE_CACHE_REGISTRY.lock().push(e.downgrade());
         cx.observe_release(&e, |image_cache, cx| {
             for (_, mut item) in std::mem::replace(&mut image_cache.0, HashMap::new()) {
                 if let Some(Ok(image)) = item.get() {
@@ -312,6 +350,24 @@ impl RetainAllImageCache {
     /// Returns true if the cache is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Total raw pixel bytes across every successfully-loaded image currently
+    /// held by this cache (sums every frame of an animated image). Images
+    /// still loading, or that failed to load, contribute nothing. Part of
+    /// Phase 3 of the profiling epic (issue #59); see
+    /// `total_retained_image_cache_memory_usage`.
+    #[cfg(feature = "flamegraph")]
+    fn memory_usage(&self) -> u64 {
+        self.0
+            .values()
+            .filter_map(|item| match item {
+                ImageCacheItem::Loaded(Ok(image)) => Some(image),
+                _ => None,
+            })
+            .flat_map(|image| (0..image.frame_count()).filter_map(|frame_index| image.as_bytes(frame_index)))
+            .map(|bytes| bytes.len() as u64)
+            .sum()
     }
 }
 

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -371,6 +371,18 @@ impl Capture {
         self.frames.len()
     }
 
+    /// Approximate heap bytes retained by this stopped capture's own frames
+    /// (Phase 3 of the profiling epic, issue #59): the CPU/GPU span vectors
+    /// held inside every [`FrameCapture`] in `self.frames`, plus a
+    /// per-`FrameCapture` fixed-field allowance. A profiler that doesn't
+    /// account for its own footprint is misleading, so this is meant to sit
+    /// alongside [`MemorySnapshot::capture_engine_bytes`] (which reports the
+    /// *live*, still-recording engine's footprint) as the equivalent number
+    /// for a trace that has already been stopped and handed to the caller.
+    pub fn retained_trace_bytes(&self) -> u64 {
+        self.frames.iter().map(frame_capture_memory_usage).sum()
+    }
+
     /// Aggregate mean/max statistics over the frames currently held in this
     /// capture's ring buffer (see [`CounterSummary`]'s doc comment). This is
     /// the Phase 2 (issue #58) replacement for the reverted `render_stats`
@@ -1335,6 +1347,161 @@ impl std::fmt::Display for CounterSummary {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3: on-demand memory snapshots (issue #59).
+//
+// Unlike the spans/counters above, memory sizes are not tracked continuously
+// per-frame -- they're cheap to recompute from the subsystems that already
+// own the data (a wgpu buffer already knows its own `size()`, an `Arena`
+// already knows its own `capacity()`), so there's nothing to accumulate.
+// `MemorySnapshot`/`GpuMemorySnapshot` are plain data, computed and returned
+// fresh on every call.
+//
+// #59 suggested exposing this as `Capture::memory_snapshot()`. That doesn't
+// fit the real merged shape: a stopped `Capture` (this module's only
+// `Capture` type so far, see its doc comment) has no reference back to the
+// live `App`/`Window`/`WgpuRenderer` state the CPU/GPU subsystems actually
+// live in -- `element_arena` is on `App`, the glyph cache is on the
+// process-wide `TextSystem`, the shaped-line cache and GPU renderer are
+// per-`Window`. Forcing the query through `Capture` would mean threading all
+// of that state into a type whose only job today is holding already-finished
+// frames. Instead, each snapshot is computed where its data actually lives:
+// `Window::memory_snapshot` (CPU) and `Window::gpu_memory_snapshot` (GPU),
+// both `#[cfg(feature = "flamegraph")]`-gated same as everything else here.
+// This mirrors, rather than fights, the same lesson phase 1/2 already
+// learned about call sites with no natural path to a specific type --
+// `current_gpu_correlation_frame_index` and the `FRAME_COUNTERS`
+// thread-local accumulator both exist because the natural owner of the data
+// (a `GpuQueryManager` generation, a draw-call counter) isn't the same place
+// that has a handle to the `Capture`/`FrameCapture` it needs to reach.
+// `MemorySnapshot`/`GpuMemorySnapshot` face the mirror-image version of that
+// problem -- the natural owner of a `Capture` doesn't have a handle to the
+// subsystems -- so they get the mirror-image fix: compute at the source
+// instead of routing through `Capture`.
+
+/// On-demand snapshot of memory held by WGPUI's own CPU-side subsystems for
+/// one `Window` (Phase 3 of the profiling epic, issue #59). This is
+/// explicitly not a general-purpose heap profiler -- it reports sizes of
+/// known allocating subsystems (element arena, text caches, image cache, and
+/// the flamegraph engine's own buffers) rather than intercepting every
+/// allocation. See [`Window::memory_snapshot`](crate::Window::memory_snapshot).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct MemorySnapshot {
+    /// Reserved capacity of the per-frame element arena (`Window::draw`'s
+    /// `ElementArenaScope`). See `App::element_arena_capacity_bytes`.
+    pub element_arena_bytes: u64,
+    /// Text system cache sizes. See [`TextSystemMemory`].
+    pub text_system: TextSystemMemory,
+    /// Sum of every registered `RetainAllImageCache`'s currently-loaded image
+    /// bytes. Custom `ImageCache` implementations are not registered and are
+    /// therefore invisible here -- this profiler only has visibility into
+    /// WGPUI's own built-in cache, not arbitrary embedder-provided ones.
+    pub image_cache_bytes: u64,
+    /// The flamegraph capture engine's own live footprint: per-thread
+    /// completed-span ring buffers, plus (if a capture is currently running)
+    /// the frames and pending background spans it's holding. Zero until the
+    /// first span is ever recorded on any thread, consistent with this
+    /// module's zero-overhead-when-idle rule. See
+    /// `capture_engine_memory_usage`.
+    pub capture_engine_bytes: u64,
+}
+
+impl MemorySnapshot {
+    /// Sum of every field above: one headline "how much is WGPUI holding
+    /// onto for this window" number.
+    pub fn total_bytes(&self) -> u64 {
+        self.element_arena_bytes
+            + self.text_system.total_bytes()
+            + self.image_cache_bytes
+            + self.capture_engine_bytes
+    }
+}
+
+/// Text system cache sizes, part of [`MemorySnapshot`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TextSystemMemory {
+    /// The rasterized-glyph bitmap cache (cosmic-text's `SwashCache`),
+    /// shared by every window in the `App` (one `PlatformTextSystem` per
+    /// `App`).
+    pub glyph_cache_bytes: u64,
+    /// This window's shaped-line layout cache (`LineLayoutCache`), covering
+    /// both the current and the previous frame's retained entries -- the
+    /// cache deliberately keeps one frame of history so lines that didn't
+    /// change survive a redraw without being re-shaped.
+    pub shaped_line_cache_bytes: u64,
+}
+
+impl TextSystemMemory {
+    /// Sum of both fields above.
+    pub fn total_bytes(&self) -> u64 {
+        self.glyph_cache_bytes + self.shaped_line_cache_bytes
+    }
+}
+
+/// On-demand snapshot of GPU memory held by one window's renderer (Phase 3 of
+/// the profiling epic, issue #59). Mostly summing sizes that already exist on
+/// wgpu resources (`wgpu::Buffer::size`, texture dimensions) rather than any
+/// new tracking. See
+/// [`Window::gpu_memory_snapshot`](crate::Window::gpu_memory_snapshot).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct GpuMemorySnapshot {
+    /// Fixed-size buffers in `render_context.rs` (quads/shadows/sprites/
+    /// paths/underlines/backdrop_filters/globals/color_adjustments), summed
+    /// from each buffer's own `wgpu::Buffer::size()`.
+    pub fixed_buffer_bytes: u64,
+    /// Atlas texture memory (`atlas.rs`), monochrome and polychrome
+    /// textures combined.
+    pub atlas_bytes: u64,
+    /// `SurfaceRegistry`'s triple-buffered offscreen textures, across every
+    /// registered surface.
+    pub surface_registry_bytes: u64,
+    /// The swapchain's own backing textures, computed from
+    /// `surface_configuration`'s dimensions/format -- wgpu doesn't expose
+    /// the presentation engine's actual image count, so this uses
+    /// `desired_maximum_frame_latency` as a best-effort estimate of how many
+    /// images it's holding.
+    pub swapchain_bytes: u64,
+}
+
+impl GpuMemorySnapshot {
+    /// Sum of every field above.
+    pub fn total_bytes(&self) -> u64 {
+        self.fixed_buffer_bytes + self.atlas_bytes + self.surface_registry_bytes + self.swapchain_bytes
+    }
+}
+
+/// The flamegraph capture engine's own live CPU memory footprint: every
+/// thread's completed-span ring buffer capacity (`THREAD_SPAN_BUDGET_BYTES`
+/// each, for every thread that has ever recorded a span), plus -- if a
+/// capture is currently running -- the frames its ring buffer is holding and
+/// any background spans awaiting the next frame close. Cheap: no allocation,
+/// just reading `Vec`/`VecDeque` lengths already held behind locks this
+/// module takes elsewhere. Used by [`MemorySnapshot::capture_engine_bytes`].
+pub(crate) fn capture_engine_memory_usage() -> u64 {
+    let thread_recorder_bytes =
+        (GLOBAL_THREAD_RECORDERS.lock().len() as u64) * (THREAD_SPAN_BUDGET_BYTES as u64);
+
+    let active_capture_bytes = ACTIVE_CAPTURE.lock().as_ref().map_or(0, |state| {
+        let pending_bytes = (state.pending_background_spans.lock().len() as u64)
+            * (core::mem::size_of::<CpuSpan>() as u64);
+        let frames_bytes: u64 = state.finished_frames.lock().iter().map(frame_capture_memory_usage).sum();
+        pending_bytes + frames_bytes
+    });
+
+    thread_recorder_bytes + active_capture_bytes
+}
+
+/// Approximate heap bytes held by one [`FrameCapture`]'s span vectors, plus a
+/// per-frame fixed-field allowance. Shared by `capture_engine_memory_usage`
+/// (a still-running capture's currently-buffered frames) and
+/// `Capture::retained_trace_bytes` (a stopped capture's frames).
+fn frame_capture_memory_usage(frame: &FrameCapture) -> u64 {
+    let cpu_span_bytes = ((frame.cpu_spans.len() + frame.background_spans.len()) as u64)
+        * (core::mem::size_of::<CpuSpan>() as u64);
+    let gpu_span_bytes = (frame.gpu_spans.len() as u64) * (core::mem::size_of::<GpuSpan>() as u64);
+    core::mem::size_of::<FrameCapture>() as u64 + cpu_span_bytes + gpu_span_bytes
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1617,5 +1784,93 @@ mod tests {
         assert_eq!(frames.len(), 3);
         let expected: Vec<DecodedFrameCapture> = capture.frames().map(decode_frame).collect();
         assert_eq!(frames, expected);
+
+        // Phase 3 (issue #59): the capture engine's own footprint should be
+        // visible while a capture is running -- three finished frames, each
+        // with the "Window::draw"/"Window::draw_roots" CPU spans recorded
+        // above, are still held by `ACTIVE_CAPTURE` at this point (the
+        // capture hasn't been stopped yet). `capture_engine_memory_usage` is
+        // recomputed from scratch on every call rather than tracked
+        // continuously, so it's safe to call here mid-capture and again
+        // after `stop()` below.
+        assert!(
+            capture_engine_memory_usage() > 0,
+            "engine footprint should be nonzero with frames still buffered and a thread-local span recorder live"
+        );
+
+        // The capture's own retained bytes should equal the sum of each
+        // buffered frame's span vectors (each of the 3 frames here has 2 CPU
+        // spans -- "Window::draw" and "Window::draw_roots" -- and no
+        // background/GPU spans), computed independently of
+        // `frame_capture_memory_usage` to actually exercise the formula
+        // rather than just calling it a second time.
+        let expected_retained_bytes: u64 = capture
+            .frames()
+            .map(|frame| {
+                core::mem::size_of::<FrameCapture>() as u64
+                    + ((frame.cpu_spans.len() + frame.background_spans.len()) as u64)
+                        * (core::mem::size_of::<CpuSpan>() as u64)
+                    + (frame.gpu_spans.len() as u64) * (core::mem::size_of::<GpuSpan>() as u64)
+            })
+            .sum();
+        assert_eq!(capture.retained_trace_bytes(), expected_retained_bytes);
+        assert!(capture.retained_trace_bytes() > 0);
+
+        // A freshly stopped, empty capture should report zero retained
+        // bytes -- there's nothing buffered to hold onto. Sequential with
+        // (not concurrent with) the capture above: only one flamegraph
+        // capture session may be active process-wide, so this test is the
+        // sole owner of that global state for its whole duration rather than
+        // splitting into a second `#[test]` that could race with this one
+        // under the default parallel test runner.
+        let empty_handle = start_capture(CaptureOptions {
+            max_frames: 8,
+            capture_gpu: false,
+        })
+        .expect("the capture above was already stopped, so starting a new one here should succeed");
+        let empty_capture = empty_handle.stop();
+        assert_eq!(empty_capture.frame_count(), 0);
+        assert_eq!(empty_capture.retained_trace_bytes(), 0);
+
+        // Now that every capture from this test is stopped, `ACTIVE_CAPTURE`
+        // is empty, so the engine's live footprint should be nothing but
+        // this thread's own completed-span recorder -- still allocated,
+        // since a thread keeps its ring buffer for its whole lifetime once
+        // first used, which is exactly why this is cheap and safe to call
+        // with no capture running at all.
+        let recorder_count = GLOBAL_THREAD_RECORDERS.lock().len() as u64;
+        assert_eq!(
+            capture_engine_memory_usage(),
+            recorder_count * (THREAD_SPAN_BUDGET_BYTES as u64)
+        );
+    }
+
+    #[test]
+    fn memory_snapshot_total_bytes_sums_every_field() {
+        let snapshot = MemorySnapshot {
+            element_arena_bytes: 1_048_576,
+            text_system: TextSystemMemory {
+                glyph_cache_bytes: 2048,
+                shaped_line_cache_bytes: 4096,
+            },
+            image_cache_bytes: 8192,
+            capture_engine_bytes: 16384,
+        };
+        assert_eq!(snapshot.text_system.total_bytes(), 2048 + 4096);
+        assert_eq!(snapshot.total_bytes(), 1_048_576 + 2048 + 4096 + 8192 + 16384);
+    }
+
+    #[test]
+    fn gpu_memory_snapshot_total_bytes_sums_every_field() {
+        let snapshot = GpuMemorySnapshot {
+            fixed_buffer_bytes: 64 * 1024 * 1024,
+            atlas_bytes: 4 * 1024 * 1024,
+            surface_registry_bytes: 12 * 1024 * 1024,
+            swapchain_bytes: 3 * 1920 * 1080 * 4,
+        };
+        assert_eq!(
+            snapshot.total_bytes(),
+            64 * 1024 * 1024 + 4 * 1024 * 1024 + 12 * 1024 * 1024 + 3 * 1920 * 1080 * 4
+        );
     }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -448,6 +448,15 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         None
     }
 
+    /// Current GPU memory footprint of this window's renderer (Phase 3 of the
+    /// profiling epic, issue #59). Default `None` for platforms/backends that
+    /// don't use the WGPU renderer, matching `create_wgpu_surface`'s
+    /// convention; `CrossWindow` overrides this once its renderer exists.
+    #[cfg(feature = "flamegraph")]
+    fn gpu_memory_snapshot(&self) -> Option<crate::GpuMemorySnapshot> {
+        None
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         None
@@ -504,6 +513,16 @@ pub(crate) trait PlatformTextSystem: Send + Sync {
         raster_bounds: Bounds<DevicePixels>,
     ) -> Result<(Size<DevicePixels>, Vec<u8>)>;
     fn layout_line(&self, text: &str, font_size: Pixels, runs: &[FontRun]) -> LineLayout;
+
+    /// Bytes held by this text system's own rasterized-glyph cache, for
+    /// `MemorySnapshot`'s `text_system.glyph_cache_bytes` field (Phase 3 of
+    /// the profiling epic, issue #59). Default `0` for implementations that
+    /// don't maintain their own glyph cache; `CosmicTextSystem` overrides
+    /// this to report `SwashCache`'s size.
+    #[cfg(feature = "flamegraph")]
+    fn glyph_cache_memory_usage(&self) -> u64 {
+        0
+    }
 }
 
 pub(crate) struct NoopTextSystem;

--- a/src/platform/cross/atlas.rs
+++ b/src/platform/cross/atlas.rs
@@ -41,6 +41,25 @@ impl WgpuAtlas {
             raw_view: texture.raw_view.clone(),
         }
     }
+
+    /// Sum of every live atlas texture's backing memory, monochrome and
+    /// polychrome combined (Phase 3 of the profiling epic, issue #59).
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn memory_usage(&self) -> u64 {
+        let state = self.0.lock();
+        atlas_texture_list_memory_usage(&state.storage.monochrome_textures)
+            + atlas_texture_list_memory_usage(&state.storage.polychrome_textures)
+    }
+}
+
+#[cfg(feature = "flamegraph")]
+fn atlas_texture_list_memory_usage(textures: &AtlasTextureList<WgpuAtlasTexture>) -> u64 {
+    textures
+        .textures
+        .iter()
+        .flatten()
+        .map(|texture| super::render_context::texture_memory_bytes(&texture.raw))
+        .sum()
 }
 
 impl PlatformAtlas for WgpuAtlas {

--- a/src/platform/cross/render_context.rs
+++ b/src/platform/cross/render_context.rs
@@ -229,6 +229,59 @@ impl WgpuContext {
     }
 }
 
+impl WgpuContext {
+    /// Sum of every fixed-size buffer's `wgpu::Buffer::size()` (Phase 3 of
+    /// the profiling epic, issue #59). A poisoned mutex (meaning some other
+    /// thread already panicked while holding it) is treated as contributing
+    /// zero rather than panicking here too -- a memory query should never
+    /// itself be the thing that brings down an already-degraded process.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn fixed_buffer_memory_usage(&self) -> u64 {
+        self.globals_buffer.size()
+            + self.color_adjustments_buffer.size()
+            + buffer_size_or_zero(&self.quads_buffer)
+            + buffer_size_or_zero(&self.shadows_buffer)
+            + buffer_size_or_zero(&self.backdrop_filters_buffer)
+            + buffer_size_or_zero(&self.underlines_buffer)
+            + buffer_size_or_zero(&self.mono_sprites_buffer)
+            + buffer_size_or_zero(&self.poly_sprites_buffer)
+            + buffer_size_or_zero(&self.paths_vertices_buffer)
+    }
+}
+
+#[cfg(feature = "flamegraph")]
+fn buffer_size_or_zero(buffer: &Mutex<wgpu::Buffer>) -> u64 {
+    buffer.lock().map(|guard| guard.size()).unwrap_or(0)
+}
+
+/// Bytes per texel for `format`, for GPU memory accounting (Phase 3 of the
+/// profiling epic, issue #59). Falls back to 4 (the size of every format
+/// WGPUI actually creates textures with) for the handful of combined
+/// depth/stencil formats where `block_copy_size` needs an aspect to answer
+/// -- none of WGPUI's own textures use those formats, so this only matters
+/// for correctness-in-principle, not any real texture this crate creates.
+#[cfg(feature = "flamegraph")]
+pub(super) fn texel_size(format: wgpu::TextureFormat) -> u64 {
+    format.block_copy_size(None).unwrap_or(4) as u64
+}
+
+/// Total bytes backing a texture: every mip level's `width * height *
+/// texel_size`, times array/depth layers. WGPUI only ever creates
+/// single-mip, single-layer 2D textures today, so this is normally just
+/// `width * height * texel_size`; the general form costs nothing extra to
+/// write and stays correct if that ever changes.
+#[cfg(feature = "flamegraph")]
+pub(super) fn texture_memory_bytes(texture: &wgpu::Texture) -> u64 {
+    let bytes_per_texel = texel_size(texture.format());
+    let mut total = 0u64;
+    for mip in 0..texture.mip_level_count() {
+        let width = (texture.width() >> mip).max(1) as u64;
+        let height = (texture.height() >> mip).max(1) as u64;
+        total += width * height * bytes_per_texel;
+    }
+    total * (texture.depth_or_array_layers() as u64)
+}
+
 /// Ensures a buffer is large enough to hold the required size.
 /// If the buffer is too small, it will be recreated with the new size.
 pub(super) fn ensure_buffer_size(
@@ -249,5 +302,25 @@ pub(super) fn ensure_buffer_size(
             usage,
             mapped_at_creation: false,
         });
+    }
+}
+
+#[cfg(all(test, feature = "flamegraph"))]
+mod tests {
+    use super::texel_size;
+
+    // `texture_memory_bytes`/atlas/surface-registry memory accounting all
+    // ultimately reduce to `texel_size`, and that's the one piece testable
+    // without a real `wgpu::Device` (`wgpu::TextureFormat` is a plain enum,
+    // no adapter/device required) -- this crate has no headless-GPU test
+    // fixture, so the buffer/texture-size accessors that need a live device
+    // (`WgpuContext::fixed_buffer_memory_usage`, `WgpuAtlas::memory_usage`,
+    // `SurfaceRegistry::memory_usage`) aren't covered by an automated test.
+    #[test]
+    fn texel_size_matches_known_format_sizes() {
+        assert_eq!(texel_size(wgpu::TextureFormat::R8Unorm), 1);
+        assert_eq!(texel_size(wgpu::TextureFormat::Rgba8Unorm), 4);
+        assert_eq!(texel_size(wgpu::TextureFormat::Bgra8UnormSrgb), 4);
+        assert_eq!(texel_size(wgpu::TextureFormat::Rgba16Float), 8);
     }
 }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -3001,6 +3001,33 @@ impl WgpuRenderer {
             height: DevicePixels(self.surface_configuration.height as i32),
         }
     }
+
+    /// On-demand GPU memory snapshot for this renderer (Phase 3 of the
+    /// profiling epic, issue #59): mostly summing sizes that already exist
+    /// on already-owned wgpu resources, no new tracking required.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn gpu_memory_snapshot(&self) -> crate::GpuMemorySnapshot {
+        crate::GpuMemorySnapshot {
+            fixed_buffer_bytes: self.context.fixed_buffer_memory_usage(),
+            atlas_bytes: self.atlas.memory_usage(),
+            surface_registry_bytes: self.context.surface_registry.memory_usage(),
+            swapchain_bytes: self.swapchain_memory_usage(),
+        }
+    }
+
+    /// Best-effort swapchain memory estimate from `surface_configuration`'s
+    /// dimensions/format. wgpu doesn't expose the presentation engine's
+    /// actual backing image count, so `desired_maximum_frame_latency` (the
+    /// one buffering-depth signal WGPUI itself configures) stands in for it.
+    #[cfg(feature = "flamegraph")]
+    fn swapchain_memory_usage(&self) -> u64 {
+        let bytes_per_texel = super::render_context::texel_size(self.surface_configuration.format);
+        let image_count = self.surface_configuration.desired_maximum_frame_latency.max(1) as u64;
+        (self.surface_configuration.width as u64)
+            * (self.surface_configuration.height as u64)
+            * bytes_per_texel
+            * image_count
+    }
 }
 
 impl Drop for WgpuRenderer {

--- a/src/platform/cross/surface_registry.rs
+++ b/src/platform/cross/surface_registry.rs
@@ -287,6 +287,23 @@ impl SurfaceRegistry {
             .collect()
     }
 
+    /// Sum of every registered surface's three triple-buffered textures
+    /// (Phase 3 of the profiling epic, issue #59). A poisoned lock (some
+    /// other thread already panicked while holding it) is treated as
+    /// contributing zero rather than panicking here too.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn memory_usage(&self) -> u64 {
+        let surfaces = match self.surfaces.lock() {
+            Ok(surfaces) => surfaces,
+            Err(_) => return 0,
+        };
+        surfaces
+            .values()
+            .flat_map(|triple_buffer| triple_buffer.textures.iter())
+            .map(super::render_context::texture_memory_bytes)
+            .sum()
+    }
+
     fn create_triple_buffer(
         device: &wgpu::Device,
         width: u32,

--- a/src/platform/cross/text_system.rs
+++ b/src/platform/cross/text_system.rs
@@ -182,6 +182,28 @@ impl PlatformTextSystem for CosmicTextSystem {
     fn layout_line(&self, text: &str, font_size: Pixels, runs: &[FontRun]) -> LineLayout {
         self.0.write().layout_line(text, font_size, runs)
     }
+
+    // Phase 3 of the profiling epic (issue #59): report the size of
+    // cosmic-text's rasterized-glyph bitmap cache (`SwashCache::image_cache`,
+    // a public field on the upstream type). Only the raster bitmap cache is
+    // counted, not `SwashCache::outline_command_cache` (vector outline
+    // commands used for the outline glyph path) -- the bitmap cache is the
+    // one that actually scales with glyph count/size and dominates this
+    // subsystem's footprint.
+    #[cfg(feature = "flamegraph")]
+    fn glyph_cache_memory_usage(&self) -> u64 {
+        let state = self.0.read();
+        state
+            .swash_cache
+            .image_cache
+            .values()
+            .map(|entry| {
+                let key_bytes = core::mem::size_of::<CacheKey>() as u64;
+                let image_bytes = entry.as_ref().map_or(0, |image| image.data.len() as u64);
+                key_bytes + image_bytes
+            })
+            .sum()
+    }
 }
 
 impl CosmicTextSystemState {

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -452,6 +452,14 @@ impl PlatformWindow for CrossWindow {
         self.0.sprite_atlas.clone()
     }
 
+    #[cfg(feature = "flamegraph")]
+    fn gpu_memory_snapshot(&self) -> Option<crate::GpuMemorySnapshot> {
+        self.0
+            .renderer
+            .get()
+            .map(|renderer| renderer.borrow().gpu_memory_snapshot())
+    }
+
     fn gpu_specs(&self) -> Option<crate::GpuSpecs> {
         // TODO(mdeand): Retrieve GPU specs from the graphics context.
         None

--- a/src/text_system.rs
+++ b/src/text_system.rs
@@ -334,6 +334,14 @@ impl TextSystem {
         self.platform_text_system
             .rasterize_glyph(params, raster_bounds)
     }
+
+    /// Bytes held by this (process-wide, shared across every window)
+    /// text system's rasterized-glyph cache. Part of Phase 3 of the
+    /// profiling epic (issue #59); see `WindowTextSystem::memory_snapshot`.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn glyph_cache_memory_usage(&self) -> u64 {
+        self.platform_text_system.glyph_cache_memory_usage()
+    }
 }
 
 /// The GPUI text layout subsystem.
@@ -354,6 +362,18 @@ impl WindowTextSystem {
 
     pub(crate) fn layout_index(&self) -> LineLayoutIndex {
         self.line_layout_cache.layout_index()
+    }
+
+    /// This window's text system cache sizes (Phase 3 of the profiling epic,
+    /// issue #59): the shaped-line cache is per-window, while the glyph
+    /// cache is shared crate-wide and reached through `Deref<Target =
+    /// TextSystem>`. See `Window::memory_snapshot`.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn memory_snapshot(&self) -> crate::TextSystemMemory {
+        crate::TextSystemMemory {
+            glyph_cache_bytes: self.glyph_cache_memory_usage(),
+            shaped_line_cache_bytes: self.line_layout_cache.memory_usage(),
+        }
     }
 
     pub(crate) fn reuse_layouts(&self, index: Range<LineLayoutIndex>) {

--- a/src/text_system/line_layout.rs
+++ b/src/text_system/line_layout.rs
@@ -413,6 +413,61 @@ pub(crate) struct LineLayoutIndex {
     wrapped_lines_index: usize,
 }
 
+/// Approximate heap bytes held by one [`CacheKey`]: the cached text plus its
+/// font runs. Ignores allocator overhead/`HashMap` bucket cost -- a rough
+/// "how much is this cache holding" estimate, not an exact accounting.
+#[cfg(feature = "flamegraph")]
+fn cache_key_memory_usage(key: &CacheKey) -> u64 {
+    core::mem::size_of::<CacheKey>() as u64
+        + (key.text.len() as u64)
+        + (key.runs.len() as u64) * (core::mem::size_of::<FontRun>() as u64)
+}
+
+/// Approximate heap bytes held by one [`LineLayout`]: its shaped runs and
+/// their glyphs.
+#[cfg(feature = "flamegraph")]
+fn line_layout_memory_usage(layout: &LineLayout) -> u64 {
+    let runs_bytes: u64 = layout
+        .runs
+        .iter()
+        .map(|run| {
+            core::mem::size_of::<ShapedRun>() as u64
+                + (run.glyphs.len() as u64) * (core::mem::size_of::<ShapedGlyph>() as u64)
+        })
+        .sum();
+    core::mem::size_of::<LineLayout>() as u64 + runs_bytes
+}
+
+/// Approximate heap bytes held by one [`WrappedLineLayout`]: its own wrap
+/// boundaries plus the unwrapped `LineLayout` it wraps.
+#[cfg(feature = "flamegraph")]
+fn wrapped_line_layout_memory_usage(layout: &WrappedLineLayout) -> u64 {
+    core::mem::size_of::<WrappedLineLayout>() as u64
+        + line_layout_memory_usage(&layout.unwrapped_layout)
+        + (layout.wrap_boundaries.len() as u64) * (core::mem::size_of::<WrapBoundary>() as u64)
+}
+
+/// Approximate heap bytes held by one [`FrameCache`] (either the current or
+/// previous frame's half of a [`LineLayoutCache`]).
+#[cfg(feature = "flamegraph")]
+fn frame_cache_memory_usage(frame: &FrameCache) -> u64 {
+    let lines_bytes: u64 = frame
+        .lines
+        .iter()
+        .map(|(key, layout)| cache_key_memory_usage(key) + line_layout_memory_usage(layout))
+        .sum();
+    let wrapped_bytes: u64 = frame
+        .wrapped_lines
+        .iter()
+        .map(|(key, layout)| cache_key_memory_usage(key) + wrapped_line_layout_memory_usage(layout))
+        .sum();
+    // `used_lines`/`used_wrapped_lines` hold `Arc` clones of keys already
+    // counted above; only the pointer-sized `Vec` slot itself is additional.
+    let index_bytes = ((frame.used_lines.len() + frame.used_wrapped_lines.len()) as u64)
+        * (core::mem::size_of::<Arc<CacheKey>>() as u64);
+    lines_bytes + wrapped_bytes + index_bytes
+}
+
 impl LineLayoutCache {
     pub fn new(platform_text_system: Arc<dyn PlatformTextSystem>) -> Self {
         Self {
@@ -467,6 +522,18 @@ impl LineLayoutCache {
         curr_frame.wrapped_lines.clear();
         curr_frame.used_lines.clear();
         curr_frame.used_wrapped_lines.clear();
+    }
+
+    /// Approximate heap bytes retained by this cache right now, across both
+    /// the current and previous frame's entries (the cache keeps one frame
+    /// of history so unchanged lines survive a redraw without being
+    /// re-shaped; both halves are live memory). Part of `MemorySnapshot`'s
+    /// `text_system.shaped_line_cache_bytes` field (Phase 3 of the profiling
+    /// epic, issue #59). This walks every cached entry rather than tracking a
+    /// running total, since it's only called on demand, not per-frame.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn memory_usage(&self) -> u64 {
+        frame_cache_memory_usage(&self.previous_frame.lock()) + frame_cache_memory_usage(&self.current_frame.read())
     }
 
     pub fn layout_wrapped_line<Text>(

--- a/src/window.rs
+++ b/src/window.rs
@@ -1677,6 +1677,31 @@ impl Window {
         &self.text_system
     }
 
+    /// On-demand snapshot of memory held by WGPUI's own CPU-side subsystems
+    /// for this window (Phase 3 of the profiling epic, issue #59): the
+    /// per-frame element arena, this window's text caches, the built-in
+    /// image cache, and the flamegraph capture engine's own footprint. Cheap
+    /// -- a summation over already-allocated caches, not a fresh allocation
+    /// pass -- but not tracked per-frame like spans/counters, so call it as
+    /// needed rather than every frame.
+    #[cfg(feature = "flamegraph")]
+    pub fn memory_snapshot(&self, cx: &App) -> crate::MemorySnapshot {
+        crate::MemorySnapshot {
+            element_arena_bytes: cx.element_arena_capacity_bytes(),
+            text_system: self.text_system.memory_snapshot(),
+            image_cache_bytes: crate::elements::total_retained_image_cache_memory_usage(cx),
+            capture_engine_bytes: crate::capture_engine_memory_usage(),
+        }
+    }
+
+    /// On-demand GPU memory snapshot for this window's renderer (Phase 3 of
+    /// the profiling epic, issue #59). `None` on platforms/backends that
+    /// don't use the WGPU renderer, or before the renderer has been created.
+    #[cfg(feature = "flamegraph")]
+    pub fn gpu_memory_snapshot(&self) -> Option<crate::GpuMemorySnapshot> {
+        self.platform_window.gpu_memory_snapshot()
+    }
+
     /// The current text style. Which is composed of all the style refinements provided to `with_text_style`.
     pub fn text_style(&self) -> TextStyle {
         let mut style = TextStyle::default();


### PR DESCRIPTION
## Summary

Phase 3 of the profiling/replay epic (#64), building on the merged capture engine (#65) and counters (#68): memory visibility for WGPUI's own subsystems — not a general-purpose heap profiler (Valgrind/heaptrack already cover that), just "what is this framework itself holding onto." Computed on demand rather than tracked per-frame, since memory sizes don't need the same granularity as timing/counters.

- `Window::memory_snapshot(&self, cx: &App) -> MemorySnapshot` — element arena capacity, text system glyph/shaped-line caches, image cache, and the flamegraph engine's own live footprint (a profiler that hides its own overhead is misleading).
- `Window::gpu_memory_snapshot(&self) -> Option<GpuMemorySnapshot>` — fixed renderer buffers, atlas textures, surface registry's triple buffers, swapchain estimate, reachable via a new `PlatformWindow::gpu_memory_snapshot` trait method.
- `Capture::retained_trace_bytes()` — a stopped capture's own retained size.
- New `PlatformTextSystem::glyph_cache_memory_usage` trait method and `LineLayoutCache::memory_usage`, plus a weak-handle registry in the image cache so its current size is queryable without adding tracking overhead to the hot path.

Full design writeup and progress notes: #59 (closed by this PR).

## Deviation from the original design (documented on #59)

`Capture::memory_snapshot()`, as originally sketched, doesn't work: a stopped `Capture` has no reference back to the live `App`/`Window`/`WgpuRenderer` state these subsystem sizes actually live in. The query lives on `Window` instead — the same "no natural path to the data" constraint phases 1-2 already hit (GPU-span correlation, counter accumulation), applied here to memory queries.

## Test plan

- [x] `cargo build` / `cargo build --release`, with and without `--features flamegraph` — 4/4 clean
- [x] Zero new dependencies (`Cargo.toml`/`Cargo.lock` diff is empty)
- [x] Full lib test suite: 83/83 (`--features flamegraph`, 80 existing + 3 new), 79/79 (without)
- [x] `cargo build --release --examples`, both feature configs — clean
- [x] `cargo clippy --release --all-targets --all-features` diffed against a clean `main` checkout — identical warning/error sets, zero new
- [x] No `unwrap()`/`expect()` introduced outside tests; mutex poisoning handled explicitly
- [x] Live windowed run — same sandbox limitation as phases 1-2 (no display server); flagging for whoever reviews with a real display

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)