### PR TITLE
Restore opt-in render_stats instrumentation module

### DIFF
--- a/src/gpui.rs
+++ b/src/gpui.rs
@@ -39,6 +39,7 @@ mod path_builder;
 mod platform;
 pub mod prelude;
 mod queue;
+pub mod render_stats;
 mod scene;
 mod shared_string;
 mod shared_uri;

--- a/src/render_stats.rs
+++ b/src/render_stats.rs
@@ -1,0 +1,178 @@
+//! Frame-path instrumentation.
+//!
+//! Enable with `WGPUI_RENDER_STATS=1`. Once per second every accumulated timer
+//! and counter is dumped to stderr, so a slow frame can be attributed to a
+//! specific stage instead of guessed at.
+//!
+//! Everything here compiles to an atomic load of `ENABLED` when disabled, so it
+//! is safe to leave the call sites in place.
+//!
+//! Timers report count, mean and max in milliseconds; the max column is the one
+//! that matters for stalls, since a single multi-second frame vanishes into a
+//! mean over 120 samples.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+static ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("WGPUI_RENDER_STATS")
+        .map(|v| v != "0" && !v.is_empty())
+        .unwrap_or(false)
+});
+
+/// Whether instrumentation is on. Check this before doing any work that only
+/// exists to feed the stats.
+#[inline]
+pub fn enabled() -> bool {
+    *ENABLED
+}
+
+#[derive(Default)]
+struct Accum {
+    count: u64,
+    total_ns: u64,
+    max_ns: u64,
+}
+
+struct Registry {
+    timers: Mutex<BTreeMap<&'static str, Accum>>,
+    counters: Mutex<BTreeMap<&'static str, u64>>,
+    last_report: Mutex<Instant>,
+    reporting: AtomicBool,
+    frames: AtomicU64,
+}
+
+static REGISTRY: LazyLock<Registry> = LazyLock::new(|| Registry {
+    timers: Mutex::new(BTreeMap::new()),
+    counters: Mutex::new(BTreeMap::new()),
+    last_report: Mutex::new(Instant::now()),
+    reporting: AtomicBool::new(false),
+    frames: AtomicU64::new(0),
+});
+
+/// Record a single timing sample.
+pub fn record(name: &'static str, dur: Duration) {
+    if !enabled() {
+        return;
+    }
+    let ns = dur.as_nanos() as u64;
+    let mut timers = REGISTRY.timers.lock().unwrap();
+    let entry = timers.entry(name).or_default();
+    entry.count += 1;
+    entry.total_ns += ns;
+    entry.max_ns = entry.max_ns.max(ns);
+}
+
+/// Bump a named counter (frames drawn, blits attempted, refreshes forced, ...).
+pub fn count(name: &'static str) {
+    if !enabled() {
+        return;
+    }
+    *REGISTRY.counters.lock().unwrap().entry(name).or_insert(0) += 1;
+}
+
+/// RAII timer. Records on drop.
+pub struct Scope {
+    name: &'static str,
+    start: Instant,
+}
+
+impl Drop for Scope {
+    fn drop(&mut self) {
+        record(self.name, self.start.elapsed());
+    }
+}
+
+/// Start a scoped timer. Returns `None` when instrumentation is disabled, so the
+/// whole thing costs one atomic load.
+#[inline]
+pub fn scope(name: &'static str) -> Option<Scope> {
+    if !enabled() {
+        return None;
+    }
+    Some(Scope {
+        name,
+        start: Instant::now(),
+    })
+}
+
+/// Call once per presented frame. Dumps and clears the accumulators every second.
+pub fn tick_frame() {
+    if !enabled() {
+        return;
+    }
+
+    REGISTRY.frames.fetch_add(1, Ordering::Relaxed);
+
+    // Only one thread reports; the rest return immediately.
+    if REGISTRY.reporting.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    let elapsed = {
+        let last = REGISTRY.last_report.lock().unwrap();
+        last.elapsed()
+    };
+
+    if elapsed < Duration::from_secs(1) {
+        REGISTRY.reporting.store(false, Ordering::Release);
+        return;
+    }
+
+    *REGISTRY.last_report.lock().unwrap() = Instant::now();
+
+    let timers: Vec<(&'static str, Accum)> = {
+        let mut guard = REGISTRY.timers.lock().unwrap();
+        std::mem::take(&mut *guard).into_iter().collect()
+    };
+    let counters: Vec<(&'static str, u64)> = {
+        let mut guard = REGISTRY.counters.lock().unwrap();
+        std::mem::take(&mut *guard).into_iter().collect()
+    };
+    let frames = REGISTRY.frames.swap(0, Ordering::Relaxed);
+
+    let secs = elapsed.as_secs_f64();
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\n=== WGPUI RENDER STATS ({:.2}s, {} frames, {:.1} fps) ===\n",
+        secs,
+        frames,
+        frames as f64 / secs
+    ));
+
+    if !timers.is_empty() {
+        out.push_str(&format!(
+            "{:<38} {:>7} {:>10} {:>10} {:>10}\n",
+            "stage", "n", "mean ms", "max ms", "total ms"
+        ));
+        // Worst max first: that is what a stall looks like.
+        let mut rows = timers;
+        rows.sort_by(|a, b| b.1.max_ns.cmp(&a.1.max_ns));
+        for (name, a) in rows {
+            if a.count == 0 {
+                continue;
+            }
+            out.push_str(&format!(
+                "{:<38} {:>7} {:>10.3} {:>10.3} {:>10.2}\n",
+                name,
+                a.count,
+                (a.total_ns as f64 / a.count as f64) / 1.0e6,
+                a.max_ns as f64 / 1.0e6,
+                a.total_ns as f64 / 1.0e6,
+            ));
+        }
+    }
+
+    if !counters.is_empty() {
+        out.push_str("--- counters ---\n");
+        for (name, v) in counters {
+            out.push_str(&format!("{:<38} {:>7}  ({:.1}/s)\n", name, v, v as f64 / secs));
+        }
+    }
+
+    eprint!("{}", out);
+
+    REGISTRY.reporting.store(false, Ordering::Release);
+}

