### PR TITLE
Flamegraph GPU deep capture (phase 4)

### DIFF
--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -2087,4 +2087,71 @@ mod tests {
             64 * 1024 * 1024 + 4 * 1024 * 1024 + 12 * 1024 * 1024 + 3 * 1920 * 1080 * 4
         );
     }
+
+    // Phase 4 (issue #60): the public arm/retrieve half of the deep-capture
+    // lifecycle. `WgpuRenderer::draw`'s actual recording/readback is covered
+    // in `flamegraph_gpu`'s test module (it needs a real `wgpu::Device`);
+    // this test covers everything reachable without one -- the request flag,
+    // the completed-capture mailbox, and `DeepCapture::buffer_contents`'s
+    // lookup helper. `DEEP_CAPTURE_REQUESTED`/`COMPLETED_DEEP_CAPTURE` are
+    // process-wide statics that no other test in this suite touches (nothing
+    // outside a real `WgpuRenderer::draw` call exercises them), so unlike
+    // `ACTIVE_CAPTURE` above there's no cross-test ownership concern here.
+    #[test]
+    fn deep_capture_request_and_retrieval_round_trip() {
+        assert!(!deep_capture_requested(), "should start unarmed");
+        assert!(!take_deep_capture_request(), "taking with nothing armed should report false");
+
+        request_deep_capture();
+        assert!(deep_capture_requested(), "should be armed immediately after requesting");
+        assert!(take_deep_capture_request(), "the first take after a request should report true");
+        assert!(
+            !take_deep_capture_request(),
+            "a second take with nothing newly requested should report false"
+        );
+        assert!(!deep_capture_requested(), "taking the request should clear the armed flag");
+
+        assert!(
+            take_completed_deep_capture().is_none(),
+            "nothing has completed yet, so retrieval should be empty"
+        );
+
+        let quads_bytes = vec![1u8, 2, 3, 4];
+        let capture = DeepCapture {
+            draw_calls: vec![DeepCaptureDrawCall {
+                sequence: 0,
+                kind: DrawCallKind::Quads,
+                pipeline_label: "quads",
+                pass_label: "main",
+                vertex_range: (0, 4),
+                instance_range: (0, 1),
+                bind_group_count: 2,
+                buffer_kind: Some(DeepCaptureBufferKind::Quads),
+                atlas_texture_id: None,
+            }],
+            buffer_contents: vec![DeepCaptureBufferContents {
+                kind: DeepCaptureBufferKind::Quads,
+                bytes: quads_bytes.clone(),
+            }],
+            resources_finalized: true,
+        };
+        complete_deep_capture(capture);
+
+        let taken = take_completed_deep_capture().expect("the capture published above should be retrievable");
+        assert_eq!(taken.draw_calls.len(), 1);
+        assert!(taken.resources_finalized);
+        assert_eq!(
+            taken.buffer_contents(DeepCaptureBufferKind::Quads).map(|contents| &contents.bytes),
+            Some(&quads_bytes)
+        );
+        assert!(
+            taken.buffer_contents(DeepCaptureBufferKind::Shadows).is_none(),
+            "a buffer kind that was never touched should not be present"
+        );
+
+        assert!(
+            take_completed_deep_capture().is_none(),
+            "taking the completed capture should clear the mailbox, so a second take is empty"
+        );
+    }
 }

--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -265,16 +265,26 @@ impl DrawCallCounters {
     }
 }
 
-/// Which `PrimitiveBatch` kind a [`record_draw_call`] call is tallying.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DrawCallKind {
+/// Which `PrimitiveBatch` kind a [`record_draw_call`] call is tallying. `pub`
+/// (not `pub(crate)`) since Phase 4's [`DeepCaptureDrawCall::kind`] field also
+/// uses this type and is itself part of the public `flamegraph` API surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DrawCallKind {
+    /// `PrimitiveBatch::Quads`.
     Quads,
+    /// `PrimitiveBatch::Shadows`.
     Shadows,
+    /// `PrimitiveBatch::MonochromeSprites`.
     MonoSprites,
+    /// `PrimitiveBatch::PolychromeSprites`.
     PolySprites,
+    /// `PrimitiveBatch::Paths`.
     Paths,
+    /// `PrimitiveBatch::Underlines`.
     Underlines,
+    /// `PrimitiveBatch::BackdropFilters`.
     BackdropFilters,
+    /// `PrimitiveBatch::Surfaces`.
     Surfaces,
 }
 
