### PR TITLE
Add InspectorTab::Profiler variant for the phase 7 viewer UI

### DIFF
--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -74,17 +74,23 @@ mod conditional {
         Layout,
         /// Registered event listeners on the selected element.
         EventListeners,
+        /// CPU+GPU flamegraph/profiler panel, backed by the `flamegraph` capture engine.
+        #[cfg(feature = "flamegraph")]
+        Profiler,
     }
 
     impl InspectorTab {
         /// All tabs in display order.
-        pub fn all() -> [InspectorTab; 4] {
-            [
+        pub fn all() -> Vec<InspectorTab> {
+            let mut tabs = vec![
                 InspectorTab::Elements,
                 InspectorTab::Styles,
                 InspectorTab::Layout,
                 InspectorTab::EventListeners,
-            ]
+            ];
+            #[cfg(feature = "flamegraph")]
+            tabs.push(InspectorTab::Profiler);
+            tabs
         }
 
         /// Human-readable label for the tab.
@@ -94,6 +100,8 @@ mod conditional {
                 InspectorTab::Styles => "Styles",
                 InspectorTab::Layout => "Layout",
                 InspectorTab::EventListeners => "Listeners",
+                #[cfg(feature = "flamegraph")]
+                InspectorTab::Profiler => "Profiler",
             }
         }
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -457,6 +457,16 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         None
     }
 
+    /// The live `wgpu::Device`/`Queue` backing this window's renderer, for
+    /// GPU deep-capture replay (Phase 6 of the profiling epic, issue #62).
+    /// Default `None` for platforms/backends that don't use the WGPU
+    /// renderer or before the renderer exists, matching
+    /// `gpu_memory_snapshot`'s convention.
+    #[cfg(feature = "flamegraph")]
+    fn gpu_device_and_queue(&self) -> Option<(wgpu::Device, wgpu::Queue)> {
+        None
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         None

--- a/src/platform/cross/renderer.rs
+++ b/src/platform/cross/renderer.rs
@@ -3212,6 +3212,20 @@ impl WgpuRenderer {
         }
     }
 
+    /// The live `wgpu::Device`/`Queue` backing this renderer, for callers
+    /// that want to drive GPU work outside the normal frame path -- e.g.
+    /// `flamegraph_replay::render_deep_capture_step` (Phase 6 of the
+    /// profiling epic, issue #62), so a deep-capture replay preview runs
+    /// against the app's real device instead of spinning up a second,
+    /// separate headless one on every call. `Device`/`Queue` are cheap
+    /// `Clone` handles (wgpu itself reference-counts the underlying
+    /// resources), so returning owned clones here is the idiomatic wgpu
+    /// pattern, not a meaningful cost.
+    #[cfg(feature = "flamegraph")]
+    pub(crate) fn gpu_device_and_queue(&self) -> (wgpu::Device, wgpu::Queue) {
+        (self.context.device.clone(), self.context.queue.clone())
+    }
+
     /// Best-effort swapchain memory estimate from `surface_configuration`'s
     /// dimensions/format. wgpu doesn't expose the presentation engine's
     /// actual backing image count, so `desired_maximum_frame_latency` (the

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -460,6 +460,14 @@ impl PlatformWindow for CrossWindow {
             .map(|renderer| renderer.borrow().gpu_memory_snapshot())
     }
 