--- a/src/render_stats.rs
+++ b/src/render_stats.rs
@@ -149,7 +149,7 @@ pub fn tick_frame() {
         ));
         // Worst max first: that is what a stall looks like.
         let mut rows = timers;
-        rows.sort_by(|a, b| b.1.max_ns.cmp(&a.1.max_ns));
+        rows.sort_by_key(|(_, a)| std::cmp::Reverse(a.max_ns));
         for (name, a) in rows {
             if a.count == 0 {
                 continue;


### PR DESCRIPTION
## Summary

Same situation as #78 (`submit_guard`/`present_synced_silent`): this module was part of the 2026-07-24 surface-rendering work reverted wholesale (`999e472aac`) for not converging as a day-long chain -- not because this specific piece was wrong. It's small, fully self-contained, and purely additive: an env-var-gated (`WGPUI_RENDER_STATS=1`) stderr stats dump with no dependency on or changes to any rendering internals. Restored verbatim from `eee47a4535`.

**Deliberately not restoring** that commit's internal call sites in `window.rs`/`renderer.rs`/`platform.rs`: this repo now has a much more capable feature-gated replacement (the `flamegraph` module family, phases 1-7 of #64), which phase 2's counters (#58) explicitly built as `render_stats`' "direct successor." Re-wiring the old module into the render hot path a second time would be pure regression with no upside -- this restores only the public module surface a real downstream consumer needs to build against, without touching gpui-ce's own internals again.

## Why

Same downstream consumer as #78 (`Pulsar-Native`'s level editor viewport renderer) calls `gpui::render_stats::scope/count/record` directly, built against the pre-revert API:
```
error[E0433]: cannot find `render_stats` in `gpui`  (x5)
```

**Verified directly against that consumer, combined with #78**: merged both branches into a scratch test branch, pointed `Pulsar-Native`'s `crates/ui/wgpui` submodule at it, built `ui_level_editor` -- clean build, only pre-existing unrelated warnings in `Pulsar-Native`'s own code. Both PRs are needed together for that crate to build; this one alone doesn't fix all 7 of its original errors.

## Test plan

- [x] `cargo build`/`cargo build --release`, with and without `--features flamegraph` -- clean
- [x] Full lib test suite: 79/79
- [x] `cargo clippy --lib --features "inspector,flamegraph"` diffed against `main` -- one new lint from the verbatim-restored code (`unnecessary_sort_by`, a lint that didn't exist/fire when this file was originally written), fixed to `sort_by_key` before this PR; final diff is identical to baseline (80/80), zero new warnings
- [x] Direct downstream verification: merged with #78, built `Pulsar-Native`'s `ui_level_editor` against the combined result -- clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)