@@ -1500,6 +1510,210 @@ fn frame_capture_memory_usage(frame: &FrameCapture) -> u64 {
         * (core::mem::size_of::<CpuSpan>() as u64);
     let gpu_span_bytes = (frame.gpu_spans.len() as u64) * (core::mem::size_of::<GpuSpan>() as u64);
     core::mem::size_of::<FrameCapture>() as u64 + cpu_span_bytes + gpu_span_bytes
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: on-demand GPU deep capture (issue #60).
+//
+// Everything above this point is the phase 1-3 always-on-capable path: cheap
+// enough (a handful of relaxed atomic loads plus, while a session is
+// recording, some bookkeeping) to leave instrumented in a shipping build.
+// `DeepCapture` is deliberately not part of that path. Reading back full
+// buffer contents is orders of magnitude more expensive than the timestamp
+// pairs `flamegraph_gpu`'s `GpuQueryManager` resolves every frame, so this
+// models a completely separate, single-shot mode: armed explicitly with
+// `request_deep_capture()`, fires once on the very next `WgpuRenderer::draw()`
+// call, and is torn down (its wgpu staging buffers dropped) the moment
+// readback completes. There is no persistent state here beyond one
+// `AtomicBool` (armed?) and one `Mutex<Option<DeepCapture>>` (last completed
+// result) -- the expensive state (staging buffers, in-flight command stream)
+// lives entirely in `flamegraph_gpu::DeepCaptureRecorder` /
+// `DeepCapturePendingReadback`, scoped to `WgpuRenderer` and only allocated
+// while a capture is actually in flight.
+//
+// Resource contents are read back once per touched fixed buffer for the
+// whole captured frame, not once per draw call boundary as a literal reading
+// of "resource contents at time of use" might suggest. This is intentional:
+// every fixed buffer in `WgpuContext` (`quads_buffer`, `shadows_buffer`, ...)
+// is written exactly once per frame, with the *entire* frame's data for that
+// primitive kind, before any draw call reads from it (see
+// `WgpuRenderer::draw`'s `ensure_buffer_size`/`write_buffer` calls, which all
+// happen before the render-pass loop). So a buffer's contents are already
+// identical at every draw call boundary that reads it within one frame --
+// reading it back per call would mean N redundant `map_async` round trips of
+// the same bytes for N draw calls sharing that buffer, for zero additional
+// information. Recording each draw call's `vertex_range`/`instance_range`
+// alongside the once-per-buffer snapshot is exactly as informative (a viewer
+// slices the snapshot using those ranges) at a fraction of the readback cost.
+//
+// Same "no natural path to the data" constraint phases 1-3 kept hitting
+// applies here too: `WgpuContext`'s fixed buffers are `pub(super)` to
+// `platform::cross`, invisible to this module and to `flamegraph_gpu.rs`
+// (neither lives inside that module). Rather than widening that visibility,
+// the buffer-copy commands are recorded from `WgpuRenderer::draw` itself
+// (which already holds live `&wgpu::Buffer` references for its own bind-group
+// setup), and only the resulting `wgpu::Buffer` staging handles/state machine
+// live in `flamegraph_gpu.rs`.
+
+/// Which of `WgpuContext`'s fixed-size resource buffers (`src/platform/cross/
+/// render_context.rs`) fed a [`DeepCaptureDrawCall`]. `Surfaces` batches build
+/// a fresh per-surface uniform buffer on every call rather than reading one of
+/// these shared buffers, so `DeepCaptureDrawCall::buffer_kind` is `None` for
+/// them -- there is deliberately no `Surfaces` variant here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DeepCaptureBufferKind {
+    /// `WgpuContext::quads_buffer`.
+    Quads,
+    /// `WgpuContext::shadows_buffer`.
+    Shadows,
+    /// `WgpuContext::underlines_buffer`.
+    Underlines,
+    /// `WgpuContext::mono_sprites_buffer`.
+    MonoSprites,
+    /// `WgpuContext::poly_sprites_buffer`.
+    PolySprites,
+    /// `WgpuContext::backdrop_filters_buffer`.
+    BackdropFilters,
+    /// `WgpuContext::paths_vertices_buffer`.
+    Paths,
+}
+
+/// One entry in a [`DeepCapture`]'s command stream: full identifying detail
+/// for a single `RenderPass::draw` call recorded during the one triggered
+/// frame, in submission order. Walks the same `PrimitiveBatch` match arms in
+/// `WgpuRenderer::draw` that phase 2's `record_draw_call` already tallies
+/// counts from (see `DrawCallCounters`) -- this is the same call sites,
+/// recording identifying detail instead of just a running total.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeepCaptureDrawCall {
+    /// Position in the command stream, 0-based, in submission order.
+    pub sequence: u32,
+    /// Which `PrimitiveBatch` kind this call issued.
+    pub kind: DrawCallKind,
+    /// The `wgpu::RenderPipeline` label bound for this call (see
+    /// `WgpuPipelines` in `renderer.rs`, e.g. `"quads"`, `"mono_sprites"`).
+    /// Doubles as shader identity per the issue's ask: each `DrawCallKind`
+    /// maps 1:1 to exactly one pipeline/shader module in `WgpuRenderer::draw`,
+    /// so the pipeline label already uniquely identifies the shader.
+    pub pipeline_label: &'static str,
+    /// The render pass this call was recorded into (`"main"`,
+    /// `"main_resumed"`, `"filter_group"`, or `"filter_group_resumed"` --
+    /// see `GpuPassKind`, which this mirrors).
+    pub pass_label: &'static str,
+    /// Vertex range passed to `RenderPass::draw` (start, end).
+    pub vertex_range: (u32, u32),
+    /// Instance range passed to `RenderPass::draw` (start, end).
+    pub instance_range: (u32, u32),
+    /// Number of bind groups set for this call (2-4 depending on kind).
+    pub bind_group_count: u32,
+    /// Which fixed resource buffer (if any) this call's instance/vertex data
+    /// came from; see [`DeepCaptureBufferKind`]'s doc comment for why
+    /// `Surfaces` calls are always `None` here.
+    pub buffer_kind: Option<DeepCaptureBufferKind>,
+    /// `(AtlasTextureKind as u64) << 32 | AtlasTextureId::index`, for sprite
+    /// calls (`MonoSprites`/`PolySprites`); `None` for every other kind.
+    pub atlas_texture_id: Option<u64>,
+}
+
+/// One fixed buffer's full contents at the time of the triggered frame, part
+/// of a [`DeepCapture`]. Read back once per buffer touched by that frame's
+/// command stream -- see the module-level comment above this section for why
+/// once-per-buffer (not once-per-draw-call) is both sufficient and far
+/// cheaper.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeepCaptureBufferContents {
+    /// Which buffer this is.
+    pub kind: DeepCaptureBufferKind,
+    /// Raw bytes copied back from the GPU buffer, from offset 0 through the
+    /// buffer's full `wgpu::Buffer::size()` (which may include unwritten
+    /// tail bytes past what this frame actually wrote -- a viewer should
+    /// slice using the `vertex_range`/`instance_range` recorded on the
+    /// [`DeepCaptureDrawCall`]s that reference this buffer, not assume the
+    /// whole slice is meaningful).
+    pub bytes: Vec<u8>,
+}
+
+/// One on-demand, single-frame "deep capture" (Phase 4 of the profiling
+/// epic, issue #60): the full command stream and fixed-buffer resource
+/// contents for exactly one triggered `WgpuRenderer::draw()` call. See the
+/// module-level comment above this section for the full design rationale and
+/// how this differs from phase 1's always-on [`Capture`].
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct DeepCapture {
+    /// Every `RenderPass::draw` call issued during the captured frame, in
+    /// submission order.
+    pub draw_calls: Vec<DeepCaptureDrawCall>,
+    /// Full contents of each fixed buffer touched by at least one entry in
+    /// `draw_calls`, one entry per distinct [`DeepCaptureBufferKind`] seen.
+    pub buffer_contents: Vec<DeepCaptureBufferContents>,
+    /// Whether every buffer readback that was attempted actually completed
+    /// successfully. `true` for an empty `draw_calls`/`buffer_contents` (there
+    /// was nothing to read back). `false` if any individual buffer's
+    /// `map_async` reported an error -- that buffer is simply missing from
+    /// `buffer_contents` rather than the whole capture being discarded, so a
+    /// partial result is still usable.
+    pub resources_finalized: bool,
+}
+
+impl DeepCapture {
+    /// The buffer contents recorded for `kind`, if that buffer was touched by
+    /// this capture's command stream and its readback completed.
+    pub fn buffer_contents(&self, kind: DeepCaptureBufferKind) -> Option<&DeepCaptureBufferContents> {
+        self.buffer_contents.iter().find(|contents| contents.kind == kind)
+    }
+}
+
+/// Whether a deep capture has been armed (via [`request_deep_capture`]) but
+/// not yet consumed by a `WgpuRenderer::draw()` call.
+static DEEP_CAPTURE_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// The most recently completed deep capture, if any and if it has not
+/// already been taken by [`take_completed_deep_capture`].
+static COMPLETED_DEEP_CAPTURE: parking_lot::Mutex<Option<DeepCapture>> = parking_lot::Mutex::new(None);
+
+/// Arm a one-shot deep GPU capture: full command stream plus fixed-buffer
+/// resource contents for the very next `WgpuRenderer::draw()` call. Distinct
+/// from [`start_capture`]'s always-on session -- see this module's Phase 4
+/// section doc comment for why full resource readback needs its own,
+/// far-more-expensive, non-persistent path. Independent of whether a phase
+/// 1-3 capture session is currently running: a deep capture can be requested
+/// with or without one active.
+///
+/// Calling this while a deep capture is already armed or actively being read
+/// back is a no-op; the in-flight one is left to finish. Check
+/// [`deep_capture_requested`]/[`take_completed_deep_capture`] if that
+/// distinction matters to the caller.
+pub fn request_deep_capture() {
+    DEEP_CAPTURE_REQUESTED.store(true, Ordering::Release);
+}
+
+/// Whether a deep capture has been requested but not yet started recording.
+/// Does not reflect a capture that has started recording but not finished
+/// readback -- there is no public "in progress" signal this round, only
+/// "requested" and "the last completed result" (see
+/// [`take_completed_deep_capture`]).
+pub fn deep_capture_requested() -> bool {
+    DEEP_CAPTURE_REQUESTED.load(Ordering::Acquire)
+}
+
+/// Consume the pending request, if any, so at most one `WgpuRenderer::draw()`
+/// call starts recording per `request_deep_capture()` call.
+pub(crate) fn take_deep_capture_request() -> bool {
+    DEEP_CAPTURE_REQUESTED.swap(false, Ordering::AcqRel)
+}
+
+/// Publish a finished deep capture, overwriting whatever the previous one
+/// left behind if it was never collected. Called by
+/// `flamegraph_gpu::DeepCapturePendingReadback::poll` once every touched
+/// buffer's readback has resolved (successfully or not).
+pub(crate) fn complete_deep_capture(capture: DeepCapture) {
+    *COMPLETED_DEEP_CAPTURE.lock() = Some(capture);
+}
+
+/// Take the most recently completed deep capture, if any, clearing it so a
+/// second call returns `None` until another capture finishes.
+pub fn take_completed_deep_capture() -> Option<DeepCapture> {
+    COMPLETED_DEEP_CAPTURE.lock().take()
 }
 
 #[cfg(test)]

