### PR TITLE
Backend: CPU-observed GPU submit/fence-observed timeline markers

### DIFF
--- a/src/flamegraph.rs
+++ b/src/flamegraph.rs
@@ -212,6 +212,32 @@ pub struct FrameCapture {
     pub frame_start_ns: u64,
     /// Frame end, in nanoseconds relative to the capture's anchor.
     pub frame_end_ns: u64,
+    /// CPU wall-clock instant `queue.submit()` returned for this frame's GPU
+    /// work, anchor-relative. This is a **CPU-side observation of when the
+    /// CPU asked the GPU to run something** -- not when the GPU actually
+    /// started running it (that's `gpu_spans`' calibrated `start_ns`, a value
+    /// *inferred* from a GPU-clock timestamp via the session's one-time
+    /// calibration, not directly observed on the CPU timeline) and not when
+    /// drawing finished on the CPU (`frame_end_ns`, which happens before
+    /// submission is even asked for). Plotting this alongside the calibrated
+    /// GPU span start is what surfaces GPU queue backlog: a growing gap here
+    /// means the GPU is falling behind CPU-side submission, not that
+    /// individual passes are slow. `None` until a submission has been
+    /// correlated to this frame (or if this frame never requested GPU
+    /// capture at all).
+    pub cpu_gpu_submit_ns: Option<u64>,
+    /// CPU wall-clock instant the render thread's non-blocking poll first
+    /// observed this frame's GPU readback as complete, anchor-relative. This
+    /// is when the **CPU found out** the GPU had fenced/finished -- not when
+    /// the GPU actually finished (that's the end of `gpu_spans`' calibrated
+    /// timeline) and not a blocking wait's completion (readback is polled
+    /// non-blockingly, so this always lags true GPU completion by however
+    /// long it took the render thread to next call `poll_readback`, on the
+    /// order of 1-2 frames by design -- see `GpuSpan`'s doc comment). The gap
+    /// between the calibrated GPU end time and this value is CPU-side
+    /// readback/polling latency, distinct from GPU execution time itself.
+    /// `None` until observed.
+    pub cpu_gpu_fence_observed_ns: Option<u64>,
     /// Aggregate "how much work" counters for this frame (Phase 2, issue
     /// #58), gathered alongside the timing spans above. See
     /// [`FrameCounters`].
@@ -484,6 +510,7 @@ impl Capture {
             draw_calls,
             atlas,
             events,
+            gpu_timeline: gpu_timeline_summary(&self.frames),
             present_mode: current_present_mode(),
             full_draw_frame_count: self.full_draw_frame_count,
             fast_path_frame_count: self.fast_path_frame_count,
@@ -683,13 +710,41 @@ pub(crate) fn current_gpu_correlation_frame_index() -> Option<u64> {
     })
 }
 
+/// CPU wall-clock "now," anchor-relative in the same nanosecond timeline as
+/// every other timestamp in a `Capture` (`frame_start_ns`, `frame_end_ns`,
+/// and -- after calibration -- `GpuSpan::start_ns`). `flamegraph_gpu` uses
+/// this to stamp `queue.submit()`/readback-observed instants so they're
+/// directly comparable to calibrated GPU timestamps on one shared timeline,
+/// the same way `current_gpu_correlation_frame_index` lets it tag spans by
+/// frame without a parameter threaded through `PlatformWindow::draw`. `None`
+/// when no capture is active.
+pub(crate) fn anchor_relative_now_ns() -> Option<u64> {
+    ACTIVE_CAPTURE.lock().as_ref().map(|state| state.now_ns())
+}
+
 /// Attach resolved GPU spans to the frame they belong to, if that frame is
 /// still held by the active capture's ring buffer (it may have been evicted
