### PR TITLE
fix: ime support

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -889,7 +889,7 @@ impl PlatformInputHandler {
             .flatten()
     }
 
-    fn replace_text_in_range(&mut self, replacement_range: Option<Range<usize>>, text: &str) {
+    pub(crate) fn replace_text_in_range(&mut self, replacement_range: Option<Range<usize>>, text: &str) {
         self.cx
             .update(|window, cx| {
                 self.handler
@@ -917,9 +917,28 @@ impl PlatformInputHandler {
             .ok();
     }
 
-    fn unmark_text(&mut self) {
+    pub(crate) fn unmark_text(&mut self) {
         self.cx
             .update(|window, cx| self.handler.unmark_text(window, cx))
+            .ok();
+    }
+
+    /// Reposition the platform IME candidate/composing window at the current
+    /// text selection. Called after the input handler's selection changes so that
+    /// winit can be told the new caret location for IME candidate placement.
+    pub(crate) fn update_ime_cursor(&mut self) {
+        self.cx
+            .update(|window, cx| {
+                let selection = self.handler.selected_text_range(true, window, cx)?;
+                let range = if selection.reversed {
+                    selection.range.start..selection.range.start
+                } else {
+                    selection.range.end..selection.range.end
+                };
+                let bounds = self.handler.bounds_for_range(range, window, cx)?;
+                window.platform_window.update_ime_position(bounds);
+                Some(())
+            })
             .ok();
     }
 

--- a/src/platform/cross/platform.rs
+++ b/src/platform/cross/platform.rs
@@ -1311,6 +1311,7 @@ impl winit::application::ApplicationHandler<CrossEvent> for AppState {
             }
 
             winit::event::WindowEvent::Focused(active) => {
+                window.window().set_ime_allowed(active);
                 if active {
                     self.active_window_id.set(Some(window_id));
                 } else if self.active_window_id.get() == Some(window_id) {
@@ -1645,6 +1646,10 @@ impl winit::application::ApplicationHandler<CrossEvent> for AppState {
                     });
             }
 
+            winit::event::WindowEvent::Ime(ime) => {
+                handle_ime_event(&window, &ime);
+            }
+
             _ => (),
         }
 
@@ -1706,6 +1711,57 @@ fn winit_mouse_button_to_gpui(button: winit::event::MouseButton) -> MouseButton 
             MouseButton::Navigate(crate::NavigationDirection::Forward)
         }
         winit::event::MouseButton::Other(_) => MouseButton::Left,
+    }
+}
+
+/// Convert a byte offset into a UTF-8 string into the equivalent offset in
+/// UTF-16 code units. winit's IME preedit cursor is byte-wise indexed, whereas
+/// GPUI's input handler API uses UTF-16 ranges (matching macOS' text input
+/// contracts), so we translate here.
+fn byte_to_utf16_offset(text: &str, byte_offset: usize) -> usize {
+    let byte_offset = byte_offset.min(text.len());
+    let mut utf16 = 0;
+    for (index, character) in text.char_indices() {
+        if index >= byte_offset {
+            break;
+        }
+        utf16 += character.len_utf16();
+    }
+    utf16
+}
+
+/// Forward a winit `Ime` event to the window's platform input handler, bridging
+/// winit's IME protocol onto GPUI's `InputHandler` (the `NSTextInputClient`-style
+/// API). Without this, IME composition/commit text never reaches the editor and
+/// the candidate window is never positioned.
+fn handle_ime_event(window: &CrossWindow, ime: &winit::event::Ime) {
+    let mut handler = window.0.state.input_handler.borrow_mut();
+    let Some(input_handler) = handler.as_mut() else {
+        // No focused text input to route IME state to; nothing to do.
+        return;
+    };
+
+    match ime {
+        winit::event::Ime::Enabled => {
+            // Ensure any stale composing state is cleared and the candidate
+            // window is positioned at the current cursor.
+            input_handler.unmark_text();
+            input_handler.update_ime_cursor();
+        }
+        winit::event::Ime::Preedit(text, cursor) => {
+            let selected_range = cursor.map(|(start, end)| {
+                byte_to_utf16_offset(text, start)..byte_to_utf16_offset(text, end)
+            });
+            input_handler.replace_and_mark_text_in_range(None, text, selected_range);
+            input_handler.update_ime_cursor();
+        }
+        winit::event::Ime::Commit(text) => {
+            input_handler.replace_text_in_range(None, text);
+            input_handler.update_ime_cursor();
+        }
+        winit::event::Ime::Disabled => {
+            input_handler.unmark_text();
+        }
     }
 }
 

--- a/src/platform/cross/platform.rs
+++ b/src/platform/cross/platform.rs
@@ -1311,7 +1311,12 @@ impl winit::application::ApplicationHandler<CrossEvent> for AppState {
             }
 
             winit::event::WindowEvent::Focused(active) => {
-                window.window().set_ime_allowed(active);
+                if !active {
+                    // Disable IME immediately on OS focus loss. Enabling is
+                    // synchronized after a completed frame, once we know a
+                    // focused text input handler is actually installed.
+                    window.window().set_ime_allowed(false);
+                }
                 if active {
                     self.active_window_id.set(Some(window_id));
                 } else if self.active_window_id.get() == Some(window_id) {
@@ -1743,9 +1748,6 @@ fn handle_ime_event(window: &CrossWindow, ime: &winit::event::Ime) {
 
     match ime {
         winit::event::Ime::Enabled => {
-            // Ensure any stale composing state is cleared and the candidate
-            // window is positioned at the current cursor.
-            input_handler.unmark_text();
             input_handler.update_ime_cursor();
         }
         winit::event::Ime::Preedit(text, cursor) => {

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -545,7 +545,20 @@ impl PlatformWindow for CrossWindow {
         None
     }
 
-    fn update_ime_position(&self, _bounds: crate::Bounds<crate::Pixels>) {}
+    fn update_ime_position(&self, bounds: crate::Bounds<crate::Pixels>) {
+        let window = self.window();
+        let scale_factor = window.scale_factor() as f64;
+        window.set_ime_cursor_area(
+            winit::dpi::PhysicalPosition::new(
+                bounds.origin.x.0 as f64 * scale_factor,
+                bounds.origin.y.0 as f64 * scale_factor,
+            ),
+            winit::dpi::PhysicalSize::new(
+                (bounds.size.width.0 as f64 * scale_factor).round().max(1.0) as u32,
+                (bounds.size.height.0 as f64 * scale_factor).round().max(1.0) as u32,
+            ),
+        );
+    }
 
     fn start_window_move(&self) {
         let _ = self.window().drag_window();

--- a/src/platform/cross/window.rs
+++ b/src/platform/cross/window.rs
@@ -484,6 +484,15 @@ impl PlatformWindow for CrossWindow {
         }
     }
 
+    fn completed_frame(&self) {
+        // Input handlers are rebuilt during painting. Synchronize IME here so
+        // temporary take_input_handler() calls during key dispatch do not
+        // spuriously toggle IME state.
+        let ime_allowed =
+            self.window().has_focus() && self.0.state.input_handler.borrow().is_some();
+        self.window().set_ime_allowed(ime_allowed);
+    }
+
     fn create_wgpu_surface(
         &self,
         width: u32,


### PR DESCRIPTION
Add IME support to the cross-platform winit backend.

- Handle winit IME preedit and commit events
- Convert IME cursor offsets from UTF-8 byte offsets to UTF-16 offsets
- Position the IME candidate window at the current caret
- Enable IME only while a text input handler is active and the window is focused
- Keep IME activation synchronized as text input focus changes