--- a/src/flamegraph_gpu.rs
+++ b/src/flamegraph_gpu.rs
@@ -445,3 +445,98 @@ pub(crate) fn sync_with_active_capture(
         _ => {}
     }
 }
+
+// ---------------------------------------------------------------------------
+// Phase 4: on-demand GPU deep capture (issue #60).
+//
+// `DeepCaptureRecorder`/`DeepCapturePendingReadback` deliberately do not
+// reuse `GpuQueryManager`'s triple-buffered generation array: a deep capture
+// is single-shot and torn down the moment its readback completes (see
+// `flamegraph.rs`'s Phase 4 section doc comment), so there is nothing to
+// triple-buffer -- at most one `DeepCapturePendingReadback` exists at a time,
+// held in `WgpuRenderer::deep_capture`. The *shape* of the readback state
+// machine (record during the frame -> copy into a staging buffer before
+// `encoder.finish()` -> `map_async` after submit -> poll non-blockingly on
+// the render thread every frame until ready -> harvest) is intentionally the
+// same pattern `QueryGeneration` above uses, for the same reason documented
+// in this file's module docs: this device may only safely be polled from the
+// render thread that submits to it.
+//
+// This stage (first commit of Phase 4) wires the arm/fire/teardown lifecycle
+// end-to-end with an intentionally empty command stream and no resource
+// readback -- `WgpuRenderer::draw` doesn't call `record_draw_call` yet, so
+// `finish` always sees zero touched buffers. Real per-draw-call recording and
+// real buffer readback land in the two commits that follow, each replacing
+// one of the two stub bodies below without changing this type's public
+// shape.
+
+/// Accumulates one triggered frame's command stream while `WgpuRenderer::draw`
+/// is recording it. Created fresh by `WgpuRenderer::draw` when
+/// `flamegraph::take_deep_capture_request()` returns true, consumed by
+/// `finish` once the frame's `PrimitiveBatch` loop completes.
+pub(crate) struct DeepCaptureRecorder {
+    draw_calls: Vec<flamegraph::DeepCaptureDrawCall>,
+}
+
+impl DeepCaptureRecorder {
+    pub(crate) fn new() -> Self {
+        Self {
+            draw_calls: Vec::new(),
+        }
+    }
+
+    /// Finish recording and hand off to the readback phase. Must be called
+    /// after the frame's render-pass loop has ended (so `draw_calls` is
+    /// complete) and before `encoder.finish()` (once resource readback lands,
+    /// this will need to record buffer-copy commands into `encoder`).
+    pub(crate) fn finish(self, device: &wgpu::Device) -> DeepCapturePendingReadback {
+        // Stub: no wgpu resources to copy yet, since `draw_calls` never holds
+        // a `buffer_kind` this round. `device` is accepted now so the later
+        // commit that starts creating staging buffers doesn't need to change
+        // this method's call site in `WgpuRenderer::draw`.
+        let _ = device;
+        DeepCapturePendingReadback {
+            draw_calls: self.draw_calls,
+            resources_finalized: true,
+        }
+    }
+}
+
+/// A deep capture's command stream, mid-readback. Held in
+/// `WgpuRenderer::deep_capture` from the frame it was recorded until
+/// `poll` reports the readback complete, at which point `WgpuRenderer::draw`
+/// drops it -- freeing any staging buffers it holds -- and publishes the
+/// result via `flamegraph::complete_deep_capture`.
+pub(crate) struct DeepCapturePendingReadback {
+    draw_calls: Vec<flamegraph::DeepCaptureDrawCall>,
+    resources_finalized: bool,
+}
+
+impl DeepCapturePendingReadback {
+    /// Start any async readback maps. Must be called once, after the encoder
+    /// `finish` recorded copy commands into (once resource readback lands)
+    /// has actually been submitted to the queue -- mirrors
+    /// `GpuQueryManager::begin_readback`'s same ordering requirement.
+    pub(crate) fn begin_readback(&mut self) {
+        // Stub: nothing to map yet.
+    }
+
+    /// Non-blocking poll (mirrors `GpuQueryManager::poll_readback`'s
+    /// same-thread, non-blocking pattern documented at the top of this
+    /// file). Returns the finished [`flamegraph::DeepCapture`] once every
+    /// touched buffer's map has resolved (successfully or not); the caller
+    /// is expected to drop `self` immediately afterward, satisfying "no
+    /// persistent overhead, no persistent buffers" once a capture is done.
+    pub(crate) fn poll(&mut self, device: &wgpu::Device) -> Option<flamegraph::DeepCapture> {
+        // Stub: nothing pending, so this is always immediately "ready" -- the
+        // very next `WgpuRenderer::draw` call after `begin_readback` reaps
+        // it. Once real buffer readback lands, this gates on `map_async`
+        // completion the same way `QueryGeneration::try_harvest` does.
+        let _ = device;
+        Some(flamegraph::DeepCapture {
+            draw_calls: std::mem::take(&mut self.draw_calls),
+            buffer_contents: Vec::new(),
+            resources_finalized: self.resources_finalized,
+        })
+    }
+}

--- a/src/flamegraph_gpu.rs
+++ b/src/flamegraph_gpu.rs
@@ -28,7 +28,10 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use crate::flamegraph::{self, GpuClockCalibration, GpuPassKind, GpuSpan, SpanName};
+use crate::flamegraph::{
+    self, DeepCaptureBufferKind, DeepCaptureDrawCall, DrawCallKind, GpuClockCalibration, GpuPassKind, GpuSpan,
+    SpanName,
+};
 
 /// Timestamp-pair budget per frame: main/main_resumed/up to 4 nested filter
 /// groups + resumes/fast_surface_blit, with headroom, plus the whole-encoder