-/// already, given GPU readback latency of 1-2 frames).
-pub(crate) fn attach_gpu_spans(frame_index: u64, spans: Vec<GpuSpan>, truncated: bool) {
+/// already, given GPU readback latency of 1-2 frames). `submit_cpu_ns` is the
+/// CPU-observed instant `queue.submit()` returned for this frame's GPU work;
+/// `fence_observed_cpu_ns` is the CPU-observed instant the render thread's
+/// non-blocking poll first saw that work as complete. Both are `None` if
+/// unavailable (e.g. this generation was reset before submission), and both
+/// are CPU-side *observations*, not the GPU's own execution timing --
+/// see the doc comments on `FrameCapture`'s matching fields for why that
+/// distinction matters and how it differs from `gpu_spans`' calibrated
+/// (inferred, not directly observed) start/end times.
+pub(crate) fn attach_gpu_spans(
+    frame_index: u64,
+    spans: Vec<GpuSpan>,
+    truncated: bool,
+    submit_cpu_ns: Option<u64>,
+    fence_observed_cpu_ns: Option<u64>,
+) {
     if let Some(state) = ACTIVE_CAPTURE.lock().as_ref() {
         let mut finished = state.finished_frames.lock();
         if let Some(frame) = finished.iter_mut().find(|frame| frame.frame_index == frame_index) {
+            frame.cpu_gpu_submit_ns = submit_cpu_ns;
+            frame.cpu_gpu_fence_observed_ns = fence_observed_cpu_ns;
             frame.gpu_spans = spans;
             frame.gpu_spans_finalized = true;
             frame.gpu_spans_truncated = truncated;
@@ -817,6 +872,8 @@ impl CaptureState {
             gpu_spans_truncated: false,
             frame_start_ns: open_frame.frame_start_ns,
             frame_end_ns,
+            cpu_gpu_submit_ns: None,
+            cpu_gpu_fence_observed_ns: None,
             counters: take_frame_counters(),
         };
 
@@ -1272,6 +1329,73 @@ pub struct EventSummary {
     pub entities_invalidated: MeanMax,
 }
 
+/// Mean/max CPU-to-GPU timeline correlation over a window of frames -- when
+/// the CPU asked the GPU to run a frame's work vs. when the GPU actually
+/// started (backlog), and when the GPU actually finished vs. when the CPU
+/// found out (readback/polling latency). See `FrameCapture::cpu_gpu_submit_ns`
+/// and `cpu_gpu_fence_observed_ns`'s doc comments for the underlying
+/// distinction this reports on: a CPU-side *observation* of submit/fence,
+/// not the GPU's own (calibrated, inferred) execution timing, which is what
+/// `gpu_spans` already gives you.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub struct GpuTimelineSummary {
+    /// Mean/max nanoseconds from `cpu_gpu_submit_ns` (CPU asked the GPU to
+    /// run this frame) to the calibrated start of the frame's first GPU
+    /// span (GPU actually began running it). A growing value here means the
+    /// GPU queue is backlogged relative to CPU submission -- not that
+    /// individual passes got slower.
+    pub submit_to_gpu_start: MeanMax,
+    /// Mean/max nanoseconds from the calibrated end of a frame's last GPU
+    /// span (GPU actually finished) to `cpu_gpu_fence_observed_ns` (CPU found
+    /// out). This is readback/polling latency, not GPU execution time --
+    /// expect it to sit around 1-2 frame durations by design (see
+    /// `FrameCapture::gpu_spans_finalized`'s doc comment).
+    pub gpu_end_to_fence_observed: MeanMax,
+    /// How many frames in the window had everything needed for the two
+    /// stats above: both CPU-observed instants present, and `gpu_spans`
+    /// finalized and non-empty. GPU data lags CPU data by design (calibration
+    /// only runs once GPU capture is requested, and readback itself lags
+    /// 1-2 frames), so this is very often smaller than `frame_count`.
+    pub samples: usize,
+}
+
+fn gpu_timeline_summary(frames: &VecDeque<FrameCapture>) -> GpuTimelineSummary {
+    let mut submit_to_start = Vec::new();
+    let mut end_to_observed = Vec::new();
+
+    for frame in frames {
+        if !frame.gpu_spans_finalized || frame.gpu_spans.is_empty() {
+            continue;
+        }
+        let Some(submit_ns) = frame.cpu_gpu_submit_ns else {
+            continue;
+        };
+        let Some(observed_ns) = frame.cpu_gpu_fence_observed_ns else {
+            continue;
+        };
+
+        let gpu_start_ns = frame.gpu_spans.iter().map(|span| span.start_ns).min();
+        let gpu_end_ns = frame
+            .gpu_spans
+            .iter()
+            .map(|span| span.start_ns.saturating_add(span.duration_ns as u64))
+            .max();
+        let (Some(gpu_start_ns), Some(gpu_end_ns)) = (gpu_start_ns, gpu_end_ns) else {
+            continue;
+        };
+
+        submit_to_start.push(gpu_start_ns.saturating_sub(submit_ns).min(u32::MAX as u64) as u32);
+        end_to_observed.push(observed_ns.saturating_sub(gpu_end_ns).min(u32::MAX as u64) as u32);
+    }
+
+    let samples = submit_to_start.len();
+    GpuTimelineSummary {
+        submit_to_gpu_start: mean_max(submit_to_start.into_iter()),
+        gpu_end_to_fence_observed: mean_max(end_to_observed.into_iter()),
+        samples,
+    }
+}
+
 /// Aggregated statistics over the frames currently held in a [`Capture`]'s
 /// ring buffer, from [`Capture::counter_summary`]. Replaces what the
 /// reverted `render_stats` module reported via a periodic stderr dump with a
@@ -1297,6 +1421,8 @@ pub struct CounterSummary {
     pub atlas: AtlasSummary,
     /// Input/notification statistics.
     pub events: EventSummary,
+    /// CPU-observed GPU submit/fence timeline correlation statistics.
+    pub gpu_timeline: GpuTimelineSummary,
     /// The renderer's current present mode.
     pub present_mode: PresentMode,
     /// See `Capture::full_draw_frame_count`'s doc comment: these two are
@@ -1364,7 +1490,20 @@ impl std::fmt::Display for CounterSummary {
             self.events.notify_calls.max,
             self.events.entities_invalidated.mean,
             self.events.entities_invalidated.max,
-        )
+        )?;
+        if self.gpu_timeline.samples > 0 {
+            writeln!(
+                f,
+                "--- gpu timeline ({} samples): submit->gpu-start {:.3}/{:.3}ms  gpu-end->cpu-observed {:.3}/{:.3}ms ---",
+                self.gpu_timeline.samples,
+                self.gpu_timeline.submit_to_gpu_start.mean / 1.0e6,
+                self.gpu_timeline.submit_to_gpu_start.max as f64 / 1.0e6,
+                self.gpu_timeline.gpu_end_to_fence_observed.mean / 1.0e6,
+                self.gpu_timeline.gpu_end_to_fence_observed.max as f64 / 1.0e6,
+            )
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -1804,6 +1943,8 @@ mod tests {
         gpu_spans_truncated: bool,
         frame_start_ns: u64,
         frame_end_ns: u64,
+        cpu_gpu_submit_ns: Option<u64>,
+        cpu_gpu_fence_observed_ns: Option<u64>,
         // `FrameCounters` derives `Deserialize` directly (plain numeric
         // data, no `&'static str` fields), so it's reused as-is here rather
         // than needing its own decoded mirror type.
@@ -1889,6 +2030,8 @@ mod tests {
             gpu_spans_truncated: frame.gpu_spans_truncated,
             frame_start_ns: frame.frame_start_ns,
             frame_end_ns: frame.frame_end_ns,
+            cpu_gpu_submit_ns: frame.cpu_gpu_submit_ns,
+            cpu_gpu_fence_observed_ns: frame.cpu_gpu_fence_observed_ns,
             counters: frame.counters,
         }
     }

--- a/src/flamegraph_gpu.rs
+++ b/src/flamegraph_gpu.rs
@@ -71,6 +71,12 @@ struct QueryGeneration {
     /// readback ordering (`GpuSpan::query_set_generation`).
     epoch: u64,
     map_ready: Arc<AtomicBool>,
+    /// CPU-observed instant `queue.submit()` returned for this generation's
+    /// frame, set in `begin_readback` (called right after that submit at the
+    /// renderer's call site) -- see `FrameCapture::cpu_gpu_submit_ns`'s doc
+    /// comment for why this is a distinct thing from the GPU's own
+    /// (calibrated, inferred) execution-start time.
+    submit_cpu_ns: Option<u64>,
 }
 
 impl QueryGeneration {
@@ -105,6 +111,7 @@ impl QueryGeneration {
             truncated: false,
             epoch: 0,
             map_ready: Arc::new(AtomicBool::new(false)),
+            submit_cpu_ns: None,
         }
     }
 
@@ -122,6 +129,7 @@ impl QueryGeneration {
         self.truncated = false;
         self.epoch += 1;
         self.map_ready.store(false, Ordering::Release);
+        self.submit_cpu_ns = None;
     }
 
     /// Reserve a begin/end timestamp-write pair. Returns `None` (without
@@ -171,11 +179,15 @@ impl QueryGeneration {
     }
 
     /// Start the async readback map. Must be called after the encoder
-    /// recorded by `resolve` has been submitted.
+    /// recorded by `resolve` has been submitted -- this doubles as the CPU
+    /// submission-instant stamp (`FrameCapture::cpu_gpu_submit_ns`), since
+    /// this method's own doc contract already requires callers to invoke it
+    /// immediately after `queue.submit()` returns.
     fn begin_readback(&mut self) {
         if self.state != GenerationState::Resolving {
             return;
         }
+        self.submit_cpu_ns = flamegraph::anchor_relative_now_ns();
         self.state = GenerationState::MapPending;
         let size = (self.next_query_index as u64) * 8;
         let map_ready = self.map_ready.clone();
@@ -193,6 +205,10 @@ impl QueryGeneration {
         if self.state != GenerationState::MapPending || !self.map_ready.load(Ordering::Acquire) {
             return;
         }
+        // Stamped here, not after the (cheap, in-memory) span decoding below,
+        // so it reflects the moment the poll loop actually observed
+        // completion rather than however long this function takes to run.
+        let fence_observed_cpu_ns = flamegraph::anchor_relative_now_ns();
 
         let size = (self.next_query_index as u64) * 8;
         let calibration = flamegraph::gpu_calibration();
@@ -213,7 +229,13 @@ impl QueryGeneration {
         };
         self.staging_buffer.unmap();
 
-        flamegraph::attach_gpu_spans(self.frame_index, spans, self.truncated);
+        flamegraph::attach_gpu_spans(
+            self.frame_index,
+            spans,
+            self.truncated,
+            self.submit_cpu_ns,
+            fence_observed_cpu_ns,
+        );
         self.state = GenerationState::Idle;
     }
 }
@@ -817,6 +839,17 @@ mod tests {
     /// with no GPU or software rasterizer skips the readback assertions below
     /// instead of failing the whole suite.
     fn create_headless_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+        create_headless_device_with_features(wgpu::Features::empty())
+    }
+
+    /// Same as `create_headless_device`, but requests the given features --
+    /// needed by tests that create a `wgpu::QuerySet` (`QueryType::Timestamp`
+    /// requires `Features::TIMESTAMP_QUERY`), which `create_headless_device`'s
+    /// zero-features default device doesn't have, unlike the real
+    /// `WgpuContext::new` (`render_context.rs`), which requires
+    /// `TIMESTAMP_QUERY`/`TIMESTAMP_QUERY_INSIDE_ENCODERS` outright on
+    /// non-macOS.
+    fn create_headless_device_with_features(features: wgpu::Features) -> Option<(wgpu::Device, wgpu::Queue)> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::default(),
@@ -831,8 +864,12 @@ mod tests {
         // that case.
         let adapter = pollster::block_on(instance.enumerate_adapters(wgpu::Backends::all()))
             .into_iter()
-            .next()?;
-        pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default())).ok()
+            .find(|adapter| adapter.features().contains(features))?;
+        pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            required_features: features,
+            ..Default::default()
+        }))
+        .ok()
     }
 
     /// End-to-end readback test: records a command stream referencing a