+    #[cfg(feature = "flamegraph")]
+    fn gpu_device_and_queue(&self) -> Option<(wgpu::Device, wgpu::Queue)> {
+        self.0
+            .renderer
+            .get()
+            .map(|renderer| renderer.borrow().gpu_device_and_queue())
+    }
+
     fn gpu_specs(&self) -> Option<crate::GpuSpecs> {
         // TODO(mdeand): Retrieve GPU specs from the graphics context.
         None

--- a/src/window.rs
+++ b/src/window.rs
@@ -1702,6 +1702,17 @@ impl Window {
         self.platform_window.gpu_memory_snapshot()
     }
 
+    /// The live `wgpu::Device`/`Queue` backing this window's renderer, so a
+    /// GPU deep-capture replay preview (Phase 6 of the profiling epic, issue
+    /// #62, `flamegraph_replay::render_deep_capture_step`) can run against
+    /// the app's real device instead of creating a second one. `None` on
+    /// platforms/backends that don't use the WGPU renderer, or before the
+    /// renderer has been created.
+    #[cfg(feature = "flamegraph")]
+    pub fn gpu_device_and_queue(&self) -> Option<(wgpu::Device, wgpu::Queue)> {
+        self.platform_window.gpu_device_and_queue()
+    }
+
     /// The current text style. Which is composed of all the style refinements provided to `with_text_style`.
     pub fn text_style(&self) -> TextStyle {
         let mut style = TextStyle::default();


### PR DESCRIPTION
## Summary

Small upstream pieces unblocking phase 7 of the profiling epic (#64) — the actual viewer UI (WGPUI-Component#7) lives in a different repo and needs three things from here: a tab slot in the Inspector panel, a way to get the live GPU device for replay previews, and (found live, mid-build) a real crash fix.

**Commit 1 — `InspectorTab::Profiler`:**
- `InspectorTab` gains a `Profiler` variant, gated `#[cfg(feature = "flamegraph")]` (inside the already-gated `mod conditional`, so it only exists when both `inspector`/`debug_assertions` *and* `flamegraph` are active).
- `InspectorTab::all()` changes from a fixed `[InspectorTab; 4]` to `Vec<InspectorTab>`, since the tab count is now conditional. WGPUI-Component's existing consumer (`render_inspector_tabs`) only ever iterates/indexes/`.len()`s the result — all source-compatible, no call-site edits needed there.

**Commit 2 — `Window::gpu_device_and_queue`:**
- `flamegraph_replay::render_deep_capture_step` (phase 6, #62) needs a `wgpu::Device`/`Queue` to render against. Mirrors `Window::gpu_memory_snapshot`'s existing plumbing exactly (`Window` → `PlatformWindow` trait → `CrossWindow` → `WgpuRenderer`). `Device`/`Queue` are cheap-clone handle types in wgpu, so returning owned clones is idiomatic, not a real cost.

**Commit 3 — fix a real wgpu validation panic:**
- GPU deep capture (phase 4, #60/#71) reads seven fixed buffers (`quads_buffer`, `shadows_buffer`, `underlines_buffer`, `mono_sprites_buffer`, `poly_sprites_buffer`, `backdrop_filters_buffer`, `paths_vertices_buffer`) back via `copy_buffer_to_buffer` during a triggered capture, but they were never given `COPY_SRC` when created in `render_context.rs`. wgpu's validator rejects the encoder outright, and by default that **panics the whole process** — not a soft error. Reproduced live: a user hit this exact crash (identical error message) building the phase 7 viewer against this code.
- Root cause phase 4's own test missed: its test built a throwaway buffer with `COPY_SRC` set explicitly, exercising the readback *logic* but never the real `WgpuContext` buffer-creation path where the bug actually lives.
- Fix adds `COPY_SRC` to exactly those seven buffers, gated behind `feature = "flamegraph"` so a non-flamegraph build is unaffected.
- Adds a regression test that goes through the real `WgpuContext::new()` path and asserts `copy_buffer_to_buffer` is accepted on all seven, via `push_error_scope`/`.pop()` rather than relying on wgpu's default uncaptured-error handler (which is what panics in the field). **Manually verified the test fails with the exact reported error message when the fix is reverted**, and passes with it restored, before landing this.

## Test plan

- [x] `cargo build --lib` (dev, no features) — clean
- [x] `cargo build --release --lib` (no features) — clean
- [x] `cargo build --release --lib --features "inspector,flamegraph"` — clean, the real target combo for the viewer
- [x] Full lib test suite, `--features flamegraph`, single-threaded: 97/97
- [x] New regression test confirmed to fail (with the exact user-reported error text) when the fix is reverted, confirmed to pass with it restored
- [x] `cargo clippy --lib --features "inspector,flamegraph"` — identical warning count to baseline (80/80), zero new findings

Not opening this against the epic issue directly since it's not one of the 7 phase issues — small supporting infrastructure and a bugfix for WGPUI-Component#7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)