@@ -475,14 +478,57 @@ pub(crate) fn sync_with_active_capture(
 /// `flamegraph::take_deep_capture_request()` returns true, consumed by
 /// `finish` once the frame's `PrimitiveBatch` loop completes.
 pub(crate) struct DeepCaptureRecorder {
-    draw_calls: Vec<flamegraph::DeepCaptureDrawCall>,
+    draw_calls: Vec<DeepCaptureDrawCall>,
+    /// Distinct `DeepCaptureBufferKind`s seen across `draw_calls` so far, in
+    /// first-seen order. Small (at most 7 possible kinds) so a linear-scan
+    /// `contains` check on every `record_draw_call` is cheaper than a
+    /// `HashSet` and avoids pulling in a hasher for something this size.
+    touched_buffers: Vec<DeepCaptureBufferKind>,
 }
 
 impl DeepCaptureRecorder {
     pub(crate) fn new() -> Self {
         Self {
             draw_calls: Vec::new(),
+            touched_buffers: Vec::new(),
         }
+    }
+
+    /// Record one `RenderPass::draw` call's full identifying detail. Called
+    /// from every `PrimitiveBatch` match arm in `WgpuRenderer::draw` that
+    /// phase 2's `record_draw_call` (a different, counter-only function of
+    /// the same name in `flamegraph.rs`) already instruments -- same call
+    /// sites, recording detail instead of just a running tally.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn record_draw_call(
+        &mut self,
+        kind: DrawCallKind,
+        pipeline_label: &'static str,
+        pass_label: &'static str,
+        vertex_range: std::ops::Range<u32>,
+        instance_range: std::ops::Range<u32>,
+        bind_group_count: u32,
+        buffer_kind: Option<DeepCaptureBufferKind>,
+        atlas_texture_id: Option<u64>,
+    ) {
+        if let Some(buffer_kind) = buffer_kind
+            && !self.touched_buffers.contains(&buffer_kind)
+        {
+            self.touched_buffers.push(buffer_kind);
+        }
+
+        let sequence = self.draw_calls.len() as u32;
+        self.draw_calls.push(DeepCaptureDrawCall {
+            sequence,
+            kind,
+            pipeline_label,
+            pass_label,
+            vertex_range: (vertex_range.start, vertex_range.end),
+            instance_range: (instance_range.start, instance_range.end),
+            bind_group_count,
+            buffer_kind,
+            atlas_texture_id,
+        });
     }
 
     /// Finish recording and hand off to the readback phase. Must be called
@@ -490,11 +536,13 @@ impl DeepCaptureRecorder {
     /// complete) and before `encoder.finish()` (once resource readback lands,
     /// this will need to record buffer-copy commands into `encoder`).
     pub(crate) fn finish(self, device: &wgpu::Device) -> DeepCapturePendingReadback {
-        // Stub: no wgpu resources to copy yet, since `draw_calls` never holds
-        // a `buffer_kind` this round. `device` is accepted now so the later
-        // commit that starts creating staging buffers doesn't need to change
-        // this method's call site in `WgpuRenderer::draw`.
+        // Stub: resource readback lands in the next commit. `device` is
+        // accepted now so that commit doesn't need to change this method's
+        // call site in `WgpuRenderer::draw`. `touched_buffers` is already
+        // tracked above so the real `finish` only needs to add the
+        // buffer-copy/staging logic, not any new bookkeeping.
         let _ = device;
+        let _ = &self.touched_buffers;
         DeepCapturePendingReadback {
             draw_calls: self.draw_calls,
             resources_finalized: true,

--- a/src/flamegraph_gpu.rs
+++ b/src/flamegraph_gpu.rs
@@ -25,7 +25,7 @@
 
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
 use crate::flamegraph::{
@@ -465,13 +465,13 @@ pub(crate) fn sync_with_active_capture(
 // in this file's module docs: this device may only safely be polled from the
 // render thread that submits to it.
 //
-// This stage (first commit of Phase 4) wires the arm/fire/teardown lifecycle
-// end-to-end with an intentionally empty command stream and no resource
-// readback -- `WgpuRenderer::draw` doesn't call `record_draw_call` yet, so
-// `finish` always sees zero touched buffers. Real per-draw-call recording and
-// real buffer readback land in the two commits that follow, each replacing
-// one of the two stub bodies below without changing this type's public
-// shape.
+// Resource readback covers `WgpuContext`'s fixed buffers only (quads,
+// shadows, underlines, mono/poly sprites, backdrop filters, paths vertices)
+// -- not the atlas or surface textures the issue also mentions. See
+// `flamegraph.rs`'s Phase 4 section doc comment for why buffers are read
+// back once per touched kind rather than once per draw call, and this
+// module's final Phase 4 doc note (bottom of file) for why texture readback
+// specifically was scoped out of this round.
 
 /// Accumulates one triggered frame's command stream while `WgpuRenderer::draw`
 /// is recording it. Created fresh by `WgpuRenderer::draw` when
@@ -531,23 +531,85 @@ impl DeepCaptureRecorder {
         });
     }
 
-    /// Finish recording and hand off to the readback phase. Must be called
-    /// after the frame's render-pass loop has ended (so `draw_calls` is
-    /// complete) and before `encoder.finish()` (once resource readback lands,
-    /// this will need to record buffer-copy commands into `encoder`).
-    pub(crate) fn finish(self, device: &wgpu::Device) -> DeepCapturePendingReadback {
-        // Stub: resource readback lands in the next commit. `device` is
-        // accepted now so that commit doesn't need to change this method's
-        // call site in `WgpuRenderer::draw`. `touched_buffers` is already
-        // tracked above so the real `finish` only needs to add the
-        // buffer-copy/staging logic, not any new bookkeeping.
-        let _ = device;
-        let _ = &self.touched_buffers;
+    /// Finish recording and hand off to the readback phase: for every
+    /// distinct buffer kind touched by this frame's command stream, look it
+    /// up in `buffers`, allocate a same-sized `MAP_READ` staging buffer, and
+    /// record a `copy_buffer_to_buffer` from the live buffer into it. Must be
+    /// called after the frame's render-pass loop has ended (so `draw_calls`
+    /// is complete, and the live buffers are no longer borrowed by an active
+    /// `RenderPass`) and before `encoder.finish()` (the copy commands have to
+    /// land in the same encoder submission as the draws they're snapshotting
+    /// after).
+    ///
+    /// `buffers` is expected to list every `DeepCaptureBufferKind` `WgpuContext`
+    /// actually has a fixed buffer for (see that type's variants); a touched
+    /// kind missing from `buffers` is silently skipped rather than panicking,
+    /// since `finish` has no way to distinguish "programmer error" from "this
+    /// buffer kind doesn't apply to the current renderer configuration" --
+    /// either way, dropping one buffer's contents from an otherwise-useful
+    /// capture is better than losing the whole thing.
+    pub(crate) fn finish(
+        self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        buffers: &[(DeepCaptureBufferKind, &wgpu::Buffer)],
+    ) -> DeepCapturePendingReadback {
+        let mut staging = Vec::with_capacity(self.touched_buffers.len());
+        for kind in &self.touched_buffers {
+            let Some((_, source)) = buffers.iter().find(|(candidate, _)| candidate == kind) else {
+                continue;
+            };
+            let size = source.size();
+            if size == 0 {
+                continue;
+            }
+            let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("flamegraph_deep_capture_staging_buffer"),
+                size,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            encoder.copy_buffer_to_buffer(source, 0, &staging_buffer, 0, size);
+            staging.push(DeepCaptureStagingBuffer {
+                kind: *kind,
+                size,
+                buffer: staging_buffer,
+                map_state: Arc::new(AtomicU8::new(MAP_STATE_PENDING)),
+            });
+        }
+
         DeepCapturePendingReadback {
             draw_calls: self.draw_calls,
-            resources_finalized: true,
+            staging,
+            state: PendingReadbackState::AwaitingSubmit,
         }
     }
+}
+
+/// One touched buffer's readback: the live buffer's kind (for tagging the
+/// resulting [`flamegraph::DeepCaptureBufferContents`]), its size (both
+/// buffers are this size -- `copy_buffer_to_buffer` requires matching
+/// lengths), the staging buffer itself, and the async map's completion state.
+struct DeepCaptureStagingBuffer {
+    kind: DeepCaptureBufferKind,
+    size: u64,
+    buffer: wgpu::Buffer,
+    map_state: Arc<AtomicU8>,
+}
+
+const MAP_STATE_PENDING: u8 = 0;
+const MAP_STATE_OK: u8 = 1;
+const MAP_STATE_ERR: u8 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingReadbackState {
+    /// `finish` has recorded the copy commands but the encoder holding them
+    /// has not been submitted yet -- `map_async` must not be called until it
+    /// has (mapping a buffer that a not-yet-submitted copy still targets is a
+    /// wgpu validation error).
+    AwaitingSubmit,
+    /// `begin_readback` has been called; waiting on `staging`'s maps.
+    MapPending,
 }
 
 /// A deep capture's command stream, mid-readback. Held in
@@ -556,35 +618,279 @@ impl DeepCaptureRecorder {
 /// drops it -- freeing any staging buffers it holds -- and publishes the
 /// result via `flamegraph::complete_deep_capture`.
 pub(crate) struct DeepCapturePendingReadback {
-    draw_calls: Vec<flamegraph::DeepCaptureDrawCall>,
-    resources_finalized: bool,
+    draw_calls: Vec<DeepCaptureDrawCall>,
+    staging: Vec<DeepCaptureStagingBuffer>,
+    state: PendingReadbackState,
 }
 
 impl DeepCapturePendingReadback {
-    /// Start any async readback maps. Must be called once, after the encoder
-    /// `finish` recorded copy commands into (once resource readback lands)
-    /// has actually been submitted to the queue -- mirrors
-    /// `GpuQueryManager::begin_readback`'s same ordering requirement.
+    /// Start the async readback maps for every staging buffer `finish`
+    /// created. Must be called once, after the encoder `finish` recorded copy
+    /// commands into has actually been submitted to the queue -- mirrors
+    /// `GpuQueryManager::begin_readback`'s same ordering requirement, for the
+    /// same reason (see [`PendingReadbackState::AwaitingSubmit`]).
     pub(crate) fn begin_readback(&mut self) {
-        // Stub: nothing to map yet.
+        if self.state != PendingReadbackState::AwaitingSubmit {
+            return;
+        }
+        for staging in &self.staging {
+            let map_state = staging.map_state.clone();
+            staging.buffer.slice(0..staging.size).map_async(wgpu::MapMode::Read, move |result| {
+                map_state.store(
+                    if result.is_ok() { MAP_STATE_OK } else { MAP_STATE_ERR },
+                    Ordering::Release,
+                );
+            });
+        }
+        self.state = PendingReadbackState::MapPending;
     }
 
     /// Non-blocking poll (mirrors `GpuQueryManager::poll_readback`'s
     /// same-thread, non-blocking pattern documented at the top of this
     /// file). Returns the finished [`flamegraph::DeepCapture`] once every
-    /// touched buffer's map has resolved (successfully or not); the caller
+    /// touched buffer's map has resolved -- successfully or not, so a single
+    /// failed map can't leave this capture stuck pending forever; the caller
     /// is expected to drop `self` immediately afterward, satisfying "no
     /// persistent overhead, no persistent buffers" once a capture is done.
     pub(crate) fn poll(&mut self, device: &wgpu::Device) -> Option<flamegraph::DeepCapture> {
-        // Stub: nothing pending, so this is always immediately "ready" -- the
-        // very next `WgpuRenderer::draw` call after `begin_readback` reaps
-        // it. Once real buffer readback lands, this gates on `map_async`
-        // completion the same way `QueryGeneration::try_harvest` does.
-        let _ = device;
+        if self.state != PendingReadbackState::MapPending {
+            return None;
+        }
+        let _ = device.poll(wgpu::PollType::Poll);
+        let all_resolved = self
+            .staging
+            .iter()
+            .all(|staging| staging.map_state.load(Ordering::Acquire) != MAP_STATE_PENDING);
+        if !all_resolved {
+            return None;
+        }
+
+        let mut resources_finalized = true;
+        let mut buffer_contents = Vec::with_capacity(self.staging.len());
+        for staging in &self.staging {
+            if staging.map_state.load(Ordering::Acquire) != MAP_STATE_OK {
+                resources_finalized = false;
+                continue;
+            }
+            let slice = staging.buffer.slice(0..staging.size);
+            match slice.get_mapped_range() {
+                Ok(view) => {
+                    buffer_contents.push(flamegraph::DeepCaptureBufferContents {
+                        kind: staging.kind,
+                        bytes: view.to_vec(),
+                    });
+                }
+                Err(_) => resources_finalized = false,
+            }
+            staging.buffer.unmap();
+        }
+
         Some(flamegraph::DeepCapture {
             draw_calls: std::mem::take(&mut self.draw_calls),
-            buffer_contents: Vec::new(),
-            resources_finalized: self.resources_finalized,
+            buffer_contents,
+            resources_finalized,
         })
+    }
+}
+
+// Deferred this round: texture content readback (atlas mono/poly textures,
+// surface textures). The issue's "resource contents" bullet covers both
+// buffers and textures; this implementation covers buffers only.
+//
+// Reasoning for the cut: every fixed buffer above is one `wgpu::Buffer` of a
+// known, stable usage flag set, so one `copy_buffer_to_buffer` + one staging
+// buffer per kind (7 total, worst case) is all `DeepCaptureRecorder::finish`
+// needs. Textures are a meaningfully different shape of problem --
+// `copy_texture_to_buffer` requires `bytes_per_row` padded to
+// `COPY_BYTES_PER_ROW_ALIGNMENT` (256), the atlas has a dynamic, growable
+// number of monochrome/polychrome texture pages (`WgpuAtlasStorage`, not a
+// single fixed handle), and surface textures vary in count/size/format per
+// registered `SurfaceId` (`SurfaceRegistry`). Getting that right (padding
+// math, iterating a dynamic page/surface list, one staging buffer and
+// `map_async` per texture rather than per fixed field) is a distinctly
+// larger and riskier chunk of work than the buffer case, on top of an
+// already GPU-readback-heavy phase. Per this phase's own risk guidance, a
+// smaller correct slice now (full command stream + pipeline/shader identity
+// + fixed-buffer contents) was chosen over forcing texture readback into the
+// same session. `DeepCaptureDrawCall::atlas_texture_id` still identifies
+// *which* atlas texture a sprite call bound, even though this round can't
+// read that texture's pixels back -- a future pass can add
+// `DeepCaptureTextureContents` alongside `DeepCaptureBufferContents` without
+// needing to change anything landed here.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `DeepCaptureRecorder::record_draw_call`/`touched_buffers` are pure
+    // bookkeeping with no wgpu resource involved, so this is covered without
+    // needing a live `wgpu::Device` -- exercising exactly the logic
+    // `WgpuRenderer::draw`'s `PrimitiveBatch` match arms call into, and the
+    // same touched-buffer tracking `finish` (tested below, where a device is
+    // available) relies on to know which buffers to stage.
+    #[test]
+    fn record_draw_call_builds_command_stream_with_deduped_touched_buffers() {
+        let mut recorder = DeepCaptureRecorder::new();
+
+        recorder.record_draw_call(
+            DrawCallKind::Quads,
+            "quads",
+            "main",
+            0..4,
+            0..10,
+            2,
+            Some(DeepCaptureBufferKind::Quads),
+            None,
+        );
+        recorder.record_draw_call(
+            DrawCallKind::MonoSprites,
+            "mono_sprites",
+            "main",
+            0..4,
+            10..15,
+            4,
+            Some(DeepCaptureBufferKind::MonoSprites),
+            Some(42),
+        );
+        // A second `Quads` call: exercises that `touched_buffers` dedups
+        // rather than recording `DeepCaptureBufferKind::Quads` twice.
+        recorder.record_draw_call(
+            DrawCallKind::Quads,
+            "quads",
+            "main_resumed",
+            0..4,
+            15..20,
+            2,
+            Some(DeepCaptureBufferKind::Quads),
+            None,
+        );
+
+        assert_eq!(recorder.draw_calls.len(), 3, "all three draw calls should be recorded");
+        assert_eq!(
+            recorder.draw_calls.iter().map(|call| call.sequence).collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "sequence should be 0-based submission order"
+        );
+        assert_eq!(recorder.draw_calls[0].kind, DrawCallKind::Quads);
+        assert_eq!(recorder.draw_calls[0].pipeline_label, "quads");
+        assert_eq!(recorder.draw_calls[0].pass_label, "main");
+        assert_eq!(recorder.draw_calls[0].vertex_range, (0, 4));
+        assert_eq!(recorder.draw_calls[0].instance_range, (0, 10));
+        assert_eq!(recorder.draw_calls[0].bind_group_count, 2);
+        assert_eq!(recorder.draw_calls[0].buffer_kind, Some(DeepCaptureBufferKind::Quads));
+        assert_eq!(recorder.draw_calls[0].atlas_texture_id, None);
+
+        assert_eq!(recorder.draw_calls[1].kind, DrawCallKind::MonoSprites);
+        assert_eq!(recorder.draw_calls[1].atlas_texture_id, Some(42));
+
+        assert_eq!(
+            recorder.draw_calls[2].pass_label, "main_resumed",
+            "the third call's pass_label should reflect the pass at the time it was recorded, \
+             independent of the first call's"
+        );
+
+        assert_eq!(
+            recorder.touched_buffers,
+            vec![DeepCaptureBufferKind::Quads, DeepCaptureBufferKind::MonoSprites],
+            "Quads should appear once despite being touched by two draw calls, in first-seen order"
+        );
+    }
+
+    #[test]
+    fn record_draw_call_with_no_buffer_kind_does_not_touch_anything() {
+        let mut recorder = DeepCaptureRecorder::new();
+        recorder.record_draw_call(DrawCallKind::Surfaces, "surfaces", "main", 0..4, 0..1, 2, None, None);
+        assert_eq!(recorder.draw_calls.len(), 1);
+        assert!(
+            recorder.touched_buffers.is_empty(),
+            "Surfaces draws a per-call uniform buffer, not a fixed WgpuContext buffer"
+        );
+    }
+
+    /// Creates a headless (surface-less) `wgpu::Device`/`Queue` for testing
+    /// buffer readback, the same way `WgpuContext::new` does minus the
+    /// window-bound `Surface` (which needs a real window handle this test
+    /// doesn't have). Returns `None` rather than panicking when no adapter is
+    /// available -- this repo has no headless-GPU CI fixture (see
+    /// `render_context.rs`'s test module doc comment for the same caveat on
+    /// phase 3's buffer/texture-size accessors), so a sandbox/CI environment
+    /// with no GPU or software rasterizer skips the readback assertions below
+    /// instead of failing the whole suite.
+    fn create_headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            flags: wgpu::InstanceFlags::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            display: None,
+        });
+        // Mirrors `WgpuContext::new`'s `enumerate_adapters` + pick-first
+        // approach (`render_context.rs`) rather than `request_adapter`, for
+        // the same reason: no `compatible_surface` is available here (there
+        // is no window), and this crate's established pattern already covers
+        // that case.
+        let adapter = pollster::block_on(instance.enumerate_adapters(wgpu::Backends::all()))
+            .into_iter()
+            .next()?;
+        pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default())).ok()
+    }
+
+    /// End-to-end readback test: records a command stream referencing a
+    /// single fake "quads" buffer, runs it through `finish` (stages + copies)
+    /// and `begin_readback`/`poll` (maps + harvests), and asserts the
+    /// harvested `DeepCapture`'s buffer contents match what was written --
+    /// the concrete "resource contents at time of use" claim from the issue,
+    /// covering the fixed-buffer slice of it this phase implements.
+    #[test]
+    fn finish_and_poll_read_back_real_buffer_contents() {
+        let Some((device, queue)) = create_headless_device() else {
+            eprintln!(
+                "skipping finish_and_poll_read_back_real_buffer_contents: no wgpu adapter available in this environment"
+            );
+            return;
+        };
+
+        let source_bytes: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let source_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("test_quads_buffer"),
+            size: source_bytes.len() as u64,
+            usage: wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&source_buffer, 0, &source_bytes);
+
+        let mut recorder = DeepCaptureRecorder::new();
+        recorder.record_draw_call(
+            DrawCallKind::Quads,
+            "quads",
+            "main",
+            0..4,
+            0..1,
+            2,
+            Some(DeepCaptureBufferKind::Quads),
+            None,
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let mut pending = recorder.finish(&device, &mut encoder, &[(DeepCaptureBufferKind::Quads, &source_buffer)]);
+        queue.submit(Some(encoder.finish()));
+        pending.begin_readback();
+
+        let capture = loop {
+            let _ = device.poll(wgpu::PollType::wait_indefinitely());
+            if let Some(capture) = pending.poll(&device) {
+                break capture;
+            }
+        };
+
+        assert_eq!(capture.draw_calls.len(), 1);
+        assert!(capture.resources_finalized, "the one touched buffer's readback should have succeeded");
+        let contents = capture
+            .buffer_contents(DeepCaptureBufferKind::Quads)
+            .expect("Quads buffer should have been read back");
+        assert_eq!(
+            contents.bytes, source_bytes,
+            "readback bytes should match exactly what was written to the source buffer"
+        );
     }
 }

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -1506,6 +1506,15 @@ pub struct WgpuRenderer {
     // plain field.
     #[cfg(feature = "flamegraph")]
     gpu_query_manager: parking_lot::Mutex<Option<crate::flamegraph_gpu::GpuQueryManager>>,
+
+    // On-demand GPU deep capture (issue #60). `None` except for the brief
+    // window between a `flamegraph::request_deep_capture()` call firing on a
+    // `draw()` and that capture's resource readback completing a few frames
+    // later -- see `flamegraph_gpu`'s Phase 4 section doc comment for why
+    // this is a completely separate, non-persistent path from
+    // `gpu_query_manager` above rather than sharing its machinery.
+    #[cfg(feature = "flamegraph")]
+    deep_capture: parking_lot::Mutex<Option<crate::flamegraph_gpu::DeepCapturePendingReadback>>,
 }
 
 impl WgpuRenderer {
@@ -1683,6 +1692,8 @@ impl WgpuRenderer {
             layout_version: Arc::new(AtomicU64::new(0)),
             #[cfg(feature = "flamegraph")]
             gpu_query_manager: parking_lot::Mutex::new(None),
+            #[cfg(feature = "flamegraph")]
+            deep_capture: parking_lot::Mutex::new(None),
         })
     }
 