@@ -892,5 +929,89 @@ mod tests {
             contents.bytes, source_bytes,
             "readback bytes should match exactly what was written to the source buffer"
         );
+    }
+
+    /// End-to-end test for the CPU/GPU timeline correlation markers: drives
+    /// a real `GpuQueryManager` through `begin_frame` -> `reserve_pair` ->
+    /// `finish_frame` -> submit -> `begin_readback` -> `poll_readback`
+    /// against a real headless device, with an active capture session, and
+    /// asserts the resulting `FrameCapture` has both `cpu_gpu_submit_ns` and
+    /// `cpu_gpu_fence_observed_ns` populated with a sane ordering --
+    /// `fence_observed >= submit`, since observing GPU completion can only
+    /// happen after the CPU asked the GPU to do the work, in wall-clock
+    /// terms. This is the concrete regression case for a real gap: before
+    /// this, `FrameCapture` had no CPU-side submit/fence-observed markers at
+    /// all, only the CPU-side `frame_start_ns`/`frame_end_ns` (drawing, not
+    /// GPU submission) and the calibrated (inferred, not directly observed)
+    /// `GpuSpan` timestamps.
+    #[test]
+    fn gpu_query_manager_records_cpu_submit_and_fence_observed_instants() {
+        let required = wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+        let Some((device, queue)) = create_headless_device_with_features(required) else {
+            eprintln!(
+                "skipping gpu_query_manager_records_cpu_submit_and_fence_observed_instants: no wgpu adapter available in this environment"
+            );
+            return;
+        };
+
+        let handle = flamegraph::start_capture(flamegraph::CaptureOptions {
+            max_frames: 8,
+            capture_gpu: true,
+        })
+        .expect("no other capture should be active in this test process");
+
+        let mut manager_slot: Option<GpuQueryManager> = None;
+        sync_with_active_capture(&mut manager_slot, &device, &queue);
+        let manager = manager_slot.as_mut().expect("capture_gpu: true should allocate a manager");
+
+        let frame_index = flamegraph::open_frame_cpu_side(1).expect("capture is active, open_frame_cpu_side should succeed");
+        manager.begin_frame(frame_index);
+
+        let reserved = manager
+            .reserve_pair(SpanName::Static("test_pass"), GpuPassKind::Main)
+            .expect("first reservation in a freshly-begun frame should always succeed");
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        encoder.write_timestamp(reserved.query_set(), reserved.begin_index());
+        encoder.write_timestamp(reserved.query_set(), reserved.end_index());
+        manager.finish_frame(&mut encoder);
+        queue.submit(Some(encoder.finish()));
+        manager.begin_readback();
+
+        flamegraph::close_frame_cpu_side(Some(frame_index));
+
+        // `CaptureHandle` has no mid-flight peek (only `stop`, which ends the
+        // session), so drive the async readback to completion first -- a
+        // blocking wait forces the GPU to finish and process the pending
+        // `map_async` callback, then `poll_readback`'s own non-blocking poll
+        // sees `map_ready` already set and harvests immediately. Looped
+        // rather than a single attempt purely as a margin of safety for
+        // slower/software adapters, not because one iteration is expected to
+        // be insufficient.
+        for _ in 0..20 {
+            let _ = device.poll(wgpu::PollType::wait_indefinitely());
+            manager.poll_readback(&device);
+        }
+
+        let capture = handle.stop();
+        let frame = capture
+            .frames()
+            .find(|frame| frame.frame_index == frame_index)
+            .expect("frame should still be in the ring buffer (max_frames: 8, only one frame drawn)");
+
+        assert!(frame.gpu_spans_finalized, "readback should have completed within 20 blocking-poll iterations");
+
+        let submit_ns = frame
+            .cpu_gpu_submit_ns
+            .expect("begin_readback should have stamped a CPU submit instant");
+        let observed_ns = frame
+            .cpu_gpu_fence_observed_ns
+            .expect("try_harvest should have stamped a CPU fence-observed instant");
+        assert!(
+            observed_ns >= submit_ns,
+            "the CPU can only observe GPU completion after it asked the GPU to submit work: \
+             submit_ns={submit_ns}, observed_ns={observed_ns}"
+        );
+        assert!(!frame.gpu_spans.is_empty(), "the reserved pass should have resolved into a GpuSpan");
     }
 }


### PR DESCRIPTION
## Summary

Backend half of a request to distinguish, on the CPU side, "when did the GPU start a frame" from "when the frame was fenced" -- and on the GPU side, when command submission happens. Frontend visualization work (surfacing this in the flame chart / a new stat panel) is a separate follow-up in `WGPUI-Component`.

Before this, `FrameCapture` had no way to represent the actual gap being asked about:
- `frame_start_ns`/`frame_end_ns` are CPU-side *drawing* timing (`Window::draw`/`present`), not GPU submission or completion.
- `gpu_spans`' `start_ns`/`duration_ns` are correct GPU-clock execution times, but they're *inferred* through the session's one-time CPU/GPU calibration -- a model of when the GPU worked, not a directly-observed CPU-side timestamp.
- There was no CPU-side observation of "I just called `queue.submit()`" or "I just found out via poll that the GPU finished" at all.

## What's added

- `QueryGeneration` stamps `submit_cpu_ns` in `begin_readback` (called immediately after `queue.submit()`, per that method's own doc contract) and a fence-observed instant in `try_harvest` (the moment the render thread's non-blocking poll sees the readback as complete). Both flow through an extended `attach_gpu_spans` into two new `FrameCapture` fields: `cpu_gpu_submit_ns` and `cpu_gpu_fence_observed_ns`.
- `CounterSummary` gains `gpu_timeline: GpuTimelineSummary`: `submit_to_gpu_start` (mean/max nanoseconds from CPU submit to the GPU's calibrated execution start -- GPU queue backlog) and `gpu_end_to_fence_observed` (mean/max nanoseconds from the GPU's calibrated execution end to the CPU noticing -- readback/polling latency), plus a `samples` count, since GPU data lags CPU data by design and won't be available for every frame in the window.
- New `anchor_relative_now_ns()` free function so `flamegraph_gpu` can stamp CPU wall-clock instants on the exact same anchor timeline as everything else in a `Capture` -- mirrors `current_gpu_correlation_frame_index`'s existing fix for the same "no natural path to the data" problem from phase 1.
- `Display` for `CounterSummary` gains a `gpu timeline` section when samples are available.
- The trace-format test's `DecodedFrameCapture` mirror updated to match, so the round-trip test stays accurate.

## Test plan

- [x] `cargo build`/`cargo build --release`, with and without `--features flamegraph` -- all clean
- [x] New end-to-end test drives a real `GpuQueryManager` through `begin_frame` -> `reserve_pair` -> `finish_frame` -> submit -> `begin_readback` -> `poll_readback` against a real headless device (requesting `TIMESTAMP_QUERY` explicitly -- the existing zero-features test device helper doesn't have it, extended it to accept required features) and asserts `fence_observed_ns >= submit_ns`, the one hard invariant: the CPU can only learn of GPU completion after asking for the work, in wall-clock terms
- [x] Full lib test suite: 98/98 with `--features flamegraph` (single-threaded), 79/79 without
- [x] `cargo clippy --lib --features "inspector,flamegraph"` diffed against a clean `main` checkout (temporary worktree) -- identical warning count (80/80), zero new findings

Closes nothing specific (not one of the 7 tracked epic phases) -- direct response to a follow-up request on the epic (#64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)