@@ -1741,6 +1752,28 @@ impl WgpuRenderer {
                 command_encoder.write_timestamp(reserved.query_set(), reserved.begin_index());
             }
             reserved
+        };
+
+        // On-demand GPU deep capture (issue #60): harvest any previous deep
+        // capture whose readback has completed (non-blocking, same
+        // render-thread poll pattern as the query manager above), then arm a
+        // new recorder for *this* frame if one was requested and none is
+        // currently in flight. See `flamegraph_gpu`'s Phase 4 section doc
+        // comment for the full lifecycle this participates in.
+        #[cfg(feature = "flamegraph")]
+        let mut deep_capture_recorder: Option<crate::flamegraph_gpu::DeepCaptureRecorder> = {
+            let mut guard = self.deep_capture.lock();
+            if let Some(pending) = guard.as_mut()
+                && let Some(capture) = pending.poll(&self.context.device)
+            {
+                crate::flamegraph::complete_deep_capture(capture);
+                *guard = None;
+            }
+            if guard.is_none() && crate::flamegraph::take_deep_capture_request() {
+                Some(crate::flamegraph_gpu::DeepCaptureRecorder::new())
+            } else {
+                None
+            }
         };
 
         self.atlas.before_frame(&mut command_encoder);
@@ -2658,6 +2691,16 @@ impl WgpuRenderer {
             }
         }
 
+        // On-demand GPU deep capture (issue #60): if this frame was armed for
+        // recording, hand off from `DeepCaptureRecorder` to
+        // `DeepCapturePendingReadback` now -- while `finish` still has a
+        // chance to record any buffer-copy commands into `command_encoder`,
+        // before it's finished below.
+        #[cfg(feature = "flamegraph")]
+        let deep_capture_pending = deep_capture_recorder
+            .take()
+            .map(|recorder| recorder.finish(&self.context.device));
+
         log::debug!("Renderer::draw: submitting command buffer");
         self.context.queue.submit(Some(command_encoder.finish()));
         log::debug!("Renderer::draw: presenting surface");
@@ -2671,6 +2714,19 @@ impl WgpuRenderer {
             if let Some(manager) = guard.as_mut() {
                 manager.begin_readback();
             }
+        }
+
+        // Start this frame's deep-capture readback (if one was armed) now
+        // that its buffer-copy commands, if any, have actually been
+        // submitted, and hand it off to `self.deep_capture` so future
+        // `draw()` calls poll it to completion. Overwrites (rather than
+        // stacking on top of) any prior in-flight deep capture, but that
+        // can't happen in practice: the arm step above only creates a new
+        // recorder when `self.deep_capture` is `None`.
+        #[cfg(feature = "flamegraph")]
+        if let Some(mut pending) = deep_capture_pending {
+            pending.begin_readback();
+            *self.deep_capture.lock() = Some(pending);
         }
 
         log::debug!("Renderer::draw: frame complete");

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -2821,11 +2821,26 @@ impl WgpuRenderer {
         // recording, hand off from `DeepCaptureRecorder` to
         // `DeepCapturePendingReadback` now -- while `finish` still has a
         // chance to record any buffer-copy commands into `command_encoder`,
-        // before it's finished below.
+        // before it's finished below. `quads_buffer_ref`/etc. are the same
+        // guards already held (further up in this function, for the
+        // bind-group setup above) for the whole duration of `draw`, so this
+        // reuses them rather than re-locking.
         #[cfg(feature = "flamegraph")]
-        let deep_capture_pending = deep_capture_recorder
-            .take()
-            .map(|recorder| recorder.finish(&self.context.device));
+        let deep_capture_pending = deep_capture_recorder.take().map(|recorder| {
+            let buffers: [(crate::flamegraph::DeepCaptureBufferKind, &wgpu::Buffer); 7] = [
+                (crate::flamegraph::DeepCaptureBufferKind::Quads, &quads_buffer_ref),
+                (crate::flamegraph::DeepCaptureBufferKind::Shadows, &shadows_buffer_ref),
+                (crate::flamegraph::DeepCaptureBufferKind::Underlines, &underlines_buffer_ref),
+                (crate::flamegraph::DeepCaptureBufferKind::MonoSprites, &mono_sprites_buffer_ref),
+                (crate::flamegraph::DeepCaptureBufferKind::PolySprites, &poly_sprites_buffer_ref),
+                (
+                    crate::flamegraph::DeepCaptureBufferKind::BackdropFilters,
+                    &backdrop_filters_buffer_ref,
+                ),
+                (crate::flamegraph::DeepCaptureBufferKind::Paths, &paths_vertices_buffer_ref),
+            ];
+            recorder.finish(&self.context.device, &mut command_encoder, &buffers)
+        });
 
         log::debug!("Renderer::draw: submitting command buffer");
         self.context.queue.submit(Some(command_encoder.finish()));

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -2183,6 +2183,16 @@ impl WgpuRenderer {
             // `MAX_FILTER_DEPTH` and is being painted inline, unisolated).
             let mut filter_stack: Vec<(FilterBoundary, Option<usize>)> = Vec::new();
 
+            // Deep capture (issue #60): tracks which render pass `pass`
+            // currently points at, so each recorded draw call's `pass_label`
+            // reflects reality even though `pass` gets reassigned mid-loop
+            // (backdrop filters/filter groups end and re-begin it). Kept
+            // outside the `#[cfg(feature = "flamegraph")]` recorder itself
+            // since it's just a `&'static str`, cheaper than gating every one
+            // of its several assignment sites.
+            #[cfg(feature = "flamegraph")]
+            let mut current_pass_label: &'static str = "main";
+
             for batch in scene.batches() {
                 match batch {
                     PrimitiveBatch::Quads(quads) => {
@@ -2194,6 +2204,19 @@ impl WgpuRenderer {
                         quads_first_instance += count;
                         #[cfg(feature = "flamegraph")]
                         crate::record_draw_call(crate::DrawCallKind::Quads, count);
+                        #[cfg(feature = "flamegraph")]
+                        if let Some(recorder) = deep_capture_recorder.as_mut() {
+                            recorder.record_draw_call(
+                                crate::DrawCallKind::Quads,
+                                "quads",
+                                current_pass_label,
+                                0..4,
+                                quads_first_instance - count..quads_first_instance,
+                                2,
+                                Some(crate::flamegraph::DeepCaptureBufferKind::Quads),
+                                None,
+                            );
+                        }
                     }
 
                     PrimitiveBatch::MonochromeSprites {
@@ -2237,6 +2260,19 @@ impl WgpuRenderer {
                         mono_sprites_first_instance += count;
                         #[cfg(feature = "flamegraph")]
                         crate::record_draw_call(crate::DrawCallKind::MonoSprites, count);
+                        #[cfg(feature = "flamegraph")]
+                        if let Some(recorder) = deep_capture_recorder.as_mut() {
+                            recorder.record_draw_call(
+                                crate::DrawCallKind::MonoSprites,
+                                "mono_sprites",
+                                current_pass_label,
+                                0..4,
+                                mono_sprites_first_instance - count..mono_sprites_first_instance,
+                                4,
+                                Some(crate::flamegraph::DeepCaptureBufferKind::MonoSprites),
+                                Some(((texture_id.kind as u64) << 32) | texture_id.index as u64),
+                            );
+                        }
                     }
                     PrimitiveBatch::PolychromeSprites {
                         texture_id,
@@ -2278,6 +2314,19 @@ impl WgpuRenderer {
                         poly_sprites_first_instance += count;
                         #[cfg(feature = "flamegraph")]
                         crate::record_draw_call(crate::DrawCallKind::PolySprites, count);
+                        #[cfg(feature = "flamegraph")]
+                        if let Some(recorder) = deep_capture_recorder.as_mut() {
+                            recorder.record_draw_call(
+                                crate::DrawCallKind::PolySprites,
+                                "poly_sprites",
+                                current_pass_label,
+                                0..4,
+                                poly_sprites_first_instance - count..poly_sprites_first_instance,
+                                3,
+                                Some(crate::flamegraph::DeepCaptureBufferKind::PolySprites),
+                                Some(((texture_id.kind as u64) << 32) | texture_id.index as u64),
+                            );
+                        }
                     }
                     PrimitiveBatch::Shadows(shadows) => {
                         let count = shadows.len() as u32;
@@ -2288,6 +2337,19 @@ impl WgpuRenderer {
                         shadows_first_instance += count;
                         #[cfg(feature = "flamegraph")]
                         crate::record_draw_call(crate::DrawCallKind::Shadows, count);
+                        #[cfg(feature = "flamegraph")]
+                        if let Some(recorder) = deep_capture_recorder.as_mut() {
+                            recorder.record_draw_call(
+                                crate::DrawCallKind::Shadows,
+                                "shadows",
+                                current_pass_label,
+                                0..4,
+                                shadows_first_instance - count..shadows_first_instance,
+                                2,
+                                Some(crate::flamegraph::DeepCaptureBufferKind::Shadows),
+                                None,
+                            );
+                        }
                     }
                     PrimitiveBatch::BackdropFilters(backdrop_filters) => {
                         let count = backdrop_filters.len() as u32;
@@ -2339,6 +2401,10 @@ impl WgpuRenderer {
                             occlusion_query_set: None,
                             multiview_mask: None,
                         });
+                        #[cfg(feature = "flamegraph")]
+                        {
+                            current_pass_label = "main_resumed";
+                        }
 
                         // Now render the backdrop blur quads
                         pass.set_pipeline(&self.pipelines.backdrop_filters_pipeline);
@@ -2352,6 +2418,19 @@ impl WgpuRenderer {
                         backdrop_filters_first_instance += count;
                         #[cfg(feature = "flamegraph")]
                         crate::record_draw_call(crate::DrawCallKind::BackdropFilters, count);
+                        #[cfg(feature = "flamegraph")]
+                        if let Some(recorder) = deep_capture_recorder.as_mut() {
+                            recorder.record_draw_call(
+                                crate::DrawCallKind::BackdropFilters,
+                                "backdrop_filters",
+                                current_pass_label,
+                                0..4,
+                                backdrop_filters_first_instance - count..backdrop_filters_first_instance,
+                                3,
+                                Some(crate::flamegraph::DeepCaptureBufferKind::BackdropFilters),
+                                None,
+                            );
+                        }
                     }
                     PrimitiveBatch::FilterBoundary(index) => {
                         let boundary = scene.filter_boundaries[index];
@@ -2389,6 +2468,10 @@ impl WgpuRenderer {
                                     occlusion_query_set: None,
                                     multiview_mask: None,
                                 });
+                                #[cfg(feature = "flamegraph")]
+                                {
+                                    current_pass_label = "filter_group";
+                                }
 
                                 filter_stack.push((boundary, Some(depth)));
                             }
@@ -2438,6 +2521,10 @@ impl WgpuRenderer {
                                 occlusion_query_set: None,
                                 multiview_mask: None,
                             });
+                            #[cfg(feature = "flamegraph")]
+                            {
+                                current_pass_label = "filter_group_resumed";
+                            }
 
                             // Composite the blurred group content back over the parent using
                             // the same backdrop-filter pipeline, sampling from the group's
@@ -2514,6 +2601,19 @@ impl WgpuRenderer {
                         underlines_first_instance += count;
                         #[cfg(feature = "flamegraph")]
                         crate::record_draw_call(crate::DrawCallKind::Underlines, count);
+                        #[cfg(feature = "flamegraph")]
+                        if let Some(recorder) = deep_capture_recorder.as_mut() {
+                            recorder.record_draw_call(
+                                crate::DrawCallKind::Underlines,
+                                "underlines",
+                                current_pass_label,
+                                0..4,
+                                underlines_first_instance - count..underlines_first_instance,
+                                2,
+                                Some(crate::flamegraph::DeepCaptureBufferKind::Underlines),
+                                None,
+                            );
+                        }
                     }
                     PrimitiveBatch::Surfaces(surfaces) => {
                         log::debug!("Renderer: processing {} surface(s)", surfaces.len());
@@ -2635,6 +2735,19 @@ impl WgpuRenderer {
                                     pass.draw(0..4, 0..1);
                                     #[cfg(feature = "flamegraph")]
                                     crate::record_draw_call(crate::DrawCallKind::Surfaces, 1);
+                                    #[cfg(feature = "flamegraph")]
+                                    if let Some(recorder) = deep_capture_recorder.as_mut() {
+                                        recorder.record_draw_call(
+                                            crate::DrawCallKind::Surfaces,
+                                            "surfaces",
+                                            current_pass_label,
+                                            0..4,
+                                            0..1,
+                                            2,
+                                            None,
+                                            None,
+                                        );
+                                    }
 
                                     // CRITICAL: Keep view alive until after render pass ends
                                     // The bind_group holds a reference to it
@@ -2667,6 +2780,19 @@ impl WgpuRenderer {
                             paths_vertex_offset += vertex_count;
                             #[cfg(feature = "flamegraph")]
                             crate::record_draw_call(crate::DrawCallKind::Paths, paths.len() as u32);
+                            #[cfg(feature = "flamegraph")]
+                            if let Some(recorder) = deep_capture_recorder.as_mut() {
+                                recorder.record_draw_call(
+                                    crate::DrawCallKind::Paths,
+                                    "paths",
+                                    current_pass_label,
+                                    paths_vertex_offset - vertex_count..paths_vertex_offset,
+                                    0..1,
+                                    2,
+                                    Some(crate::flamegraph::DeepCaptureBufferKind::Paths),
+                                    None,
+                                );
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Phase 4 of the profiling/replay epic (#64), building on the merged capture engine (#65), counters (#68), and memory profiling (#70): RenderDoc's core feature — click a draw call, see exactly what fed it. This is a heavyweight, **on-demand, single-frame** capture mode, deliberately separate from phase 1's always-on lightweight spans, since it means reading back full resource contents.

Three staged commits, each independently buildable:

1. `DeepCapture` data model and arm/fire/teardown lifecycle (`src/flamegraph.rs`) — `request_deep_capture()`/`take_completed_deep_capture()`, fires once on the next `WgpuRenderer::draw()`, torn down immediately after harvest. No persistent overhead when not armed.
2. Real command-stream recording wired into all 8 `PrimitiveBatch` match arms in `WgpuRenderer::draw` (`src/platform/cross/renderer.rs`) — pipeline, pass, vertex/instance ranges, bind-group count, buffer kind, and atlas texture id for every draw call in the triggered frame.
3. Real resource readback (`src/flamegraph_gpu.rs`, `DeepCaptureRecorder`/`DeepCapturePendingReadback`) — full byte contents of every fixed `WgpuContext` buffer touched during the frame (quads/shadows/underlines/mono_sprites/poly_sprites/backdrop_filters/paths_vertices), reusing the phase-1 `GpuQueryManager`'s record→submit→map_async→poll-on-render-thread pattern (single-shot instead of continuous, torn down on harvest).

Full design writeup and progress notes: #60 (closed by this PR).

## Deliberately deferred (documented in-code and on #60, not attempted this round)

**Atlas/surface texture content readback.** Recording per-draw-call *identity* (`atlas_texture_id`) is in; reading back the actual texture *bytes* is not. That's a meaningfully larger, separately-risky chunk on its own — row-alignment padding for texture-to-buffer copies, a dynamic atlas page list, a dynamic per-surface list — and forcing it into this same change would have traded a verified, working slice for a larger uncertain one. `atlas_texture_id` is already recorded so a follow-up can add texture readback without touching what's here.

## Test plan

- [x] `cargo build` / `cargo build --release`, with and without `--features flamegraph` — 4/4 clean
- [x] No new dependencies
- [x] `cargo build --release --examples`, both feature configs — clean
- [x] `cargo clippy --release --all-targets --all-features` diffed against a clean `main` checkout — zero new warnings
- [x] Lib tests: 87/87 with the feature (4 new, including a real headless-GPU end-to-end readback test against an actual adapter in the build environment), 79/79 without
- [x] No new `unwrap()`/`expect()` outside tests
- [x] Noted a pre-existing test flake, confirmed present on the phase-3 merge base itself (not introduced by this change) — separate from this PR, flagging for visibility
- [ ] Live windowed run — same sandbox limitation as phases 1-3 (no display server); flagging for whoever reviews with a real display. This phase did get a real headless GPU adapter for its readback test, which phases 1-3 didn't have.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)