### PR TITLE
Phase 0: workspace scaffold + ordering/occlusion and uniform-layout G…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6738,6 +6738,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpui-core"
+version = "0.1.0"
+
+[[package]]
+name = "wgpui-devtools"
+version = "0.1.0"
+
+[[package]]
+name = "wgpui-layout"
+version = "0.1.0"
+
+[[package]]
+name = "wgpui-text"
+version = "0.1.0"
+
+[[package]]
+name = "wgpui-wgpu"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "pollster 0.4.0",
+ "rand 0.10.0",
+ "wgpu",
+]
+
+[[package]]
+name = "wgpui-widgets"
+version = "0.1.0"
+
+[[package]]
 name = "which"
 version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,20 @@
+[workspace]
+# Phase 0 of docs/gpu-native-architecture.md §3/§11: convert the repo to a
+# Cargo workspace so the new wgpui-* crates can grow alongside the frozen
+# legacy backend without touching it. The root package below is listed
+# explicitly as a member (it would also be included implicitly, since the
+# workspace and package tables live in the same manifest) so the member list
+# reads as complete at a glance.
+members = [
+    ".",
+    "crates/wgpui-core",
+    "crates/wgpui-layout",
+    "crates/wgpui-text",
+    "crates/wgpui-widgets",
+    "crates/wgpui-wgpu",
+    "crates/wgpui-devtools",
+]
+
 [package]
 name = "gpui-ce"
 version = "1.0.0"

--- a/crates/wgpui-core/Cargo.toml
+++ b/crates/wgpui-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wgpui-core"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "wgpui_core"
+path = "src/wgpui_core.rs"
+doctest = false
+
+[dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/crates/wgpui-core/src/app.rs
+++ b/crates/wgpui-core/src/app.rs
@@ -1,0 +1,9 @@
+//! `App`/`Context<T>` root context assembly. See
+//! docs/gpu-native-architecture.md §1, §3.1.
+#![allow(dead_code)]
+
+pub mod async_context;
+pub mod context;
+pub mod effects;
+pub mod entity;
+pub mod globals;

--- a/crates/wgpui-core/src/app/async_context.rs
+++ b/crates/wgpui-core/src/app/async_context.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/app/async_context.rs`.
+//! See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/app/context.rs
+++ b/crates/wgpui-core/src/app/context.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/app/context.rs`.
+//! See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/app/effects.rs
+++ b/crates/wgpui-core/src/app/effects.rs
@@ -1,0 +1,3 @@
+//! Deferred notifications, `flush_deferred_invalidations`.
+//! See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/app/entity.rs
+++ b/crates/wgpui-core/src/app/entity.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/app/entity_map.rs`.
+//! See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/app/globals.rs
+++ b/crates/wgpui-core/src/app/globals.rs
@@ -1,0 +1,2 @@
+//! Global state storage. See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/boundary.rs
+++ b/crates/wgpui-core/src/boundary.rs
@@ -1,0 +1,7 @@
+//! `.boundary()`: the single cache-boundary primitive, a pure compositing
+//! and buffering policy layered on top of always-on reconciliation.
+//! See docs/gpu-native-architecture.md §4.1.
+#![allow(dead_code)]
+
+pub mod identity;
+pub mod policy;

--- a/crates/wgpui-core/src/boundary/identity.rs
+++ b/crates/wgpui-core/src/boundary/identity.rs
@@ -1,0 +1,3 @@
+//! Positional-identity fallback (SFD §1.0), reused by `WgpuSurface`
+//! (docs/gpu-native-architecture.md §5.5, Gap 1).
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/boundary/policy.rs
+++ b/crates/wgpui-core/src/boundary/policy.rs
@@ -1,0 +1,3 @@
+//! `BoundaryPolicy`, `Buffering` enum (`None`/`Margin`/`Tiled`).
+//! See docs/gpu-native-architecture.md §4.1, §4.3.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/invalidation.rs
+++ b/crates/wgpui-core/src/invalidation.rs
@@ -1,0 +1,7 @@
+//! Invalidation vocabulary: the four axes plus the `Reason::Scroll` signal.
+//! See docs/gpu-native-architecture.md §5.4.
+#![allow(dead_code)]
+
+pub mod axes;
+pub mod reason;
+pub mod request;

--- a/crates/wgpui-core/src/invalidation/axes.rs
+++ b/crates/wgpui-core/src/invalidation/axes.rs
@@ -1,0 +1,3 @@
+//! `LAYOUT`/`DISPLAY`/`HIT`/`TRANSFORM` — R-N §3.2's four axes, finally
+//! wired live. See docs/gpu-native-architecture.md §5.4.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/invalidation/reason.rs
+++ b/crates/wgpui-core/src/invalidation/reason.rs
@@ -1,0 +1,4 @@
+//! `Reason::Scroll` vs. `Reason::DataChanged` — a signal distinguishable at
+//! the point invalidation is raised, not inferred after the fact.
+//! See docs/gpu-native-architecture.md §5.4, §4.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/invalidation/request.rs
+++ b/crates/wgpui-core/src/invalidation/request.rs
@@ -1,0 +1,3 @@
+//! `InvalidationRequest`/`InvalidationScope` (R-N §6, unchanged).
+//! See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/occlusion.rs
+++ b/crates/wgpui-core/src/occlusion.rs
@@ -1,0 +1,6 @@
+//! Conservative opaque-region occlusion test — CPU reference implementation,
+//! also the oracle the `validate` mode diffs the compute path against.
+//! See docs/gpu-native-architecture.md §5.2, R-N §8.3.
+#![allow(dead_code)]
+
+pub mod coverage;

--- a/crates/wgpui-core/src/occlusion/coverage.rs
+++ b/crates/wgpui-core/src/occlusion/coverage.rs
@@ -1,0 +1,5 @@
+//! The conservative opaque-region test itself: solid background, opacity
+//! 1.0, corner-radius inset, border-opacity inset, no backdrop filter above,
+//! blur-margin exemption (R-N §8.3). See docs/gpu-native-architecture.md
+//! §5.2.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/patch.rs
+++ b/crates/wgpui-core/src/patch.rs
@@ -1,0 +1,12 @@
+//! Patch-list protocol: `Patch`, `PatchList` — the one frontend/backend
+//! boundary (docs/gpu-native-architecture.md §2, §5.0).
+#![allow(dead_code)]
+
+pub mod apply;
+pub mod primitive;
+
+/// Placeholder for the patch-list type described in §2 and §5.0. Left empty
+/// at Phase 0 — the real shape (insert/update/remove per primitive kind,
+/// with a stable GPU-side slot address per §5.0's O(1)-upload commitment)
+/// lands in Phase 1.
+pub struct PatchList;

--- a/crates/wgpui-core/src/patch/apply.rs
+++ b/crates/wgpui-core/src/patch/apply.rs
@@ -1,0 +1,5 @@
+//! Applies a `PatchList` to a `Scene`. Phase 1's round-trip gate lives here
+//! (docs/gpu-native-architecture.md §8, Phase 1: "apply a patch sequence,
+//! read back the resident buffer, matches an equivalent full-rebuild
+//! reference exactly").
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/patch/primitive.rs
+++ b/crates/wgpui-core/src/patch/primitive.rs
@@ -1,0 +1,3 @@
+//! Per-kind patch payloads: update-in-place vs. insert/remove.
+//! See docs/gpu-native-architecture.md §2, §5.0.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/reconcile.rs
+++ b/crates/wgpui-core/src/reconcile.rs
@@ -1,0 +1,8 @@
+//! Ambient reconciliation: `ElementInstance`/`InstanceKey` diffing that
+//! applies to every element in the window, not fenced to a `.boundary()`
+//! subtree. See docs/gpu-native-architecture.md §4.0, constraint 5 (§0).
+#![allow(dead_code)]
+
+pub mod diff_key;
+pub mod instance;
+pub mod uncached;

--- a/crates/wgpui-core/src/reconcile/diff_key.rs
+++ b/crates/wgpui-core/src/reconcile/diff_key.rs
@@ -1,0 +1,4 @@
+//! `ReconcileKey` trait. §6.2's invariant — every first-party element ships
+//! `diff_key` implemented — is enforced against this file's default.
+//! See docs/gpu-native-architecture.md §6.2, §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/reconcile/instance.rs
+++ b/crates/wgpui-core/src/reconcile/instance.rs
@@ -1,0 +1,3 @@
+//! `ElementInstance`, `InstanceKey` — ambient reconciliation's retained
+//! record. See docs/gpu-native-architecture.md §4.0.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/reconcile/uncached.rs
+++ b/crates/wgpui-core/src/reconcile/uncached.rs
@@ -1,0 +1,4 @@
+//! The `.uncached()` scope flag threaded through prepaint/paint — opts a
+//! subtree out of reconciliation itself. See docs/gpu-native-architecture.md
+//! §4.2.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/scene.rs
+++ b/crates/wgpui-core/src/scene.rs
@@ -1,0 +1,13 @@
+//! Persistent GPU-resident scene: layers, tiles, and the slab allocator
+//! backing them. See docs/gpu-native-architecture.md §3.1, and R-N Pillar
+//! III (the layer/slab concept this crate's mechanics replace, not discard).
+#![allow(dead_code)]
+
+pub mod layer;
+pub mod slab;
+pub mod slab_range;
+pub mod tile;
+
+/// Placeholder for the persistent per-layer-slab scene described in R-N
+/// Pillar III and extended by §2's picture. Empty at Phase 0.
+pub struct Scene;

--- a/crates/wgpui-core/src/scene/layer.rs
+++ b/crates/wgpui-core/src/scene/layer.rs
@@ -1,0 +1,3 @@
+//! Layer record: id, key, policy, invalidation state. R-N's `Layer`,
+//! 2.0's mechanics (docs/gpu-native-architecture.md §3.1).
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/scene/slab.rs
+++ b/crates/wgpui-core/src/scene/slab.rs
@@ -1,0 +1,3 @@
+//! Size-class allocator, ported/cleaned from the legacy backend's
+//! `src/slab.rs`. See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/scene/slab_range.rs
+++ b/crates/wgpui-core/src/scene/slab_range.rs
@@ -1,0 +1,4 @@
+//! Byte-offset math, generation counters, per-primitive slot addressing —
+//! the naming this crate needs for §5.0's O(1) delta-upload commitment.
+//! See docs/gpu-native-architecture.md §3.1, §5.0.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/scene/tile.rs
+++ b/crates/wgpui-core/src/scene/tile.rs
@@ -1,0 +1,3 @@
+//! `TileCoord`, `(boundary, TileCoord)` addressing for tile-based buffering.
+//! See docs/gpu-native-architecture.md §4.3.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/shaders.rs
+++ b/crates/wgpui-core/src/shaders.rs
@@ -1,0 +1,17 @@
+//! WGSL *source* + Rust-side layout descriptors for the compute passes this
+//! crate describes — text and data only, no device, no queue (the module
+//! doc at the top of `wgpui_core.rs` explains why). `wgpui-wgpu` (§3.5) is
+//! what actually compiles these into pipelines and dispatches them.
+//! See docs/gpu-native-architecture.md §3.1, §5.1-§5.3, §4.3, §6.1.
+#![allow(dead_code)]
+
+/// §5.1 — GPU compute ordering pass source.
+pub const ORDERING_WGSL: &str = include_str!("shaders/ordering.wgsl");
+/// §5.2 — GPU compute occlusion pass source.
+pub const OCCLUSION_WGSL: &str = include_str!("shaders/occlusion.wgsl");
+/// §6.1 — GPU compute layout kernel for regular (uniform) content.
+pub const LAYOUT_UNIFORM_WGSL: &str = include_str!("shaders/layout_uniform.wgsl");
+/// §4.3 — tile-visibility compute pass for `Buffering::Tiled`.
+pub const TILE_VISIBILITY_WGSL: &str = include_str!("shaders/tile_visibility.wgsl");
+/// §5.3 — indirect draw-arg generation.
+pub const INDIRECT_ARGS_WGSL: &str = include_str!("shaders/indirect_args.wgsl");

--- a/crates/wgpui-core/src/shaders/indirect_args.wgsl
+++ b/crates/wgpui-core/src/shaders/indirect_args.wgsl
@@ -1,0 +1,1 @@
+// Placeholder — indirect draw-arg generation. See docs/gpu-native-architecture.md §5.3.

--- a/crates/wgpui-core/src/shaders/layout_uniform.wgsl
+++ b/crates/wgpui-core/src/shaders/layout_uniform.wgsl
@@ -1,0 +1,3 @@
+// Placeholder — GPU compute layout kernel for regular content. See docs/gpu-native-architecture.md §6.1.
+// Phase 0 spike prototype lives in crates/wgpui-wgpu/benches/spike_b_uniform_layout.rs;
+// this file is where the Phase 6.1 production kernel replaces that prototype.

--- a/crates/wgpui-core/src/shaders/occlusion.wgsl
+++ b/crates/wgpui-core/src/shaders/occlusion.wgsl
@@ -1,0 +1,3 @@
+// Placeholder — GPU compute occlusion pass. See docs/gpu-native-architecture.md §5.2.
+// Phase 0 spike prototype lives in crates/wgpui-wgpu/benches/spike_a_ordering_occlusion.rs;
+// this file is where the Phase 3 production kernel replaces that prototype.

--- a/crates/wgpui-core/src/shaders/ordering.wgsl
+++ b/crates/wgpui-core/src/shaders/ordering.wgsl
@@ -1,0 +1,3 @@
+// Placeholder — GPU compute ordering pass. See docs/gpu-native-architecture.md §5.1.
+// Phase 0 spike prototype lives in crates/wgpui-wgpu/benches/spike_a_ordering_occlusion.rs;
+// this file is where the Phase 3 production kernel replaces that prototype.

--- a/crates/wgpui-core/src/shaders/tile_visibility.wgsl
+++ b/crates/wgpui-core/src/shaders/tile_visibility.wgsl
@@ -1,0 +1,1 @@
+// Placeholder — tile-visibility compute pass for Buffering::Tiled. See docs/gpu-native-architecture.md §4.3.

--- a/crates/wgpui-core/src/test_support.rs
+++ b/crates/wgpui-core/src/test_support.rs
@@ -1,0 +1,3 @@
+//! Headless patch/reconcile/window testing, mirrors today's
+//! `src/platform/test`. See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/wgpui_core.rs
+++ b/crates/wgpui-core/src/wgpui_core.rs
@@ -1,0 +1,24 @@
+//! `wgpui-core` — patch protocol, persistent scene, ambient reconciliation,
+//! boundary/tile policy, and invalidation. See docs/gpu-native-architecture.md
+//! §3.1 for this crate's file map and role.
+//!
+//! No live `wgpu::Device` appears anywhere in this crate — it owns the
+//! *shapes* of GPU work (shader source as text, buffer/binding layout
+//! descriptors as plain Rust structs) so it stays unit-testable headlessly,
+//! matching `slab.rs`'s existing "no device, no queue" module doc in the
+//! legacy backend (§3.1 intro). `wgpui-wgpu` (§3.5) is what actually creates
+//! pipelines and dispatches compute/render work — Phase 0's spike harnesses
+//! (§8) live there too, in `crates/wgpui-wgpu/benches/`, since they need a
+//! real device.
+#![allow(dead_code)]
+
+pub mod app;
+pub mod boundary;
+pub mod invalidation;
+pub mod occlusion;
+pub mod patch;
+pub mod reconcile;
+pub mod scene;
+pub mod shaders;
+pub mod test_support;
+pub mod window;

--- a/crates/wgpui-core/src/window.rs
+++ b/crates/wgpui-core/src/window.rs
@@ -1,0 +1,16 @@
+//! `window.rs`'s actual successors, one concern each — the targeted split
+//! of today's 14,278-line, 450-method `impl Window` block.
+//! See docs/gpu-native-architecture.md §1, §3.1.
+#![allow(dead_code)]
+
+pub mod animation;
+pub mod dispatch;
+pub mod focus;
+pub mod hitbox;
+pub mod input;
+pub mod prompts;
+
+/// Placeholder for `Window` struct assembly only — the split moves behavior
+/// into `focus`/`hitbox`/`dispatch`/`input`/`animation`/`prompts`, this file
+/// just wires them together.
+pub struct Window;

--- a/crates/wgpui-core/src/window/animation.rs
+++ b/crates/wgpui-core/src/window/animation.rs
@@ -1,0 +1,3 @@
+//! `request_animation_frame(_for)`, §5.4's `TRANSFORM`-only glide path.
+//! See docs/gpu-native-architecture.md §3.1, §5.4.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/window/dispatch.rs
+++ b/crates/wgpui-core/src/window/dispatch.rs
@@ -1,0 +1,3 @@
+//! `DispatchTree`, action dispatch, `key_context`. See
+//! docs/gpu-native-architecture.md §3.1, §6.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/window/focus.rs
+++ b/crates/wgpui-core/src/window/focus.rs
@@ -1,0 +1,3 @@
+//! `FocusHandle`/`FocusId`, tab stops. See docs/gpu-native-architecture.md
+//! §3.1, §6 (kept on the CPU: "small, latency-critical, already cheap").
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/window/hitbox.rs
+++ b/crates/wgpui-core/src/window/hitbox.rs
@@ -1,0 +1,4 @@
+//! `Hitbox`, point-transform hit-testing (R-N §5.2), kept as-is per §6:
+//! small, latency-critical, already cheap. See
+//! docs/gpu-native-architecture.md §3.1, §6.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/window/input.rs
+++ b/crates/wgpui-core/src/window/input.rs
@@ -1,0 +1,3 @@
+//! Keyboard/mouse event routing. See docs/gpu-native-architecture.md §3.1,
+//! §6.
+#![allow(dead_code)]

--- a/crates/wgpui-core/src/window/prompts.rs
+++ b/crates/wgpui-core/src/window/prompts.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — already its own file in the legacy backend today
+//! (`src/window/prompts.rs`). See docs/gpu-native-architecture.md §3.1.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/Cargo.toml
+++ b/crates/wgpui-devtools/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wgpui-devtools"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "wgpui_devtools"
+path = "src/wgpui_devtools.rs"
+doctest = false
+
+[dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/crates/wgpui-devtools/src/flamegraph.rs
+++ b/crates/wgpui-devtools/src/flamegraph.rs
@@ -1,0 +1,9 @@
+//! Per-frame CPU/GPU flamegraphs and the RenderDoc-style capture-and-replay
+//! engine — ~9,000 lines across four files in the legacy backend today.
+//! See docs/gpu-native-architecture.md §3.6, §1.
+#![allow(dead_code)]
+
+pub mod cpu;
+pub mod gpu;
+pub mod replay;
+pub mod ui_capture;

--- a/crates/wgpui-devtools/src/flamegraph/cpu.rs
+++ b/crates/wgpui-devtools/src/flamegraph/cpu.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/flamegraph.rs`.
+//! See docs/gpu-native-architecture.md §3.6.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/flamegraph/gpu.rs
+++ b/crates/wgpui-devtools/src/flamegraph/gpu.rs
@@ -1,0 +1,4 @@
+//! Moved, not rebuilt — today's `src/flamegraph_gpu.rs`. §8 Phase 0 notes
+//! this crate's GPU timestamp capture is ported first, as Phase 0's
+//! baseline instrumentation. See docs/gpu-native-architecture.md §3.6, §8.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/flamegraph/replay.rs
+++ b/crates/wgpui-devtools/src/flamegraph/replay.rs
@@ -1,0 +1,4 @@
+//! Moved, not rebuilt — today's `src/flamegraph_replay.rs`
+//! ("RenderDoc for our UI framework"). See docs/gpu-native-architecture.md
+//! §3.6, §9.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/flamegraph/ui_capture.rs
+++ b/crates/wgpui-devtools/src/flamegraph/ui_capture.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/flamegraph_ui_capture.rs`.
+//! See docs/gpu-native-architecture.md §3.6.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/hooks.rs
+++ b/crates/wgpui-devtools/src/hooks.rs
@@ -1,0 +1,5 @@
+//! The small trait `wgpui-core`/`wgpui-wgpu` expose into: span push/pop, GPU
+//! timestamp write, frame-capture trigger — the same shape `profiling`
+//! (already a dependency of the legacy backend) uses for its own
+//! backend-agnostic design. See docs/gpu-native-architecture.md §3.6.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/inspector.rs
+++ b/crates/wgpui-devtools/src/inspector.rs
@@ -1,0 +1,2 @@
+//! Moved, not rebuilt. See docs/gpu-native-architecture.md §3.6.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/perf_ab_tests.rs
+++ b/crates/wgpui-devtools/src/perf_ab_tests.rs
@@ -1,0 +1,2 @@
+//! Moved, not rebuilt. See docs/gpu-native-architecture.md §3.6.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/render_stats.rs
+++ b/crates/wgpui-devtools/src/render_stats.rs
@@ -1,0 +1,4 @@
+//! Moved, not rebuilt. Ported per §8's Phase 4 note for the O(layer slots)
+//! draw-issuing measurement and §5.0's byte-count/call-count counters.
+//! See docs/gpu-native-architecture.md §3.6, §5.0, §8.
+#![allow(dead_code)]

--- a/crates/wgpui-devtools/src/wgpui_devtools.rs
+++ b/crates/wgpui-devtools/src/wgpui_devtools.rs
@@ -1,0 +1,12 @@
+//! `wgpui-devtools` — flamegraph/replay/inspector, moved wholesale behind a
+//! small hook trait `wgpui-core`/`wgpui-wgpu` expose into. Pure
+//! move-and-decouple, zero behavior change (Phase 7's gate: `wgpui-core`
+//! builds and runs with this crate absent entirely).
+//! See docs/gpu-native-architecture.md §3.6, §8 Phase 7.
+#![allow(dead_code)]
+
+pub mod flamegraph;
+pub mod hooks;
+pub mod inspector;
+pub mod perf_ab_tests;
+pub mod render_stats;

--- a/crates/wgpui-layout/Cargo.toml
+++ b/crates/wgpui-layout/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wgpui-layout"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "wgpui_layout"
+path = "src/wgpui_layout.rs"
+doctest = false
+
+[dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/crates/wgpui-layout/src/containment.rs
+++ b/crates/wgpui-layout/src/containment.rs
@@ -1,0 +1,3 @@
+//! `estimated_size` / layout containment (SFD §0.-3).
+//! See docs/gpu-native-architecture.md §3.2.
+#![allow(dead_code)]

--- a/crates/wgpui-layout/src/measure.rs
+++ b/crates/wgpui-layout/src/measure.rs
@@ -1,0 +1,3 @@
+//! Measured-layout closures (text/intrinsic-size leaves).
+//! See docs/gpu-native-architecture.md §3.2.
+#![allow(dead_code)]

--- a/crates/wgpui-layout/src/regular.rs
+++ b/crates/wgpui-layout/src/regular.rs
@@ -1,0 +1,4 @@
+//! Detects §6.1-eligible ("regular") content — position computable
+//! independently per item, in parallel; everything else stays on Taffy.
+//! See docs/gpu-native-architecture.md §3.2, §6.1.
+#![allow(dead_code)]

--- a/crates/wgpui-layout/src/taffy_tree.rs
+++ b/crates/wgpui-layout/src/taffy_tree.rs
@@ -1,0 +1,3 @@
+//! Persistent `TaffyTree` wrapper — today's `src/taffy.rs`, made ambient
+//! per §4.0. See docs/gpu-native-architecture.md §3.2.
+#![allow(dead_code)]

--- a/crates/wgpui-layout/src/wgpui_layout.rs
+++ b/crates/wgpui-layout/src/wgpui_layout.rs
@@ -1,0 +1,11 @@
+//! `wgpui-layout` — Taffy integration, isolated. See
+//! docs/gpu-native-architecture.md §3.2. Depended on for heterogeneous
+//! flexbox/grid layout, which stays on the CPU on purpose (§6); the regular-
+//! content GPU layout kernel (§6.1) lives in `wgpui-core::shaders` /
+//! `wgpui-wgpu::render::compute::layout_pass`, not here.
+#![allow(dead_code)]
+
+pub mod containment;
+pub mod measure;
+pub mod regular;
+pub mod taffy_tree;

--- a/crates/wgpui-text/Cargo.toml
+++ b/crates/wgpui-text/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wgpui-text"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "wgpui_text"
+path = "src/wgpui_text.rs"
+doctest = false
+
+[dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/crates/wgpui-text/src/fonts.rs
+++ b/crates/wgpui-text/src/fonts.rs
@@ -1,0 +1,8 @@
+//! Font feature/fallback handling. Not shown as its own `mod.rs` in
+//! §3.3's tree, but the `fonts/` directory needs a declaring file under
+//! this repo's no-`mod.rs` convention (see AGENTS.md). See
+//! docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]
+
+pub mod fallbacks;
+pub mod features;

--- a/crates/wgpui-text/src/fonts/fallbacks.rs
+++ b/crates/wgpui-text/src/fonts/fallbacks.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/text_system/font_fallbacks.rs`.
+//! See docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/fonts/features.rs
+++ b/crates/wgpui-text/src/fonts/features.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/text_system/font_features.rs`.
+//! See docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/line.rs
+++ b/crates/wgpui-text/src/line.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/text_system/line.rs`.
+//! See docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/line_layout.rs
+++ b/crates/wgpui-text/src/line_layout.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/text_system/line_layout.rs`.
+//! See docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/line_wrapper.rs
+++ b/crates/wgpui-text/src/line_wrapper.rs
@@ -1,0 +1,3 @@
+//! Moved, not rebuilt — today's `src/text_system/line_wrapper.rs`.
+//! See docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/patch.rs
+++ b/crates/wgpui-text/src/patch.rs
@@ -1,0 +1,3 @@
+//! Shaped-run → patch conversion (Phase 5), closes §6.2's `Img`/
+//! `StyledText` gap. See docs/gpu-native-architecture.md §3.3, §6.2.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/shaping.rs
+++ b/crates/wgpui-text/src/shaping.rs
@@ -1,0 +1,3 @@
+//! cosmic-text integration — today's `src/text_system.rs` core.
+//! See docs/gpu-native-architecture.md §3.3.
+#![allow(dead_code)]

--- a/crates/wgpui-text/src/wgpui_text.rs
+++ b/crates/wgpui-text/src/wgpui_text.rs
@@ -1,0 +1,11 @@
+//! `wgpui-text` — cosmic-text shaping, isolated. Text shaping stays on the
+//! CPU on purpose (§6); this crate is mostly a move, not a rewrite, of
+//! today's `src/text_system/`. See docs/gpu-native-architecture.md §3.3, §6.
+#![allow(dead_code)]
+
+pub mod fonts;
+pub mod line;
+pub mod line_layout;
+pub mod line_wrapper;
+pub mod patch;
+pub mod shaping;

--- a/crates/wgpui-wgpu/Cargo.toml
+++ b/crates/wgpui-wgpu/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "wgpui-wgpu"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "wgpui_wgpu"
+path = "src/wgpui_wgpu.rs"
+doctest = false
+
+[dependencies]
+# The only crate that touches a live wgpu::Device (docs/gpu-native-architecture.md
+# §3.5) — this dependency is genuinely needed even at the Phase 0 stub stage
+# because the Phase 0 spike harnesses (benches/) live here and open a real
+# device. Version matches the pin already used by the root gpui-ce crate.
+wgpu = { version = "30", default-features = false, features = [
+    "dx12",
+    "vulkan",
+    "wgsl",
+] }
+pollster = "0.4.0"
+bytemuck = { version = "1.24", features = ["derive"] }
+
+[dev-dependencies]
+rand = "0.10"
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/crates/wgpui-wgpu/examples/adapter_probe.rs
+++ b/crates/wgpui-wgpu/examples/adapter_probe.rs
@@ -1,0 +1,72 @@
+//! Phase 0 (docs/gpu-native-architecture.md §8, §11): before trusting any
+//! spike number, find out what GPU adapter (if any) this environment
+//! actually hands back. Run with:
+//!
+//!     cargo run -p wgpui-wgpu --example adapter_probe --offline
+//!
+//! Mirrors the legacy backend's own established pattern for headless device
+//! creation (`src/flamegraph_gpu.rs`'s `create_headless_device_with_features`,
+//! `src/platform/cross/render_context.rs`'s `WgpuContext::new`):
+//! `enumerate_adapters` + pick, not `request_adapter` — there is no window
+//! here to supply a `compatible_surface`, and this is the pattern the crate
+//! already uses for exactly that case. Prints every adapter `wgpu`
+//! enumerates on the native backends (Vulkan, DX12) and reports, honestly,
+//! whether the one this probe would use for a device is real hardware or a
+//! software/CPU fallback (llvmpipe, WARP, etc.) — see the module doc on
+//! `create_headless_device_with_features` for why a CI/sandbox environment
+//! with neither is an expected, not exceptional, outcome.
+
+fn main() {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::VULKAN | wgpu::Backends::DX12,
+        flags: wgpu::InstanceFlags::default(),
+        backend_options: wgpu::BackendOptions::default(),
+        memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        display: None,
+    });
+
+    println!("== Adapters enumerated on VULKAN | DX12 ==");
+    let adapters =
+        pollster::block_on(instance.enumerate_adapters(wgpu::Backends::VULKAN | wgpu::Backends::DX12));
+    if adapters.is_empty() {
+        println!("(none enumerated -- no usable GPU adapter, real or software, on this backend set)");
+    }
+    for adapter in &adapters {
+        let info = adapter.get_info();
+        println!(
+            "  name={:?} backend={:?} device_type={:?} driver={:?} driver_info={:?} vendor={:#x} device_id={:#x}",
+            info.name, info.backend, info.device_type, info.driver, info.driver_info, info.vendor, info.device
+        );
+    }
+
+    println!();
+    println!("== Picking the first adapter (this crate's established pattern) and requesting a device ==");
+    let Some(adapter) = adapters.into_iter().next() else {
+        println!("  No adapter available at all -- spikes cannot run a real compute pass here.");
+        return;
+    };
+
+    let info = adapter.get_info();
+    let name_lower = info.name.to_lowercase();
+    let is_software = matches!(info.device_type, wgpu::DeviceType::Cpu)
+        || name_lower.contains("llvmpipe")
+        || name_lower.contains("warp")
+        || name_lower.contains("software")
+        || name_lower.contains("microsoft basic render");
+    println!(
+        "  Selected adapter: name={:?} backend={:?} device_type={:?} driver_info={:?}",
+        info.name, info.backend, info.device_type, info.driver_info
+    );
+    println!(
+        "  software/CPU-fallback adapter: {}",
+        if is_software { "YES" } else { "no" }
+    );
+
+    match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("adapter_probe device"),
+        ..Default::default()
+    })) {
+        Ok(_) => println!("  request_device: OK"),
+        Err(error) => println!("  request_device: FAILED: {error}"),
+    }
+}

--- a/crates/wgpui-wgpu/examples/spike_a_ordering_occlusion.rs
+++ b/crates/wgpui-wgpu/examples/spike_a_ordering_occlusion.rs
@@ -1,0 +1,1108 @@
+//! Phase 0, Spike A (docs/gpu-native-architecture.md §8, §11, §5.1, §5.2):
+//! a synthetic 100,000-quad scene's ordering + occlusion culling as a GPU
+//! compute pass vs. today's CPU `BoundsTree` (`src/bounds_tree.rs`) +
+//! `Scene::finish`'s CPU sort (`src/scene.rs`).
+//!
+//! Run with:
+//!
+//!     cargo run -p wgpui-wgpu --example spike_a_ordering_occlusion --release --offline
+//!
+//! # Methodology
+//!
+//! **Scene**: 200 spatially disjoint "clusters" arranged on a grid, 500
+//! quads each (100,000 total). Each cluster is: one opaque background quad,
+//! ~480 small randomly placed/sized quads (mostly translucent, creating
+//! genuine local nesting/overlap — this is what gives the scene the
+//! "not all identical, not all disjoint" structure the spike asks for), and
+//! 20 larger opaque "occluder" quads scattered on top (inserted after the
+//! nested content, so they sort above it and some of them fully cover
+//! several smaller quads beneath — genuine occlusion structure, not just a
+//! theoretical possibility). Clusters never overlap each other, so all
+//! overlap/occlusion structure is local to a cluster — a real generic scene
+//! would need real spatial partitioning (a uniform grid or the production
+//! `BoundsTree`'s own AABB tree) to bound neighbor search the way this
+//! spike's synthetic cluster layout does for free; that's future
+//! engineering work for Phase 3, not something this spike had to solve.
+//!
+//! **CPU path**: a faithful, standalone port of `src/bounds_tree.rs`'s
+//! `BoundsTree::insert` (same AABB dynamic-tree structure, same
+//! max-intersecting-order-plus-one rule), fed one quad at a time exactly as
+//! `Scene`'s painters do today, followed by a `sort_by_key` over the
+//! resulting `order` values — the same shape as `Scene::finish`
+//! (`scene.rs:734`, `self.quads.sort_by_key(|quad| quad.order)`). Then a
+//! simplified CPU occlusion pass: for each quad, check it against the small
+//! per-cluster occluder list for a single opaque, fully-containing,
+//! later-drawn rectangle. This is NOT R-N §8.3's full conservative test
+//! (no corner-radius inset, border-opacity inset, or backdrop-filter
+//! awareness — this synthetic scene has no such properties to test) but is
+//! the same shape of computation: bounds containment + opacity + order
+//! comparison.
+//!
+//! **GPU path**: three compute passes over the same quad buffer already
+//! uploaded to a storage buffer (vertex-pulling layout, matching how the
+//! legacy renderer already binds instance data today, per
+//! docs/gpu-native-architecture.md §1):
+//!   1. `relax` — the tree's `order[i] = 1 + max(order[j] : j < i in the
+//!      same cluster, overlapping)` recurrence, solved by fixed-point Jacobi
+//!      relaxation (ping-ponged buffers) instead of a sequential tree walk.
+//!      This is mathematically the exact same recurrence the CPU
+//!      `BoundsTree` computes (verified below by exact readback comparison,
+//!      not assumed) — the tree is just a faster way to answer the same
+//!      "max order among overlapping earlier quads" query.
+//!   2. `bitonic` — an in-place bitonic sort (by `order`, tie-broken by
+//!      original index, packed into one `u32` key) over the whole padded
+//!      instance buffer, replacing the CPU `sort_by_key`.
+//!   3. `cull` — the same per-cluster occluder containment test as the CPU
+//!      reference, run once per quad in parallel.
+//!
+//! All three passes are encoded into ONE command encoder and submitted
+//! once; the reported GPU time covers buffer creation, the initial upload,
+//! all compute passes, and the final `poll(Wait)` — i.e. it is an
+//! end-to-end wall-clock number from the CPU's point of view, not an
+//! isolated on-device kernel time. Correctness is checked, not assumed: the
+//! GPU's final `order`/`culled` buffers are read back and compared
+//! bit-for-bit against the CPU reference.
+
+use std::time::Instant;
+
+use rand::{RngExt, SeedableRng};
+
+const CLUSTERS_X: u32 = 20;
+const CLUSTERS_Y: u32 = 10;
+const CLUSTERS: u32 = CLUSTERS_X * CLUSTERS_Y;
+const PER_CLUSTER: u32 = 500;
+const TOTAL_QUADS: u32 = CLUSTERS * PER_CLUSTER;
+const OCCLUDERS_PER_CLUSTER: u32 = 20;
+const NESTED_PER_CLUSTER: u32 = PER_CLUSTER - 1 - OCCLUDERS_PER_CLUSTER;
+const CLUSTER_SIZE: f32 = 200.0;
+const RELAX_ITERATIONS: u32 = 128;
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuQuad {
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+    opaque: u32,
+    cluster: u32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct GpuOccluder {
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+    order: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct BitonicParams {
+    j: u32,
+    k: u32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+#[derive(Clone, Copy)]
+struct Bounds {
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+}
+
+impl Bounds {
+    fn union(&self, other: &Bounds) -> Bounds {
+        Bounds {
+            min_x: self.min_x.min(other.min_x),
+            min_y: self.min_y.min(other.min_y),
+            max_x: self.max_x.max(other.max_x),
+            max_y: self.max_y.max(other.max_y),
+        }
+    }
+
+    fn intersects(&self, other: &Bounds) -> bool {
+        self.min_x < other.max_x
+            && other.min_x < self.max_x
+            && self.min_y < other.max_y
+            && other.min_y < self.max_y
+    }
+
+    fn half_perimeter(&self) -> f32 {
+        (self.max_x - self.min_x) + (self.max_y - self.min_y)
+    }
+}
+
+/// Faithful, standalone port of `src/bounds_tree.rs`'s `BoundsTree` — same
+/// AABB dynamic-tree structure and max-intersecting-order-plus-one
+/// insertion rule, minus the `order_floor`/`insert_above_all`/
+/// `insert_at_order` machinery this spike's plain painter's-order scene
+/// doesn't need.
+enum Node {
+    Leaf {
+        bounds: Bounds,
+        order: u32,
+    },
+    Internal {
+        left: usize,
+        right: usize,
+        bounds: Bounds,
+        max_order: u32,
+    },
+}
+
+impl Node {
+    fn bounds(&self) -> &Bounds {
+        match self {
+            Node::Leaf { bounds, .. } => bounds,
+            Node::Internal { bounds, .. } => bounds,
+        }
+    }
+
+    fn max_ordering(&self) -> u32 {
+        match self {
+            Node::Leaf { order, .. } => *order,
+            Node::Internal { max_order, .. } => *max_order,
+        }
+    }
+}
+
+struct CpuBoundsTree {
+    root: Option<usize>,
+    nodes: Vec<Node>,
+    stack: Vec<usize>,
+}
+
+impl CpuBoundsTree {
+    fn new() -> Self {
+        Self {
+            root: None,
+            nodes: Vec::new(),
+            stack: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, new_bounds: Bounds) -> u32 {
+        let Some(mut index) = self.root else {
+            let order = 1u32;
+            let new_node = self.push_leaf(new_bounds, order);
+            self.root = Some(new_node);
+            return order;
+        };
+
+        let mut max_intersecting_ordering = 0;
+        while let Node::Internal {
+            left,
+            right,
+            bounds: node_bounds,
+            ..
+        } = &mut self.nodes[index]
+        {
+            let left = *left;
+            let right = *right;
+            *node_bounds = node_bounds.union(&new_bounds);
+            self.stack.push(index);
+
+            let left_cost = new_bounds.union(self.nodes[left].bounds()).half_perimeter();
+            let right_cost = new_bounds.union(self.nodes[right].bounds()).half_perimeter();
+            if left_cost < right_cost {
+                max_intersecting_ordering =
+                    self.find_max_ordering(right, &new_bounds, max_intersecting_ordering);
+                index = left;
+            } else {
+                max_intersecting_ordering =
+                    self.find_max_ordering(left, &new_bounds, max_intersecting_ordering);
+                index = right;
+            }
+        }
+
+        let sibling = index;
+        let Node::Leaf {
+            bounds: sibling_bounds,
+            order: sibling_ordering,
+        } = &self.nodes[index]
+        else {
+            unreachable!();
+        };
+        if sibling_bounds.intersects(&new_bounds) {
+            max_intersecting_ordering = max_intersecting_ordering.max(*sibling_ordering);
+        }
+
+        let ordering = max_intersecting_ordering + 1;
+        self.attach_leaf(sibling, new_bounds, ordering)
+    }
+
+    fn attach_leaf(&mut self, sibling: usize, bounds: Bounds, ordering: u32) -> u32 {
+        let new_node = self.push_leaf(bounds, ordering);
+        let new_parent = self.push_internal(sibling, new_node);
+
+        if let Some(old_parent) = self.stack.last().copied() {
+            let Node::Internal { left, right, .. } = &mut self.nodes[old_parent] else {
+                unreachable!();
+            };
+            if *left == sibling {
+                *left = new_parent;
+            } else {
+                *right = new_parent;
+            }
+        } else {
+            self.root = Some(new_parent);
+        }
+
+        for node_index in self.stack.drain(..).rev() {
+            let Node::Internal { max_order, .. } = &mut self.nodes[node_index] else {
+                unreachable!()
+            };
+            if *max_order >= ordering {
+                break;
+            }
+            *max_order = ordering;
+        }
+
+        ordering
+    }
+
+    fn find_max_ordering(&self, index: usize, bounds: &Bounds, mut max_ordering: u32) -> u32 {
+        match &self.nodes[index] {
+            Node::Leaf { bounds: node_bounds, order } => {
+                if bounds.intersects(node_bounds) {
+                    max_ordering = max_ordering.max(*order);
+                }
+            }
+            Node::Internal {
+                left,
+                right,
+                bounds: node_bounds,
+                max_order,
+            } => {
+                if bounds.intersects(node_bounds) && max_ordering < *max_order {
+                    let left_max = self.nodes[*left].max_ordering();
+                    let right_max = self.nodes[*right].max_ordering();
+                    if left_max > right_max {
+                        max_ordering = self.find_max_ordering(*left, bounds, max_ordering);
+                        max_ordering = self.find_max_ordering(*right, bounds, max_ordering);
+                    } else {
+                        max_ordering = self.find_max_ordering(*right, bounds, max_ordering);
+                        max_ordering = self.find_max_ordering(*left, bounds, max_ordering);
+                    }
+                }
+            }
+        }
+        max_ordering
+    }
+
+    fn push_leaf(&mut self, bounds: Bounds, order: u32) -> usize {
+        self.nodes.push(Node::Leaf { bounds, order });
+        self.nodes.len() - 1
+    }
+
+    fn push_internal(&mut self, left: usize, right: usize) -> usize {
+        let new_bounds = self.nodes[left].bounds().union(self.nodes[right].bounds());
+        let max_order = self.nodes[left].max_ordering().max(self.nodes[right].max_ordering());
+        self.nodes.push(Node::Internal {
+            bounds: new_bounds,
+            left,
+            right,
+            max_order,
+        });
+        self.nodes.len() - 1
+    }
+}
+
+struct Scene {
+    quads: Vec<GpuQuad>,
+}
+
+fn generate_scene(seed: u64) -> Scene {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let mut quads = Vec::with_capacity(TOTAL_QUADS as usize);
+
+    for cluster_y in 0..CLUSTERS_Y {
+        for cluster_x in 0..CLUSTERS_X {
+            let cluster = cluster_y * CLUSTERS_X + cluster_x;
+            let origin_x = cluster_x as f32 * CLUSTER_SIZE;
+            let origin_y = cluster_y as f32 * CLUSTER_SIZE;
+
+            // One opaque background quad, filling the cluster (index 0 in
+            // the cluster => order 1, drawn first / lowest).
+            quads.push(GpuQuad {
+                min_x: origin_x,
+                min_y: origin_y,
+                max_x: origin_x + CLUSTER_SIZE,
+                max_y: origin_y + CLUSTER_SIZE,
+                opaque: 1,
+                cluster,
+                _pad0: 0,
+                _pad1: 0,
+            });
+
+            // Small, randomly placed/sized, mostly-translucent nested
+            // content — genuine local overlap structure.
+            for _ in 0..NESTED_PER_CLUSTER {
+                let width: f32 = rng.random_range(5.0..40.0);
+                let height: f32 = rng.random_range(5.0..40.0);
+                let x = origin_x + rng.random_range(0.0..(CLUSTER_SIZE - width).max(1.0));
+                let y = origin_y + rng.random_range(0.0..(CLUSTER_SIZE - height).max(1.0));
+                let opaque: u32 = if rng.random_range(0..100) < 20 { 1 } else { 0 };
+                quads.push(GpuQuad {
+                    min_x: x,
+                    min_y: y,
+                    max_x: x + width,
+                    max_y: y + height,
+                    opaque,
+                    cluster,
+                    _pad0: 0,
+                    _pad1: 0,
+                });
+            }
+
+            // Larger opaque "occluder" quads, inserted last (so they sort
+            // above the nested content) and sized so several genuinely
+            // cover smaller quads beneath them.
+            for _ in 0..OCCLUDERS_PER_CLUSTER {
+                let width: f32 = rng.random_range(40.0..70.0);
+                let height: f32 = rng.random_range(40.0..70.0);
+                let x = origin_x + rng.random_range(0.0..(CLUSTER_SIZE - width).max(1.0));
+                let y = origin_y + rng.random_range(0.0..(CLUSTER_SIZE - height).max(1.0));
+                quads.push(GpuQuad {
+                    min_x: x,
+                    min_y: y,
+                    max_x: x + width,
+                    max_y: y + height,
+                    opaque: 1,
+                    cluster,
+                    _pad0: 0,
+                    _pad1: 0,
+                });
+            }
+        }
+    }
+
+    Scene { quads }
+}
+
+fn quad_bounds(quad: &GpuQuad) -> Bounds {
+    Bounds {
+        min_x: quad.min_x,
+        min_y: quad.min_y,
+        max_x: quad.max_x,
+        max_y: quad.max_y,
+    }
+}
+
+/// Fills `scene.occluders` (the last `OCCLUDERS_PER_CLUSTER` opaque quads of
+/// each cluster: the occluders proper, not the background) with their real
+/// order values, once the CPU ordering pass has computed `orders`.
+fn fill_occluders(scene: &Scene, orders: &[u32]) -> Vec<GpuOccluder> {
+    let mut occluders = vec![
+        GpuOccluder {
+            min_x: 0.0,
+            min_y: 0.0,
+            max_x: 0.0,
+            max_y: 0.0,
+            order: 0,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+        };
+        (CLUSTERS * OCCLUDERS_PER_CLUSTER) as usize
+    ];
+    for cluster in 0..CLUSTERS {
+        let cluster_start = (cluster * PER_CLUSTER) as usize;
+        let occluder_start_in_cluster = (1 + NESTED_PER_CLUSTER) as usize;
+        for slot in 0..OCCLUDERS_PER_CLUSTER as usize {
+            let quad_index = cluster_start + occluder_start_in_cluster + slot;
+            let quad = &scene.quads[quad_index];
+            let occluder_index = cluster as usize * OCCLUDERS_PER_CLUSTER as usize + slot;
+            occluders[occluder_index] = GpuOccluder {
+                min_x: quad.min_x,
+                min_y: quad.min_y,
+                max_x: quad.max_x,
+                max_y: quad.max_y,
+                order: orders[quad_index],
+                _pad0: 0,
+                _pad1: 0,
+                _pad2: 0,
+            };
+        }
+    }
+    occluders
+}
+
+struct CpuResult {
+    orders: Vec<u32>,
+    culled: Vec<bool>,
+    tree_time: std::time::Duration,
+    sort_time: std::time::Duration,
+    occlusion_time: std::time::Duration,
+}
+
+fn run_cpu_path(scene: &Scene) -> CpuResult {
+    let start = Instant::now();
+    let mut tree = CpuBoundsTree::new();
+    let mut orders = vec![0u32; scene.quads.len()];
+    for (i, quad) in scene.quads.iter().enumerate() {
+        orders[i] = tree.insert(quad_bounds(quad));
+    }
+    let tree_time = start.elapsed();
+
+    let sort_start = Instant::now();
+    let mut indices: Vec<u32> = (0..scene.quads.len() as u32).collect();
+    indices.sort_by_key(|&i| orders[i as usize]);
+    let sort_time = sort_start.elapsed();
+
+    let occluders = fill_occluders(scene, &orders);
+
+    let occlusion_start = Instant::now();
+    let mut culled = vec![false; scene.quads.len()];
+    for cluster in 0..CLUSTERS {
+        let cluster_start = (cluster * PER_CLUSTER) as usize;
+        let occluder_start = cluster as usize * OCCLUDERS_PER_CLUSTER as usize;
+        let cluster_occluders = &occluders[occluder_start..occluder_start + OCCLUDERS_PER_CLUSTER as usize];
+        for local_index in 0..PER_CLUSTER as usize {
+            let i = cluster_start + local_index;
+            let quad = &scene.quads[i];
+            let order = orders[i];
+            for occluder in cluster_occluders {
+                if occluder.order > order
+                    && occluder.min_x <= quad.min_x
+                    && occluder.min_y <= quad.min_y
+                    && occluder.max_x >= quad.max_x
+                    && occluder.max_y >= quad.max_y
+                {
+                    culled[i] = true;
+                    break;
+                }
+            }
+        }
+    }
+    let occlusion_time = occlusion_start.elapsed();
+
+    CpuResult {
+        orders,
+        culled,
+        tree_time,
+        sort_time,
+        occlusion_time,
+    }
+}
+
+const RELAX_SHADER: &str = r#"
+struct Quad {
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+    opaque: u32,
+    cluster: u32,
+    pad0: u32,
+    pad1: u32,
+};
+
+@group(0) @binding(0) var<storage, read> quads: array<Quad>;
+@group(0) @binding(1) var<storage, read> order_in: array<u32>;
+@group(0) @binding(2) var<storage, read_write> order_out: array<u32>;
+@group(0) @binding(3) var<storage, read_write> changed: array<atomic<u32>>;
+
+const PER_CLUSTER: u32 = 500u;
+
+@compute @workgroup_size(64)
+fn relax(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= arrayLength(&quads)) {
+        return;
+    }
+    let qi = quads[i];
+    let cluster_start = qi.cluster * PER_CLUSTER;
+    var best: u32 = 0u;
+    var j: u32 = cluster_start;
+    loop {
+        if (j >= i) {
+            break;
+        }
+        let qj = quads[j];
+        if (qj.min_x < qi.max_x && qi.min_x < qj.max_x &&
+            qj.min_y < qi.max_y && qi.min_y < qj.max_y) {
+            let oj = order_in[j];
+            if (oj > best) {
+                best = oj;
+            }
+        }
+        j = j + 1u;
+    }
+    let new_order = best + 1u;
+    if (new_order != order_in[i]) {
+        atomicAdd(&changed[0], 1u);
+    }
+    order_out[i] = new_order;
+}
+"#;
+
+const BITONIC_SHADER: &str = r#"
+struct Params {
+    j: u32,
+    k: u32,
+    pad0: u32,
+    pad1: u32,
+};
+
+@group(0) @binding(0) var<storage, read_write> keys: array<u32>;
+@group(0) @binding(1) var<storage, read_write> vals: array<u32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn bitonic(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    let n = arrayLength(&keys);
+    if (i >= n) {
+        return;
+    }
+    let ixj = i ^ params.j;
+    if (ixj > i) {
+        let ascending = (i & params.k) == 0u;
+        let ki = keys[i];
+        let kj = keys[ixj];
+        var do_swap = false;
+        if (ascending) {
+            do_swap = ki > kj;
+        } else {
+            do_swap = ki < kj;
+        }
+        if (do_swap) {
+            keys[i] = kj;
+            keys[ixj] = ki;
+            let vi = vals[i];
+            vals[i] = vals[ixj];
+            vals[ixj] = vi;
+        }
+    }
+}
+"#;
+
+const CULL_SHADER: &str = r#"
+struct Quad {
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+    opaque: u32,
+    cluster: u32,
+    pad0: u32,
+    pad1: u32,
+};
+
+struct Occluder {
+    min_x: f32,
+    min_y: f32,
+    max_x: f32,
+    max_y: f32,
+    order: u32,
+    pad0: u32,
+    pad1: u32,
+    pad2: u32,
+};
+
+@group(0) @binding(0) var<storage, read> quads: array<Quad>;
+@group(0) @binding(1) var<storage, read> orders: array<u32>;
+@group(0) @binding(2) var<storage, read> occluders: array<Occluder>;
+@group(0) @binding(3) var<storage, read_write> culled: array<u32>;
+
+const OCCLUDERS_PER_CLUSTER: u32 = 20u;
+
+@compute @workgroup_size(64)
+fn cull(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= arrayLength(&quads)) {
+        return;
+    }
+    let qi = quads[i];
+    let oi = orders[i];
+    let start = qi.cluster * OCCLUDERS_PER_CLUSTER;
+    var is_culled: u32 = 0u;
+    var k: u32 = 0u;
+    loop {
+        if (k >= OCCLUDERS_PER_CLUSTER) {
+            break;
+        }
+        let occ = occluders[start + k];
+        if (occ.order > oi &&
+            occ.min_x <= qi.min_x && occ.min_y <= qi.min_y &&
+            occ.max_x >= qi.max_x && occ.max_y >= qi.max_y) {
+            is_culled = 1u;
+            break;
+        }
+        k = k + 1u;
+    }
+    culled[i] = is_culled;
+}
+"#;
+
+fn next_pow2(n: u32) -> u32 {
+    let mut p = 1u32;
+    while p < n {
+        p <<= 1;
+    }
+    p
+}
+
+fn read_storage_buffer_u32(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    buffer: &wgpu::Buffer,
+    count: usize,
+) -> Vec<u32> {
+    let size = (count * std::mem::size_of::<u32>()) as u64;
+    let staging = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback staging"),
+        size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.copy_buffer_to_buffer(buffer, 0, &staging, 0, size);
+    queue.submit(Some(encoder.finish()));
+
+    let slice = staging.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device.poll failed");
+    rx.recv().expect("map_async channel closed").expect("buffer map failed");
+
+    let data = slice.get_mapped_range().expect("get_mapped_range failed");
+    let values: Vec<u32> = bytemuck::cast_slice(&data[..]).to_vec();
+    drop(data);
+    staging.unmap();
+    values
+}
+
+fn main() {
+    println!("=== Phase 0 Spike A: ordering + occlusion, GPU compute vs. CPU BoundsTree ===");
+    println!(
+        "Scene: {CLUSTERS} clusters x {PER_CLUSTER} quads/cluster = {TOTAL_QUADS} quads total"
+    );
+
+    // --- Device setup: same enumerate_adapters + pick-first pattern as
+    // src/platform/cross/render_context.rs / src/flamegraph_gpu.rs, for the
+    // same reason (no window / compatible_surface here). See
+    // examples/adapter_probe.rs for the full adapter honesty report.
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::VULKAN | wgpu::Backends::DX12,
+        flags: wgpu::InstanceFlags::default(),
+        backend_options: wgpu::BackendOptions::default(),
+        memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        display: None,
+    });
+    let adapters = pollster::block_on(
+        instance.enumerate_adapters(wgpu::Backends::VULKAN | wgpu::Backends::DX12),
+    );
+    let Some(adapter) = adapters.into_iter().next() else {
+        println!("NO GPU ADAPTER AVAILABLE (real or software) — cannot run the GPU half of this spike.");
+        println!("See examples/adapter_probe.rs for the full honesty report.");
+        return;
+    };
+    let info = adapter.get_info();
+    let name_lower = info.name.to_lowercase();
+    let is_software = matches!(info.device_type, wgpu::DeviceType::Cpu)
+        || name_lower.contains("llvmpipe")
+        || name_lower.contains("warp")
+        || name_lower.contains("software")
+        || name_lower.contains("microsoft basic render");
+    println!(
+        "Adapter: name={:?} backend={:?} device_type={:?} driver_info={:?} software_fallback={}",
+        info.name, info.backend, info.device_type, info.driver_info, is_software
+    );
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("spike_a device"),
+        ..Default::default()
+    }))
+    .expect("request_device failed");
+
+    // --- Scene generation (not timed — shared input to both paths).
+    let scene = generate_scene(0xA11CE);
+
+    // --- CPU reference path.
+    let cpu = run_cpu_path(&scene);
+    println!();
+    println!("--- CPU path (src/bounds_tree.rs + src/scene.rs algorithm, ported) ---");
+    println!("  BoundsTree insert (ordering):  {:>10.3?}", cpu.tree_time);
+    println!("  sort_by_key (draw order):      {:>10.3?}", cpu.sort_time);
+    println!("  occlusion cull (simplified):   {:>10.3?}", cpu.occlusion_time);
+    let cpu_total = cpu.tree_time + cpu.sort_time + cpu.occlusion_time;
+    println!("  CPU total:                     {:>10.3?}", cpu_total);
+    let cpu_culled_count = cpu.culled.iter().filter(|c| **c).count();
+    println!(
+        "  quads culled by occlusion: {} / {} ({:.1}%)",
+        cpu_culled_count,
+        scene.quads.len(),
+        100.0 * cpu_culled_count as f64 / scene.quads.len() as f64
+    );
+    let max_order = cpu.orders.iter().copied().max().unwrap_or(0);
+    println!("  max painter order in scene: {max_order} (relaxation iteration budget: {RELAX_ITERATIONS})");
+    if max_order >= RELAX_ITERATIONS {
+        println!(
+            "  WARNING: max order ({max_order}) >= relaxation iteration budget ({RELAX_ITERATIONS}) — \
+             the GPU ordering pass below may not have converged. Increase RELAX_ITERATIONS."
+        );
+    }
+
+    // --- GPU path.
+    let gpu_start = Instant::now();
+
+    let quad_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("quads"),
+        size: (scene.quads.len() * std::mem::size_of::<GpuQuad>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    queue.write_buffer(&quad_buffer, 0, bytemuck::cast_slice(&scene.quads));
+
+    let padded_len = next_pow2(TOTAL_QUADS) as usize;
+    let n = scene.quads.len();
+
+    let order_a = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("order_a"),
+        size: (n * std::mem::size_of::<u32>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let order_b = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("order_b"),
+        size: (n * std::mem::size_of::<u32>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let initial_orders = vec![1u32; n];
+    queue.write_buffer(&order_a, 0, bytemuck::cast_slice(&initial_orders));
+    queue.write_buffer(&order_b, 0, bytemuck::cast_slice(&initial_orders));
+
+    let changed_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("changed"),
+        size: 4,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    queue.write_buffer(&changed_buffer, 0, bytemuck::bytes_of(&0u32));
+
+    let relax_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("relax"),
+        source: wgpu::ShaderSource::Wgsl(RELAX_SHADER.into()),
+    });
+    let relax_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("relax pipeline"),
+        layout: None,
+        module: &relax_module,
+        entry_point: Some("relax"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let relax_layout = relax_pipeline.get_bind_group_layout(0);
+
+    let bind_group_a_to_b = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("relax a->b"),
+        layout: &relax_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: quad_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: order_a.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 2, resource: order_b.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 3, resource: changed_buffer.as_entire_binding() },
+        ],
+    });
+    let bind_group_b_to_a = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("relax b->a"),
+        layout: &relax_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: quad_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: order_b.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 2, resource: order_a.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 3, resource: changed_buffer.as_entire_binding() },
+        ],
+    });
+
+    let relax_workgroups = n.div_ceil(64) as u32;
+
+    // --- Bitonic sort setup (padded to next power of two).
+    let mut initial_keys = vec![u32::MAX; padded_len];
+    let mut initial_vals = vec![u32::MAX; padded_len];
+    for i in 0..n {
+        // Real order values are filled in after the relax passes via a
+        // combined key on the GPU; here we just need vals/keys allocated.
+        initial_keys[i] = 0;
+        initial_vals[i] = i as u32;
+    }
+    let keys_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("bitonic keys"),
+        size: (padded_len * std::mem::size_of::<u32>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let vals_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("bitonic vals"),
+        size: (padded_len * std::mem::size_of::<u32>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    queue.write_buffer(&keys_buffer, 0, bytemuck::cast_slice(&initial_keys));
+    queue.write_buffer(&vals_buffer, 0, bytemuck::cast_slice(&initial_vals));
+
+    // Pack (order, index) into keys_buffer from whichever order buffer holds
+    // the final relax result, via a tiny compute pass — done as part of the
+    // same encoder below, using a small inline shader.
+    const PACK_SHADER: &str = r#"
+        @group(0) @binding(0) var<storage, read> order_final: array<u32>;
+        @group(0) @binding(1) var<storage, read_write> keys: array<u32>;
+        @compute @workgroup_size(64)
+        fn pack(@builtin(global_invocation_id) gid: vec3<u32>) {
+            let i = gid.x;
+            if (i >= arrayLength(&order_final)) { return; }
+            keys[i] = order_final[i] * 131072u + i;
+        }
+    "#;
+    let pack_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("pack"),
+        source: wgpu::ShaderSource::Wgsl(PACK_SHADER.into()),
+    });
+    let pack_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("pack pipeline"),
+        layout: None,
+        module: &pack_module,
+        entry_point: Some("pack"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    let bitonic_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("bitonic"),
+        source: wgpu::ShaderSource::Wgsl(BITONIC_SHADER.into()),
+    });
+    let bitonic_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("bitonic pipeline"),
+        layout: None,
+        module: &bitonic_module,
+        entry_point: Some("bitonic"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let bitonic_layout = bitonic_pipeline.get_bind_group_layout(0);
+
+    let mut bitonic_stage_params: Vec<(u32, u32)> = Vec::new();
+    {
+        let mut k = 2u32;
+        while k <= padded_len as u32 {
+            let mut j = k / 2;
+            while j >= 1 {
+                bitonic_stage_params.push((j, k));
+                j /= 2;
+            }
+            k *= 2;
+        }
+    }
+    let mut bitonic_param_buffers = Vec::with_capacity(bitonic_stage_params.len());
+    let mut bitonic_bind_groups = Vec::with_capacity(bitonic_stage_params.len());
+    for &(j, k) in &bitonic_stage_params {
+        let params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bitonic params"),
+            size: std::mem::size_of::<BitonicParams>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(
+            &params_buffer,
+            0,
+            bytemuck::bytes_of(&BitonicParams { j, k, _pad0: 0, _pad1: 0 }),
+        );
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("bitonic stage"),
+            layout: &bitonic_layout,
+            entries: &[
+                wgpu::BindGroupEntry { binding: 0, resource: keys_buffer.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 1, resource: vals_buffer.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 2, resource: params_buffer.as_entire_binding() },
+            ],
+        });
+        bitonic_param_buffers.push(params_buffer);
+        bitonic_bind_groups.push(bind_group);
+    }
+    let bitonic_workgroups = (padded_len as u32).div_ceil(256);
+
+    // --- Occlusion cull setup.
+    let occluder_count = (CLUSTERS * OCCLUDERS_PER_CLUSTER) as usize;
+    let occluder_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("occluders"),
+        size: (occluder_count * std::mem::size_of::<GpuOccluder>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let culled_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("culled"),
+        size: (n * std::mem::size_of::<u32>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    // NOTE: the occluder buffer needs real `order` values, which only exist
+    // after the relax passes run. We resolve this by re-uploading the
+    // occluder buffer from the CPU-computed `cpu.orders` (already available)
+    // rather than round-tripping through the GPU — the occluder list itself
+    // is tiny (CLUSTERS * OCCLUDERS_PER_CLUSTER entries), so this upload is
+    // negligible and does not change what's being measured (the per-quad
+    // relax/sort/cull compute cost).
+    let occluders_with_orders = fill_occluders(&scene, &cpu.orders);
+    queue.write_buffer(&occluder_buffer, 0, bytemuck::cast_slice(&occluders_with_orders));
+
+    let cull_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("cull"),
+        source: wgpu::ShaderSource::Wgsl(CULL_SHADER.into()),
+    });
+    let cull_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("cull pipeline"),
+        layout: None,
+        module: &cull_module,
+        entry_point: Some("cull"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    // --- Encode everything into one command buffer, submit once.
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("spike_a"),
+    });
+
+    for iteration in 0..RELAX_ITERATIONS {
+        // Reset the convergence counter right before the LAST iteration only,
+        // so the value read back afterward reports just that iteration's
+        // residual change count (0 = fully converged by then), not the
+        // cumulative churn across all iterations. A `clear_buffer` command
+        // inside this same encoder is properly ordered relative to the
+        // compute passes around it, unlike a `queue.write_buffer` call made
+        // here (which would run before anything in this not-yet-submitted
+        // encoder, not "between iterations").
+        if iteration == RELAX_ITERATIONS - 1 {
+            encoder.clear_buffer(&changed_buffer, 0, None);
+        }
+        let bind_group = if iteration % 2 == 0 { &bind_group_a_to_b } else { &bind_group_b_to_a };
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&relax_pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.dispatch_workgroups(relax_workgroups, 1, 1);
+    }
+    // Final relax output lives in order_b if RELAX_ITERATIONS is odd,
+    // order_a if even (since iteration 0 writes a->b, iteration 1 writes
+    // b->a, ...).
+    let final_order_buffer = if RELAX_ITERATIONS % 2 == 1 { &order_b } else { &order_a };
+
+    let pack_layout = pack_pipeline.get_bind_group_layout(0);
+    let pack_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("pack bind group"),
+        layout: &pack_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: final_order_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: keys_buffer.as_entire_binding() },
+        ],
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&pack_pipeline);
+        pass.set_bind_group(0, &pack_bind_group, &[]);
+        pass.dispatch_workgroups(relax_workgroups, 1, 1);
+    }
+
+    for bind_group in &bitonic_bind_groups {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&bitonic_pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.dispatch_workgroups(bitonic_workgroups, 1, 1);
+    }
+
+    let cull_layout = cull_pipeline.get_bind_group_layout(0);
+    let cull_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("cull bind group"),
+        layout: &cull_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: quad_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: final_order_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 2, resource: occluder_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 3, resource: culled_buffer.as_entire_binding() },
+        ],
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&cull_pipeline);
+        pass.set_bind_group(0, &cull_bind_group, &[]);
+        pass.dispatch_workgroups(relax_workgroups, 1, 1);
+    }
+
+    queue.submit(Some(encoder.finish()));
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device.poll failed");
+    let gpu_total = gpu_start.elapsed();
+
+    // --- Read back and validate against the CPU reference.
+    let gpu_orders = read_storage_buffer_u32(&device, &queue, final_order_buffer, n);
+    let gpu_culled = read_storage_buffer_u32(&device, &queue, &culled_buffer, n);
+    let gpu_changed = read_storage_buffer_u32(&device, &queue, &changed_buffer, 1);
+
+    let mut order_mismatches = 0usize;
+    for i in 0..n {
+        if gpu_orders[i] != cpu.orders[i] {
+            order_mismatches += 1;
+        }
+    }
+    let mut cull_mismatches = 0usize;
+    for i in 0..n {
+        let gpu_bool = gpu_culled[i] != 0;
+        if gpu_bool != cpu.culled[i] {
+            cull_mismatches += 1;
+        }
+    }
+
+    println!();
+    println!("--- GPU path (compute: relax x{RELAX_ITERATIONS} + bitonic sort + cull, end-to-end) ---");
+    println!("  total (buffer create+upload, {} compute passes, submit, poll): {:>10.3?}",
+        RELAX_ITERATIONS + 1 + bitonic_bind_groups.len() as u32 + 1, gpu_total);
+    println!(
+        "  relax convergence check (last-iteration changed count, 0 = fully converged): {}",
+        gpu_changed[0]
+    );
+    println!(
+        "  order[] exact match vs. CPU BoundsTree: {} / {n} ({} mismatches)",
+        n - order_mismatches,
+        order_mismatches
+    );
+    println!(
+        "  culled[] exact match vs. CPU occlusion: {} / {n} ({} mismatches)",
+        n - cull_mismatches,
+        cull_mismatches
+    );
+
+    println!();
+    println!("--- Summary ---");
+    println!("  CPU total: {cpu_total:>10.3?}");
+    println!("  GPU total: {gpu_total:>10.3?}  (adapter: {:?}, software_fallback={is_software})", info.name);
+    if gpu_total < cpu_total {
+        println!(
+            "  GPU path is {:.2}x faster end-to-end on this hardware.",
+            cpu_total.as_secs_f64() / gpu_total.as_secs_f64()
+        );
+    } else {
+        println!(
+            "  GPU path is {:.2}x SLOWER end-to-end on this hardware (dispatch-count/readback overhead \
+             likely dominates at this problem size -- see docs/phase-0-results.md for discussion).",
+            gpu_total.as_secs_f64() / cpu_total.as_secs_f64()
+        );
+    }
+}

--- a/crates/wgpui-wgpu/examples/spike_b_uniform_layout.rs
+++ b/crates/wgpui-wgpu/examples/spike_b_uniform_layout.rs
@@ -1,0 +1,279 @@
+//! Phase 0, Spike B (docs/gpu-native-architecture.md §8, §11, §6.1):
+//! a 10,000-row uniform grid's layout as a compute kernel vs. today's
+//! `uniform_list`'s CPU loop (`src/elements/uniform_list.rs`).
+//!
+//! Run with:
+//!
+//!     cargo run -p wgpui-wgpu --example spike_b_uniform_layout --release --offline
+//!
+//! # Methodology
+//!
+//! **CPU path**: the exact per-item position formula `uniform_list`'s
+//! `prepaint` uses today (`src/elements/uniform_list.rs:551-553`):
+//!
+//! ```ignore
+//! let item_origin = padded_bounds.origin
+//!     + visual_scroll_offset
+//!     + point(Pixels::ZERO, item_height * ix);
+//! ```
+//!
+//! computed for all 10,000 rows (not just the scrolled-into-view subset —
+//! `uniform_list` only ever computes the visible range in production, which
+//! makes the real CPU cost lower than what's measured here; this spike
+//! intentionally computes the full item count on both sides for a fair,
+//! apples-to-apples comparison of "compute N positions", not a comparison
+//! that also credits the CPU side for a virtualization optimization the GPU
+//! side isn't being asked to replicate).
+//!
+//! **GPU path**: one compute pass, `item_count` invocations, each computing
+//! the identical formula from `(item_count, item_height, container origin,
+//! scroll offset)` — the exact inputs §6.1 names. Timed end-to-end (buffer
+//! creation, upload of the tiny parameter uniform, the compute dispatch,
+//! and the final `poll(Wait)`), the same methodology as Spike A.
+//!
+//! This is the spike most likely to go the *other* way from Spike A: the
+//! per-item computation is a single multiply-add, so the fixed cost of a
+//! GPU dispatch (buffer/pipeline setup, driver submission, `poll(Wait)`
+//! round-trip) is a much larger fraction of the total than in Spike A's
+//! much heavier per-item workload. Phase 0's gate is explicit that a spike
+//! not winning is a real, useful answer, not a failure of the harness — see
+//! docs/phase-0-results.md for the measured result and what it implies for
+//! Phase 6.1's scope.
+
+use std::time::Instant;
+
+const ITEM_COUNT: u32 = 10_000;
+const ITEM_HEIGHT: f32 = 24.0;
+const CONTAINER_ORIGIN: (f32, f32) = (0.0, 0.0);
+const SCROLL_OFFSET: (f32, f32) = (0.0, -1234.0);
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct LayoutParams {
+    item_count: u32,
+    item_height: f32,
+    origin_x: f32,
+    origin_y: f32,
+    scroll_x: f32,
+    scroll_y: f32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+fn run_cpu_path() -> (Vec<[f32; 2]>, std::time::Duration) {
+    let start = Instant::now();
+    let mut positions = Vec::with_capacity(ITEM_COUNT as usize);
+    for ix in 0..ITEM_COUNT {
+        let x = CONTAINER_ORIGIN.0 + SCROLL_OFFSET.0;
+        let y = CONTAINER_ORIGIN.1 + SCROLL_OFFSET.1 + ITEM_HEIGHT * ix as f32;
+        positions.push([x, y]);
+    }
+    let elapsed = start.elapsed();
+    (positions, elapsed)
+}
+
+const LAYOUT_SHADER: &str = r#"
+struct Params {
+    item_count: u32,
+    item_height: f32,
+    origin_x: f32,
+    origin_y: f32,
+    scroll_x: f32,
+    scroll_y: f32,
+    pad0: u32,
+    pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read_write> positions: array<vec2<f32>>;
+
+@compute @workgroup_size(64)
+fn compute_layout(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let ix = gid.x;
+    if (ix >= params.item_count) {
+        return;
+    }
+    let x = params.origin_x + params.scroll_x;
+    let y = params.origin_y + params.scroll_y + params.item_height * f32(ix);
+    positions[ix] = vec2<f32>(x, y);
+}
+"#;
+
+fn read_storage_buffer_vec2(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    buffer: &wgpu::Buffer,
+    count: usize,
+) -> Vec<[f32; 2]> {
+    let size = (count * std::mem::size_of::<[f32; 2]>()) as u64;
+    let staging = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback staging"),
+        size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.copy_buffer_to_buffer(buffer, 0, &staging, 0, size);
+    queue.submit(Some(encoder.finish()));
+
+    let slice = staging.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device.poll failed");
+    rx.recv().expect("map_async channel closed").expect("buffer map failed");
+
+    let data = slice.get_mapped_range().expect("get_mapped_range failed");
+    let values: Vec<[f32; 2]> = bytemuck::cast_slice(&data[..]).to_vec();
+    drop(data);
+    staging.unmap();
+    values
+}
+
+fn main() {
+    println!("=== Phase 0 Spike B: uniform-list layout, GPU compute kernel vs. CPU loop ===");
+    println!("Rows: {ITEM_COUNT}, item_height: {ITEM_HEIGHT}px");
+
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::VULKAN | wgpu::Backends::DX12,
+        flags: wgpu::InstanceFlags::default(),
+        backend_options: wgpu::BackendOptions::default(),
+        memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        display: None,
+    });
+    let adapters = pollster::block_on(
+        instance.enumerate_adapters(wgpu::Backends::VULKAN | wgpu::Backends::DX12),
+    );
+    let Some(adapter) = adapters.into_iter().next() else {
+        println!("NO GPU ADAPTER AVAILABLE (real or software) — cannot run the GPU half of this spike.");
+        println!("See examples/adapter_probe.rs for the full honesty report.");
+        return;
+    };
+    let info = adapter.get_info();
+    let name_lower = info.name.to_lowercase();
+    let is_software = matches!(info.device_type, wgpu::DeviceType::Cpu)
+        || name_lower.contains("llvmpipe")
+        || name_lower.contains("warp")
+        || name_lower.contains("software")
+        || name_lower.contains("microsoft basic render");
+    println!(
+        "Adapter: name={:?} backend={:?} device_type={:?} driver_info={:?} software_fallback={}",
+        info.name, info.backend, info.device_type, info.driver_info, is_software
+    );
+
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("spike_b device"),
+        ..Default::default()
+    }))
+    .expect("request_device failed");
+
+    // --- CPU reference path.
+    let (cpu_positions, cpu_time) = run_cpu_path();
+    println!();
+    println!("--- CPU path (src/elements/uniform_list.rs's per-item formula) ---");
+    println!("  total: {cpu_time:>10.3?}  ({:.1} ns/row)", cpu_time.as_nanos() as f64 / ITEM_COUNT as f64);
+
+    // --- GPU path, single dispatch, timed end-to-end.
+    let gpu_start = Instant::now();
+
+    let params = LayoutParams {
+        item_count: ITEM_COUNT,
+        item_height: ITEM_HEIGHT,
+        origin_x: CONTAINER_ORIGIN.0,
+        origin_y: CONTAINER_ORIGIN.1,
+        scroll_x: SCROLL_OFFSET.0,
+        scroll_y: SCROLL_OFFSET.1,
+        _pad0: 0,
+        _pad1: 0,
+    };
+    let params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("layout params"),
+        size: std::mem::size_of::<LayoutParams>() as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    queue.write_buffer(&params_buffer, 0, bytemuck::bytes_of(&params));
+
+    let positions_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("positions"),
+        size: (ITEM_COUNT as usize * std::mem::size_of::<[f32; 2]>()) as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("layout"),
+        source: wgpu::ShaderSource::Wgsl(LAYOUT_SHADER.into()),
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("layout pipeline"),
+        layout: None,
+        module: &module,
+        entry_point: Some("compute_layout"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let bind_group_layout = pipeline.get_bind_group_layout(0);
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("layout bind group"),
+        layout: &bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: params_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: positions_buffer.as_entire_binding() },
+        ],
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("spike_b"),
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(ITEM_COUNT.div_ceil(64), 1, 1);
+    }
+    queue.submit(Some(encoder.finish()));
+    device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device.poll failed");
+    let gpu_total = gpu_start.elapsed();
+
+    let gpu_positions = read_storage_buffer_vec2(&device, &queue, &positions_buffer, ITEM_COUNT as usize);
+
+    let mut mismatches = 0usize;
+    for i in 0..ITEM_COUNT as usize {
+        if gpu_positions[i] != cpu_positions[i] {
+            mismatches += 1;
+        }
+    }
+
+    println!();
+    println!("--- GPU path (1 compute dispatch, end-to-end) ---");
+    println!("  total (buffer create+upload, dispatch, submit, poll): {gpu_total:>10.3?}");
+    println!(
+        "  position[] exact match vs. CPU: {} / {ITEM_COUNT} ({} mismatches)",
+        ITEM_COUNT as usize - mismatches,
+        mismatches
+    );
+
+    println!();
+    println!("--- Summary ---");
+    println!("  CPU total: {cpu_time:>10.3?}");
+    println!("  GPU total: {gpu_total:>10.3?}  (adapter: {:?}, software_fallback={is_software})", info.name);
+    if gpu_total < cpu_time {
+        println!(
+            "  GPU path is {:.2}x faster end-to-end on this hardware.",
+            cpu_time.as_secs_f64() / gpu_total.as_secs_f64()
+        );
+    } else {
+        println!(
+            "  GPU path is {:.2}x SLOWER end-to-end on this hardware -- at this problem size and this \
+             per-item workload, dispatch/submit/poll overhead dominates the actual (trivial) per-item \
+             math. See docs/phase-0-results.md for discussion of what this implies for Phase 6.1's scope.",
+            gpu_total.as_secs_f64() / cpu_time.as_secs_f64()
+        );
+    }
+}

--- a/crates/wgpui-wgpu/src/render.rs
+++ b/crates/wgpui-wgpu/src/render.rs
@@ -1,0 +1,14 @@
+//! Device/queue creation, pipelines, compute dispatch, atlas, textures,
+//! draw issuance. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]
+
+pub mod atlas;
+pub mod buffers;
+pub mod compute;
+pub mod device;
+pub mod draw;
+pub mod pipelines;
+pub mod readback;
+pub mod shaders;
+pub mod surface_registry;
+pub mod textures;

--- a/crates/wgpui-wgpu/src/render/atlas.rs
+++ b/crates/wgpui-wgpu/src/render/atlas.rs
@@ -1,0 +1,3 @@
+//! Glyph/sprite atlas, `etagere` bin-packing — moved, not rebuilt.
+//! See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/buffers.rs
+++ b/crates/wgpui-wgpu/src/render/buffers.rs
@@ -1,0 +1,6 @@
+//! GPU-side buffer per slab kind, plus delta-upload adjacency coalescing.
+//! See docs/gpu-native-architecture.md §3.5, §5.0.
+#![allow(dead_code)]
+
+pub mod slab_buffers;
+pub mod upload;

--- a/crates/wgpui-wgpu/src/render/buffers/slab_buffers.rs
+++ b/crates/wgpui-wgpu/src/render/buffers/slab_buffers.rs
@@ -1,0 +1,2 @@
+//! GPU-side buffer per slab kind. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/buffers/upload.rs
+++ b/crates/wgpui-wgpu/src/render/buffers/upload.rs
@@ -1,0 +1,4 @@
+//! Delta-upload adjacency coalescing (§5.0) — reuses the same coalescing
+//! logic `OpenSlabRun` already does for draw calls, applied to writes
+//! instead of draws. See docs/gpu-native-architecture.md §5.0.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/compute.rs
+++ b/crates/wgpui-wgpu/src/render/compute.rs
@@ -1,0 +1,11 @@
+//! The GPU compute passes: ordering, occlusion, regular-content layout,
+//! tile visibility, indirect draw-arg generation. Each dispatches the
+//! corresponding WGSL source from `wgpui_core::shaders`.
+//! See docs/gpu-native-architecture.md §5.1-§5.3, §4.3, §6.1.
+#![allow(dead_code)]
+
+pub mod indirect_args_pass;
+pub mod layout_pass;
+pub mod occlusion_pass;
+pub mod ordering_pass;
+pub mod tile_visibility_pass;

--- a/crates/wgpui-wgpu/src/render/compute/indirect_args_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/indirect_args_pass.rs
@@ -1,0 +1,3 @@
+//! Dispatches `wgpui_core::shaders::INDIRECT_ARGS_WGSL` (§5.3).
+//! See docs/gpu-native-architecture.md §5.3, §8 Phase 4.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/compute/layout_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/layout_pass.rs
@@ -1,0 +1,5 @@
+//! Dispatches `wgpui_core::shaders::LAYOUT_UNIFORM_WGSL` (§6.1). Phase 0's
+//! Spike B prototype (`benches/spike_b_uniform_layout.rs`) is the throwaway
+//! precursor to this pass's real implementation.
+//! See docs/gpu-native-architecture.md §6.1, §8 Phase 0/Phase 6.1.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/compute/occlusion_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/occlusion_pass.rs
@@ -1,0 +1,5 @@
+//! Dispatches `wgpui_core::shaders::OCCLUSION_WGSL` (§5.2). Phase 0's Spike A
+//! prototype (`benches/spike_a_ordering_occlusion.rs`) is the throwaway
+//! precursor to this pass's real implementation.
+//! See docs/gpu-native-architecture.md §5.2, §8 Phase 0/Phase 3.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/compute/ordering_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/ordering_pass.rs
@@ -1,0 +1,5 @@
+//! Dispatches `wgpui_core::shaders::ORDERING_WGSL` (§5.1). Phase 0's Spike A
+//! prototype (`benches/spike_a_ordering_occlusion.rs`) is the throwaway
+//! precursor to this pass's real implementation.
+//! See docs/gpu-native-architecture.md §5.1, §8 Phase 0/Phase 3.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/compute/tile_visibility_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/tile_visibility_pass.rs
@@ -1,0 +1,3 @@
+//! Dispatches `wgpui_core::shaders::TILE_VISIBILITY_WGSL` (§4.3).
+//! See docs/gpu-native-architecture.md §4.3, §8 Phase 4.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/device.rs
+++ b/crates/wgpui-wgpu/src/render/device.rs
@@ -1,0 +1,3 @@
+//! Device/queue creation, feature negotiation — today's
+//! `src/render_context.rs`. See docs/gpu-native-architecture.md §3.5, §1.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/draw.rs
+++ b/crates/wgpui-wgpu/src/render/draw.rs
@@ -1,0 +1,3 @@
+//! Indirect draw issuance + coalescing (today's `OpenSlabRun` logic in
+//! `src/renderer.rs`). See docs/gpu-native-architecture.md §5.3, §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/pipelines.rs
+++ b/crates/wgpui-wgpu/src/render/pipelines.rs
@@ -1,0 +1,4 @@
+//! Render pipeline creation per primitive kind (today's
+//! quads/shadows/.../paths pipeline construction in `src/renderer.rs`).
+//! See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/readback.rs
+++ b/crates/wgpui-wgpu/src/render/readback.rs
@@ -1,0 +1,3 @@
+//! CPU-readback fallback for indirect draw (§5.3) — macOS best-effort and
+//! WASM. See docs/gpu-native-architecture.md §5.3, §0 constraint 2.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/shaders.rs
+++ b/crates/wgpui-wgpu/src/render/shaders.rs
@@ -1,0 +1,13 @@
+//! The hand-written render shaders, moved as-is from
+//! `src/platform/cross/shaders/*.wgsl`. See docs/gpu-native-architecture.md
+//! §3.5, §1.
+#![allow(dead_code)]
+
+pub const QUADS_WGSL: &str = include_str!("shaders/quads.wgsl");
+pub const SHADOWS_WGSL: &str = include_str!("shaders/shadows.wgsl");
+pub const MONO_SPRITES_WGSL: &str = include_str!("shaders/mono_sprites.wgsl");
+pub const POLY_SPRITES_WGSL: &str = include_str!("shaders/poly_sprites.wgsl");
+pub const PATHS_WGSL: &str = include_str!("shaders/paths.wgsl");
+pub const UNDERLINES_WGSL: &str = include_str!("shaders/underlines.wgsl");
+pub const BACKDROP_BLUR_WGSL: &str = include_str!("shaders/backdrop_blur.wgsl");
+pub const SURFACES_WGSL: &str = include_str!("shaders/surfaces.wgsl");

--- a/crates/wgpui-wgpu/src/render/shaders/backdrop_blur.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/backdrop_blur.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/backdrop_blur.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/mono_sprites.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/mono_sprites.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/mono_sprites.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/paths.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/paths.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/paths.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/poly_sprites.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/poly_sprites.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/poly_sprites.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/quads.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/quads.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/quads.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/shadows.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/shadows.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/shadows.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/surfaces.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/surfaces.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/surfaces.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/shaders/underlines.wgsl
+++ b/crates/wgpui-wgpu/src/render/shaders/underlines.wgsl
@@ -1,0 +1,2 @@
+// Placeholder — moved as-is from src/platform/cross/shaders/underlines.wgsl in a later phase.
+// See docs/gpu-native-architecture.md §3.5.

--- a/crates/wgpui-wgpu/src/render/surface_registry.rs
+++ b/crates/wgpui-wgpu/src/render/surface_registry.rs
@@ -1,0 +1,5 @@
+//! Producer-side triple-buffer for externally-rendered `WgpuSurface`
+//! content — UNCHANGED (§5.5, §9's explicit "don't touch this"). Moved,
+//! not rebuilt, from today's `src/surface_registry.rs` (772 lines).
+//! See docs/gpu-native-architecture.md §5.5, §9.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/textures.rs
+++ b/crates/wgpui-wgpu/src/render/textures.rs
@@ -1,0 +1,7 @@
+//! Boundary texture-retention pool and the unified `WgpuSurface` consumer
+//! entry (§5.5, Gap 2 — same type as `layer_texture`).
+//! See docs/gpu-native-architecture.md §3.5, §5.5.
+#![allow(dead_code)]
+
+pub mod external_surface;
+pub mod layer_texture;

--- a/crates/wgpui-wgpu/src/render/textures/external_surface.rs
+++ b/crates/wgpui-wgpu/src/render/textures/external_surface.rs
@@ -1,0 +1,6 @@
+//! Unified `WgpuSurface` consumer entry (§5.5, Gap 2) — the *consuming*
+//! half of `SurfaceRegistry`'s composite path, folded into the same
+//! indirect-draw entry mechanism `.boundary()`'s texture-retained layers
+//! use. `SurfaceRegistry`'s producer side is untouched (§9's risk table).
+//! See docs/gpu-native-architecture.md §5.5, §9.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/render/textures/layer_texture.rs
+++ b/crates/wgpui-wgpu/src/render/textures/layer_texture.rs
@@ -1,0 +1,3 @@
+//! Boundary texture-retention pool (today's `LayerTextureEntry`).
+//! See docs/gpu-native-architecture.md §3.5, §5.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/wgpui_wgpu.rs
+++ b/crates/wgpui-wgpu/src/wgpui_wgpu.rs
@@ -1,0 +1,11 @@
+//! `wgpui-wgpu` — the only crate that touches a live `wgpu::Device`:
+//! pipelines, compute dispatch, atlas, textures, winit windowing.
+//! See docs/gpu-native-architecture.md §3.5.
+//!
+//! Phase 0's two spikes (§8) live in this crate's `benches/` directory and
+//! `examples/adapter_probe.rs`, since they need a real device to compare
+//! against the CPU reference paths in the legacy backend.
+#![allow(dead_code)]
+
+pub mod render;
+pub mod window;

--- a/crates/wgpui-wgpu/src/window.rs
+++ b/crates/wgpui-wgpu/src/window.rs
@@ -1,0 +1,8 @@
+//! winit window creation/event loop glue — today's
+//! `src/platform/cross/window.rs`. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]
+
+pub mod app_menu;
+pub mod dispatcher;
+pub mod keyboard;
+pub mod resize_detector;

--- a/crates/wgpui-wgpu/src/window/app_menu.rs
+++ b/crates/wgpui-wgpu/src/window/app_menu.rs
@@ -1,0 +1,2 @@
+//! Moved, not rebuilt. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/window/dispatcher.rs
+++ b/crates/wgpui-wgpu/src/window/dispatcher.rs
@@ -1,0 +1,2 @@
+//! Moved, not rebuilt. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/window/keyboard.rs
+++ b/crates/wgpui-wgpu/src/window/keyboard.rs
@@ -1,0 +1,2 @@
+//! Moved, not rebuilt. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-wgpu/src/window/resize_detector.rs
+++ b/crates/wgpui-wgpu/src/window/resize_detector.rs
@@ -1,0 +1,2 @@
+//! Moved, not rebuilt. See docs/gpu-native-architecture.md §3.5.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/Cargo.toml
+++ b/crates/wgpui-widgets/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wgpui-widgets"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "wgpui_widgets"
+path = "src/wgpui_widgets.rs"
+doctest = false
+
+[dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow" }

--- a/crates/wgpui-widgets/src/animation.rs
+++ b/crates/wgpui-widgets/src/animation.rs
@@ -1,0 +1,3 @@
+//! Element-level animation helpers. See docs/gpu-native-architecture.md
+//! §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/canvas.rs
+++ b/crates/wgpui-widgets/src/canvas.rs
@@ -1,0 +1,2 @@
+//! `canvas()` element. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/div.rs
+++ b/crates/wgpui-widgets/src/div.rs
@@ -1,0 +1,14 @@
+//! `Div`, `DivFrameState`/`DivPrepaintState` — the small remainder once
+//! `div.rs`'s four seams (event-binding, interactivity, the `Element` impl,
+//! scroll/click retained state) move to their own files.
+//! See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]
+
+pub mod diff;
+pub mod events;
+pub mod interactivity;
+pub mod scroll_state;
+
+/// Placeholder for `Div`'s own `Element` impl plus reconciliation
+/// fingerprint. Empty at Phase 0.
+pub struct Div;

--- a/crates/wgpui-widgets/src/div/diff.rs
+++ b/crates/wgpui-widgets/src/div/diff.rs
@@ -1,0 +1,3 @@
+//! `DivDiffKey` / `ReconcileKey` impl. See docs/gpu-native-architecture.md
+//! §3.4, §6.2.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/div/events.rs
+++ b/crates/wgpui-widgets/src/div/events.rs
@@ -1,0 +1,3 @@
+//! `InteractiveElement` — today's ~456-line trait block in `src/elements/div.rs`.
+//! See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/div/interactivity.rs
+++ b/crates/wgpui-widgets/src/div/interactivity.rs
@@ -1,0 +1,10 @@
+//! `Interactivity` state-and-paint engine — today's single largest block in
+//! `src/elements/div.rs` (~1,140 lines, interleaving style application,
+//! hitbox/dispatch registration, scroll handling, and layer paint), split
+//! into `style`/`hitbox`/`layer_paint` here.
+//! See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]
+
+pub mod hitbox;
+pub mod layer_paint;
+pub mod style;

--- a/crates/wgpui-widgets/src/div/interactivity/hitbox.rs
+++ b/crates/wgpui-widgets/src/div/interactivity/hitbox.rs
@@ -1,0 +1,3 @@
+//! Hitbox/dispatch-node registration. See docs/gpu-native-architecture.md
+//! §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/div/interactivity/layer_paint.rs
+++ b/crates/wgpui-widgets/src/div/interactivity/layer_paint.rs
@@ -1,0 +1,4 @@
+//! Boundary/paint plumbing — today's layer-paint slice of the
+//! ~1,140-line `Interactivity` block. See docs/gpu-native-architecture.md
+//! §3.4, §4.1.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/div/interactivity/style.rs
+++ b/crates/wgpui-widgets/src/div/interactivity/style.rs
@@ -1,0 +1,3 @@
+//! Style application + `classify_style_change` (§6.2's engine).
+//! See docs/gpu-native-architecture.md §3.4, §6.2, §4.0.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/div/scroll_state.rs
+++ b/crates/wgpui-widgets/src/div/scroll_state.rs
@@ -1,0 +1,3 @@
+//! `ScrollAnchor`/`ScrollHandle` — today's ~235-line block in
+//! `src/elements/div.rs`. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/image_cache.rs
+++ b/crates/wgpui-widgets/src/image_cache.rs
@@ -1,0 +1,2 @@
+//! Image loading/decoding cache. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/img.rs
+++ b/crates/wgpui-widgets/src/img.rs
@@ -1,0 +1,4 @@
+//! `Img` — gets `diff_key` here (§6.2 invariant, Phase 5), closing R-N
+//! Phase 7's self-documented gap. See docs/gpu-native-architecture.md §3.4,
+//! §6.2.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/list.rs
+++ b/crates/wgpui-widgets/src/list.rs
@@ -1,0 +1,10 @@
+//! List elements: `list()`, `uniform_list()`, `virtual_list()`, `h_list()`.
+//! `uniform_list`/`h_list` are §6.1's CPU special case — the content shape
+//! the GPU layout kernel generalizes. See docs/gpu-native-architecture.md
+//! §3.4, §6.1.
+#![allow(dead_code)]
+
+pub mod h_list;
+pub mod list;
+pub mod uniform_list;
+pub mod virtual_list;

--- a/crates/wgpui-widgets/src/list/h_list.rs
+++ b/crates/wgpui-widgets/src/list/h_list.rs
@@ -1,0 +1,3 @@
+//! `h_list()` — horizontal uniform list, §6.1's other CPU special case.
+//! See docs/gpu-native-architecture.md §3.4, §6.1.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/list/list.rs
+++ b/crates/wgpui-widgets/src/list/list.rs
@@ -1,0 +1,4 @@
+//! `list()` — general (non-uniform) list element. Moved, not rebuilt, from
+//! today's `src/elements/list.rs`. See docs/gpu-native-architecture.md
+//! §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/list/uniform_list.rs
+++ b/crates/wgpui-widgets/src/list/uniform_list.rs
@@ -1,0 +1,5 @@
+//! `uniform_list()` — the CPU special case §6.1's GPU kernel generalizes.
+//! Today's `src/elements/uniform_list.rs`; Phase 0's Spike B benchmarks
+//! this file's per-item positioning loop directly. See
+//! docs/gpu-native-architecture.md §3.4, §6.1, §8 Phase 0.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/list/virtual_list.rs
+++ b/crates/wgpui-widgets/src/list/virtual_list.rs
@@ -1,0 +1,3 @@
+//! `virtual_list()` — today's `src/elements/virtual_list.rs`.
+//! See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/overlay.rs
+++ b/crates/wgpui-widgets/src/overlay.rs
@@ -1,0 +1,7 @@
+//! Overlay elements: anchored and deferred (SFD §2's unbuffered-overlay
+//! pattern, reused by §4.3's tile-spanning content rule). See
+//! docs/gpu-native-architecture.md §3.4, §4.3.
+#![allow(dead_code)]
+
+pub mod anchored;
+pub mod deferred;

--- a/crates/wgpui-widgets/src/overlay/anchored.rs
+++ b/crates/wgpui-widgets/src/overlay/anchored.rs
@@ -1,0 +1,2 @@
+//! Anchored overlay positioning. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/overlay/deferred.rs
+++ b/crates/wgpui-widgets/src/overlay/deferred.rs
@@ -1,0 +1,2 @@
+//! Deferred-draw overlay content. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/scroll.rs
+++ b/crates/wgpui-widgets/src/scroll.rs
@@ -1,0 +1,7 @@
+//! Smooth scroll animation and the overscroll buffer (R-N §7/SFD's
+//! mechanism, generalized in name only by §4.1's `Buffering::Margin`).
+//! See docs/gpu-native-architecture.md §3.4, §4.1.
+#![allow(dead_code)]
+
+pub mod scroll_buffer;
+pub mod smooth_scroll;

--- a/crates/wgpui-widgets/src/scroll/scroll_buffer.rs
+++ b/crates/wgpui-widgets/src/scroll/scroll_buffer.rs
@@ -1,0 +1,3 @@
+//! Overscroll buffer (R-N §7/SFD). See docs/gpu-native-architecture.md
+//! §3.4, §4.1.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/scroll/smooth_scroll.rs
+++ b/crates/wgpui-widgets/src/scroll/smooth_scroll.rs
@@ -1,0 +1,2 @@
+//! Smooth-scroll animation state. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/styled_text.rs
+++ b/crates/wgpui-widgets/src/styled_text.rs
@@ -1,0 +1,4 @@
+//! `StyledText` — gets `diff_key` here (§6.2 invariant, Phase 5), closing
+//! R-N Phase 7's self-documented gap. See docs/gpu-native-architecture.md
+//! §3.4, §6.2.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/surface.rs
+++ b/crates/wgpui-widgets/src/surface.rs
@@ -1,0 +1,3 @@
+//! Generic surface element (distinct from `wgpu_surface`). See
+//! docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/svg.rs
+++ b/crates/wgpui-widgets/src/svg.rs
@@ -1,0 +1,2 @@
+//! `svg()` element. See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/text.rs
+++ b/crates/wgpui-widgets/src/text.rs
@@ -1,0 +1,3 @@
+//! `text()` element — today's `src/elements/text.rs`.
+//! See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/wgpu_surface.rs
+++ b/crates/wgpui-widgets/src/wgpu_surface.rs
@@ -1,0 +1,5 @@
+//! Real identity + trivial `diff_key` (§5.5, Gap 1) — today's
+//! `src/elements/wgpu_surface.rs` (545 lines), whose `id()` is hardcoded to
+//! `None`; this is where that gets fixed. See
+//! docs/gpu-native-architecture.md §3.4, §5.5.
+#![allow(dead_code)]

--- a/crates/wgpui-widgets/src/wgpui_widgets.rs
+++ b/crates/wgpui-widgets/src/wgpui_widgets.rs
@@ -1,0 +1,17 @@
+//! `wgpui-widgets` — elements, split along `div.rs`'s own seams.
+//! See docs/gpu-native-architecture.md §3.4.
+#![allow(dead_code)]
+
+pub mod animation;
+pub mod canvas;
+pub mod div;
+pub mod image_cache;
+pub mod img;
+pub mod list;
+pub mod overlay;
+pub mod scroll;
+pub mod styled_text;
+pub mod surface;
+pub mod svg;
+pub mod text;
+pub mod wgpu_surface;

--- a/docs/gpu-native-architecture.md
+++ b/docs/gpu-native-architecture.md
@@ -1,0 +1,1302 @@
+# WGPUI 2.0
+
+### GPU-Native Rearchitecture
+
+Status: **proposal — planning phase, no code written yet.** This is the spec
+for WGPUI 2.0: a from-the-ground-up GPU-native rearchitecture, kept
+backward-compatible at the frontend (§7) and versioned as a major bump
+because almost nothing below that frontend stays the same. It follows up on
+`docs/retained-layers.md` ("R-N") and `docs/scroll-free-by-default.md`
+("SFD") — WGPUI 1.x's own retained-rendering work — and does not repeat
+their vocabulary (`Layer`, `Invalidation`, `LayerPolicy`, `ElementInstance`,
+`diff_key`, overscroll buffers), citing them as "R-N §M" / "SFD §M"
+throughout. Read those two first if you haven't; this document assumes
+them. Self-references below ("2.0 does X", "2.0's job is...") mean this
+spec, the same way the other two documents refer to themselves as "R-N" and
+"SFD." This revision unifies everything decided so far into one coherent
+pass — ambient reconciliation as the actual default (§4.0), `.boundary()`
+narrowed to a pure compositing policy (§4.1), the `.uncached()` escape
+hatch (§4.2), tile-based buffering for freeform 2D content (§4.3), the
+explicit delta-upload contract (§5.0), the `WgpuSurface` fast path (§5.5),
+and — new in this revision — the full workspace file map (§3), so every
+mechanism above has a concrete, growable home instead of a crate-level
+sketch.
+
+**Contents:** §0 Constraints · §1 Current state · §2 Target shape · §3 File
+map · §4 Reconciliation & boundaries (4.0 ambient reconciliation · 4.1
+`.boundary()` · 4.2 `.uncached()` · 4.3 tile-based buffering) · §5 GPU
+compute pipeline (5.0 upload granularity · 5.1 ordering · 5.2 occlusion ·
+5.3 indirect draw · 5.4 invalidation · 5.5 `WgpuSurface`) · §6 What stays on
+the CPU (6.1 regular-content layout · 6.2 the `diff_key` invariant) · §7
+Frontend contract · §8 Phasing · §9 Risks · §10 Rejected/deferred · §11
+Immediate next actions.
+
+## 0. What this is actually asking for
+
+R-N and SFD made WGPUI's renderer *retained* — CPU state persists across
+frames instead of being rebuilt, so unchanged content costs nothing to
+re-walk. That work is real, merged (`#98`–`#148`), and mostly on by default.
+It is also, honestly, a CPU architecture: every mechanism it added — layers,
+instances, per-layer slabs, occlusion culling, scroll buffers — is CPU code
+that *produces* GPU buffers, not GPU code that *computes* the UI. The
+ordering sort, the occlusion sweep, the layout of a ten-thousand-row list,
+the decision about which primitives are dirty: all of it still happens on
+one CPU thread, one frame at a time, in a 14,278-line file.
+
+The request this document answers is the next step past that: stop treating
+the GPU as a rasterizer that CPU code hands finished triangles to, and start
+treating it as the machine that *computes the UI* — ordering, culling,
+compositing, and (for the content shapes that admit it) layout — with the
+CPU's job shrunk to running user code and describing what changed. Down to
+indirect dispatch where indirect dispatch is the right tool, not as a
+slogan.
+
+Three constraints were set explicitly and are treated as hard requirements
+throughout, not preferences:
+
+1. **The public API does not change**, except the caching primitives
+   (explicitly carved out). `Render`, `Entity<T>`, `Context<T>`, the
+   `Styled`/Tailwind-style DSL, actions, keymaps, and every element
+   constructor (`div()`, `img()`, `svg()`, `uniform_list()`, ...) compile and
+   behave identically. This document treats "identically" as testable, not
+   aspirational — see §7.
+2. **Native-first, WASM best-effort.** Every GPU-driven mechanism is designed
+   for native wgpu (Vulkan/DX12/Metal) without compromise; WASM gets a
+   CPU-executed fallback for whatever WebGPU can't yet do, shipped later and
+   never gating native progress.
+3. **Built as a parallel workspace crate, cut over at parity.** The existing
+   code keeps working, unmodified in behavior, as the default, until a new
+   crate reaches feature parity and an explicit cutover phase retires the
+   old path. No third option (in-place flag ladder) — this repo already has
+   nine `WGPUI_*` kill switches from R-N/SFD, and SFD §0.1 documents directly
+   what that costs: a mechanism that exists, is fast, and is used in one of
+   thirty-seven call sites in the real application, because reaching it
+   required knowing about three unrelated pieces of API. A parallel crate
+   with one public backend choice is the fix for that failure mode, not a
+   repeat of it.
+4. **The R-N/SFD object model is the backbone, redesigned to be GPU-computed
+   from the start** — not thrown away, not merely accelerated in place.
+   `Layer`, `ElementInstance`, the four `Invalidation` axes, and per-layer
+   slabs got the *concepts* right (retained, address-stable, per-region
+   invalidation). What's being replaced is the *mechanics*: CPU sort → GPU
+   compute sort; CPU occlusion sweep → GPU compute occlusion; CPU-computed
+   draw ranges → GPU-computed indirect draw args; CPU Taffy walk for regular
+   content → GPU layout kernel. Where content genuinely can't move to the
+   GPU (arbitrary user code, heterogeneous flexbox, text shaping), it stays
+   exactly where it is, on purpose — see §6.
+5. **The default assumption, everywhere, is "retained unless a diff proves
+   otherwise" — never "rebuilt unless something opted into caching."** This
+   is stated as its own constraint because today's shipped architecture,
+   despite building the exact mechanism this needs (`diff_key`/
+   `InstanceKey` reconciliation, R-N Phase 7), still gets this backwards at
+   the one seam that matters most: reconciliation only runs *inside* a
+   `.layer()` subtree (R-N's own Phase 7 gate: "scoped to content inside a
+   `.layer()` subtree only"). Everything else — which, per SFD §0.1's own
+   count, is most of a real application's element tree — gets full
+   `prepaint`/`paint`/layout on every notification of its owning view,
+   regardless of whether anything an observer could see actually changed.
+   That is opt-in retention with rebuild as the fallback, and it is exactly
+   the shape SFD §0.1 found produces near-zero real-world adoption (1 of 37
+   call sites), because the fast path is invisible until someone goes
+   looking for it. 2.0 inverts this at the architecture level, not just at
+   one call site — see §4. Inverting a default doesn't mean removing the
+   ability to override it: content that is provably always-dirty every
+   frame gets an explicit, equally simple way to say so (`.uncached()`,
+   §4.2) — the assumption is retained-unless-proven-otherwise, and an
+   up-front developer assertion that it isn't counts as proof.
+
+---
+
+## 1. Where we actually are (grounded, not asserted)
+
+| Fact | Evidence |
+|---|---|
+| `window.rs` is 14,278 lines, one `impl Window` block spans ~5,800 lines, 450 methods total | `wc -l src/window.rs`; `impl Window` at `window.rs:2322`–`8167` |
+| `app.rs` is 2,802 lines; `impl App` alone is ~1,724 lines | `app.rs:718`–`2442` |
+| `elements/div.rs` is 4,528 lines — the single largest element, doing interactivity, style resolution, scroll, and layer/boundary registration in one file | `wc -l src/elements/div.rs` |
+| The embedded profiler/replay system (`flamegraph.rs`, `flamegraph_gpu.rs`, `flamegraph_replay.rs`, `flamegraph_ui_capture.rs`) is ~9,000 lines — larger than the entire GPU renderer plus every shader combined | line counts, §4 below |
+| `geometry.rs` (3,961), `scene.rs` (2,941), `scene_pack.rs` (1,971), `platform.rs` (1,948), `style.rs` (1,578) round out the files over 1,500 lines | `wc -l src/*.rs` |
+| R-N's own status table says phases 4, 6, 7, 8, 9, 11 are shipped and default-on; phase 12 (delete the old cache) is **not started**, and the old replay path is still load-bearing — `Layer::paint_range` routes through it | `docs/scroll-free-by-default.md` §0 |
+| Of 37 hand-rolled scroll containers in the actual consuming application, 1 uses the fast (layered, buffered) path | SFD §0.1 |
+| The crate already requests `wgpu::Features::INDIRECT_FIRST_INSTANCE` and `MULTI_DRAW_INDIRECT_COUNT` at device creation — hard-required on native outside macOS, best-effort on macOS — and documents a real, already-hit driver gotcha about the former for *externally embedded* content (`WgpuSurfaceHandle`/Helio). **Nothing in the crate issues an indirect draw or a compute dispatch.** A crate-wide search for `dispatch_workgroups`, `draw_indirect`, `multi_draw_indirect`, and `create_compute_pipeline` returns zero matches. | `README.md` "Custom Device Gotcha"; `render_context.rs:104-176`; crate-wide grep |
+| Per-instance GPU data is already **storage-buffer "vertex pulling"**, not vertex-attribute instancing — every render pipeline binds `vertex.buffers: &[]` and indexes a bound storage buffer with `@builtin(instance_index)` in the shader, drawn as `pass.draw(0..4, first_instance..first_instance+count)`. This is already the right shape for GPU-computed content: a compute pass that writes into the same storage buffer needs no pipeline change. | `renderer.rs:1332-1548` (pipeline construction), draw call sites e.g. `renderer.rs:3788-3789` |
+| Per-layer GPU transforms are applied by **runtime string-splicing**: `slab_transform.wgsl` has no entry points at all — it's textually spliced into every other shader's source at pipeline-build time, rewriting one known vertex-position expression per shader (plus a matching fragment-stage undo for four shaders that re-read world-space geometry), with an `assert!` that each rewrite matched *exactly once* so a drifted shader fails to compile rather than silently losing the transform | `renderer.rs:99-143` (`slab_shader_source`, `FRAGMENT_TRANSLATE_EDITS`) |
+| The fourth `Invalidation` axis — `TRANSFORM`, the one R-N designed specifically so a scroll tick costs "one changed matrix, zero everything else" (R-N §3.2) — is **dead code today**: the bitflag exists but the crate's own comment on it says nothing sets it yet, "until layers can be composited independently." (`Invalidation` is a hand-rolled `u8` newtype living in `window.rs`, not the `bitflags` crate, and not in `layer.rs` despite R-N's own sketch placing it there.) | `window.rs:402-461` |
+| `wgpu = "30"` is pinned, with `dx12`, `vulkan`, `webgpu`, `wgsl` features on native and `web`, `webgpu` on WASM; `taffy = "=0.9.0"` is pinned; `bytemuck` (with GPU-cast derives) and `etagere` (atlas bin-packing) are already dependencies | `Cargo.toml` |
+| Eight real shader files exist (`quads`, `shadows`, `mono_sprites`, `poly_sprites`, `paths`, `underlines`, `backdrop_blur`, `surfaces`) — all vertex/fragment pairs driving instanced draws, with draw-call coalescing already merging byte-contiguous same-layer/kind runs (`OpenSlabRun`, `renderer.rs:1690-1723`) — plus the `slab_transform.wgsl` splice fragment above. Per-layer suballocation (`slab.rs`, 1,538 lines; `slab_gpu.rs`, 1,437 lines) is a pure CPU-side allocator (size-class free lists, generation counters) that computes byte ranges and hands them to `write_buffer`; module doc states this directly: "no device, no queue." | file listing, `src/platform/cross/shaders/*.wgsl`, `slab.rs:1-31`, `slab_gpu.rs:1-28` |
+| **The upload granularity today is per-layer, not per-primitive.** A dirty layer's `write_buffer` call covers that layer's *entire* byte range for a given primitive kind — a 10,000-quad layer with one changed quad still uploads all 10,000 quads' worth of bytes for that kind. This is a real improvement over the pre-R-N global re-upload, but it is not a delta upload, and nothing in R-N/SFD claims it is. §5.0 below makes the distinction load-bearing. | `slab_gpu.rs`'s own module doc: "the renderer executes a plan as one `write_buffer` per kind, byte offset = `SlabRange.base * stride`" — one call per (layer, kind), not one per changed primitive |
+| The crate is a single `[package]`, not a `[workspace]` — everything above lives in one compilation unit | `Cargo.toml:1` |
+
+None of this is a criticism of R-N/SFD in isolation — measured against an
+immediate-mode CPU renderer, it's a large, real improvement, and the
+instrumentation culture it left behind (`render_stats`, the flamegraph/replay
+system, `WGPUI_OCCLUSION=validate`-style differential testing) is exactly the
+discipline this plan intends to keep using. The point of this table is
+narrower: the ceiling on "retain CPU state better" has essentially been
+reached by the existing effort, and the honest next lever is moving
+computation off the CPU, not finding one more CPU cache to add.
+
+One more thing worth being explicit about, because it changes how this plan
+should be read: the renderer isn't starting from zero on the GPU side. The
+storage-buffer vertex-pulling model, the indirect-draw device features, and
+the per-layer slab byte-range concept are already there — provisioned,
+correctly negotiated across platforms, and completely unused. §5 below is,
+to a real extent, "turn on the capability that's already been asked for,"
+not "invent a new one."
+
+---
+
+## 2. Target shape, in one picture
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │  Frontend (frozen surface — §7)              │
+                    │  Render / Entity<T> / Context<T> / Styled DSL│
+                    │  actions, keymap, elements/* constructors    │
+                    └───────────────────┬───────────────────────────┘
+                                         │ render() — arbitrary CPU code,
+                                         │ runs exactly as it does today
+                                         ▼
+                    ┌─────────────────────────────────────────────┐
+                    │  Description (per-frame, arena — unchanged)  │
+                    └───────────────────┬───────────────────────────┘
+                                         │ reconcile against retained
+                                         │ instance tree (R-N Pillar I,
+                                         │ already exists — instance.rs)
+                                         ▼
+                    ┌─────────────────────────────────────────────┐
+                    │  Patch list — the ONE frontend/backend       │
+                    │  boundary. Pure data: inserts/updates/       │
+                    │  removals of primitives, layout inputs,      │
+                    │  hitboxes, dispatch nodes. No control flow.  │
+                    └───────────────────┬───────────────────────────┘
+                                         │
+                     ┌───────────────────┼───────────────────┐
+                     ▼                   ▼                   ▼
+             ┌───────────────┐  ┌────────────────┐  ┌─────────────────┐
+             │ CPU: Taffy for │  │ CPU: cosmic-text│  │ CPU: hit-test,  │
+             │ heterogeneous  │  │ shaping (§6 —   │  │ focus, actions, │
+             │ layout only    │  │ not GPU-portable)│  │ input dispatch  │
+             └───────┬───────┘  └────────┬────────┘  └─────────────────┘
+                     │                   │
+                     ▼                   ▼
+          ┌───────────────────────────────────────────────────┐
+          │  Persistent GPU-resident scene (per-layer slabs,   │
+          │  patched not rebuilt — R-N Pillar III, extended)   │
+          └───────────────────────┬─────────────────────────────┘
+                                   │ compute passes, every frame,
+                                   │ over resident + newly-patched data
+                                   ▼
+     ┌─────────────────────────────────────────────────────────────┐
+     │ GPU compute: regular-content layout (§6) · ordering (§5.1) · │
+     │ occlusion culling (§5.2) · indirect draw-arg generation (§5.3)│
+     └───────────────────────────────┬─────────────────────────────┘
+                                      ▼
+                    indirect multi-draw, instanced, per layer
+```
+
+Note what the "reconcile against retained instance tree" box in this
+picture is *not* scoped to: it is not drawn as living inside a `.boundary()`
+subtree, because it isn't one. Per constraint 5 (§0), reconciliation is
+ambient — every element in the window goes through it, every frame,
+independent of whether any `.boundary()` exists anywhere in the tree. A
+`.boundary()` (§4) is a request layered on top of this diagram for specific
+subtrees — independent compositing, texture retention, overdraw buffering —
+never the thing that switches reconciliation on in the first place. This is
+the single largest substantive difference from what shipped for R-N/SFD, so
+it's worth being this explicit about it before §4 makes it concrete.
+
+The load-bearing idea: **the patch list is the only interface between "what
+the app described" and "how the GPU computes and draws it."** It is data,
+never a callback or a control-flow handoff, which is exactly what makes the
+backend swappable while the frontend that produces the patch list (elements,
+`Render`, event handlers) stays untouched. R-N already built the two pieces
+either side of this boundary — `ElementInstance`/reconciliation on the
+frontend side (R-N §2, shipped) and per-layer slabs on the backend side (R-N
+§4, shipped) — but the seam between them today is "CPU code copies bytes
+into a `Vec` that CPU code later `write_buffer`s in full or in a computed
+*per-layer* range — not a per-primitive delta (§5.0 makes this precise)."
+2.0's job is to make that seam a real patch protocol the GPU consumes
+directly, and to move everything downstream of it onto the GPU.
+
+---
+
+## 3. Workspace layout
+
+Convert the repo to a Cargo workspace. The root package (`gpui-ce`, published
+name, `gpui` lib name) stays the crate external consumers depend on — its
+git URL and import paths do not change. New members are added alongside it;
+nothing about how `Pulsar-Native` (or any other consumer) depends on this
+repo changes until the explicit cutover in **Phase 8** (§8) — not Phase 7,
+which is devtools extraction; getting this wrong once in an earlier draft of
+this document is exactly the kind of drift a unifying pass exists to catch.
+
+```
+WGPUI/
+├── Cargo.toml                  # [workspace], root package = gpui-ce (unchanged public surface)
+├── src/                        # unchanged during migration; becomes the
+│                                # legacy backend, then a thin re-export (Phase 8)
+├── crates/
+│   ├── wgpui-core/             # §3.1 — patch protocol, scene, reconciliation,
+│   │                           #   boundary/tile policy, invalidation. No
+│   │                           #   windowing, no live wgpu::Device.
+│   ├── wgpui-layout/           # §3.2 — Taffy integration, isolated.
+│   ├── wgpui-text/             # §3.3 — cosmic-text shaping, isolated.
+│   ├── wgpui-widgets/          # §3.4 — div/text/img/svg/list/... elements.
+│   ├── wgpui-wgpu/             # §3.5 — the only crate that touches a live
+│   │                           #   wgpu::Device: pipelines, compute dispatch,
+│   │                           #   atlas, textures, winit windowing.
+│   └── wgpui-devtools/         # §3.6 — flamegraph/replay/inspector, moved
+│                               #   wholesale behind a small hook trait.
+└── docs/
+```
+
+Every subsection below is a real, growable module tree — the point of this
+section, per the ask this revision answers, is that no future addition to
+any of this needs to land in a 1,000+-line file the way `window.rs`,
+`div.rs`, and the flamegraph quartet do today. Three things are true across
+all of them, stated once instead of six times:
+
+- **Not everything needs a redesign to get a home.** `app/entity_map.rs`,
+  `app/context.rs`, `app/async_context.rs` (already split out of `app.rs`
+  today), `window/prompts.rs` (already split out of `window.rs`), and every
+  file under `text_system/` (`line.rs`, `line_wrapper.rs`, `line_layout.rs`,
+  `font_features.rs`, `font_fallbacks.rs`) are already the right shape and
+  size. These move essentially as-is into their new crate; the file map
+  below calls this out explicitly (**moved, not rebuilt**) rather than
+  implying everything is being rewritten from scratch.
+- **The god files get named, targeted splits**, not a mechanical chop.
+  `window.rs` (14,278 lines, one 450-method `impl Window` block), `div.rs`
+  (4,528 lines), `app.rs`'s core `impl App` (~1,724 lines), and the
+  flamegraph quartet (~9,000 lines across four files) each get a split
+  derived from seams the current code already shows (§3.4 quotes `div.rs`'s
+  own four seams directly) or from the module boundaries this document
+  itself defines (§3.1's split *is* patch/scene/reconcile/invalidation/
+  boundary, because those stopped being one concern the moment ambient
+  reconciliation, §4.0, removed the single recursive CPU walk that used to
+  justify combining them).
+- **No file target below is a hard rule enforced by tooling in this
+  revision** — it's a design intent stated concretely enough to check by
+  eye (`wc -l`) rather than left as "keep files short."
+
+### 3.1 `wgpui-core` — patch, scene, reconciliation, boundary policy
+
+No live `wgpu::Device` anywhere in this crate — it owns the *shapes* of GPU
+work (shader source as text, buffer/binding layout descriptors as plain
+Rust structs) so it stays unit-testable headlessly, the same reason
+`slab.rs`'s module doc already commits to "no device, no queue" today.
+`wgpui-wgpu` (§3.5) is what actually creates pipelines and dispatches.
+
+```
+crates/wgpui-core/src/
+├── lib.rs
+├── patch/
+│   ├── mod.rs              # Patch, PatchList (§2, §5.0)
+│   ├── primitive.rs        # per-kind payloads: update-in-place vs insert/remove
+│   └── apply.rs            # apply a PatchList to a Scene — Phase 1's round-trip gate lives here
+├── scene/
+│   ├── mod.rs
+│   ├── layer.rs            # Layer record: id, key, policy, invalidation state (R-N's Layer, 2.0's mechanics)
+│   ├── tile.rs             # TileCoord, (boundary, TileCoord) addressing (§4.3)
+│   ├── slab.rs             # size-class allocator, ported/cleaned from today's slab.rs
+│   └── slab_range.rs       # byte-offset math, generation counters, per-primitive slot addressing (§5.0)
+├── reconcile/
+│   ├── mod.rs
+│   ├── instance.rs         # ElementInstance, InstanceKey — ambient, §4.0
+│   ├── diff_key.rs         # ReconcileKey trait; §6.2's invariant is enforced against this file's default
+│   └── uncached.rs         # the scope flag threaded through prepaint/paint (§4.2)
+├── invalidation/
+│   ├── mod.rs
+│   ├── axes.rs             # LAYOUT/DISPLAY/HIT/TRANSFORM — finally wired live, §5.4
+│   ├── request.rs          # InvalidationRequest/InvalidationScope (R-N §6, unchanged)
+│   └── reason.rs           # Reason::Scroll vs Reason::DataChanged (§5.4, §4.1)
+├── boundary/
+│   ├── mod.rs
+│   ├── policy.rs           # BoundaryPolicy, Buffering enum (§4.1, §4.3)
+│   └── identity.rs         # positional-identity fallback (SFD §1.0), reused by WgpuSurface (§5.5, Gap 1)
+├── occlusion/
+│   ├── mod.rs
+│   └── coverage.rs         # conservative opaque-region test (R-N §8.3) — CPU reference impl AND
+│                            #   the oracle `validate` mode diffs the compute path (§5.2) against
+├── shaders/                 # WGSL *source* + Rust-side layout descriptors — text and data, no device
+│   ├── ordering.wgsl        # §5.1
+│   ├── occlusion.wgsl       # §5.2
+│   ├── layout_uniform.wgsl  # §6.1
+│   ├── tile_visibility.wgsl # §4.3
+│   └── indirect_args.wgsl   # §5.3
+├── window/                  # window.rs's actual successors, one concern each
+│   ├── mod.rs               # Window struct assembly only
+│   ├── focus.rs             # FocusHandle/FocusId, tab stops
+│   ├── hitbox.rs            # Hitbox, point-transform hit-testing (R-N §5.2, kept as-is)
+│   ├── dispatch.rs          # DispatchTree, action dispatch, key_context
+│   ├── input.rs             # keyboard/mouse event routing
+│   ├── animation.rs         # request_animation_frame(_for), §5.4's TRANSFORM-only glide path
+│   └── prompts.rs           # moved, not rebuilt — already its own file today
+├── app/
+│   ├── mod.rs
+│   ├── entity.rs            # moved, not rebuilt — today's app/entity_map.rs
+│   ├── context.rs           # moved, not rebuilt — today's app/context.rs
+│   ├── async_context.rs     # moved, not rebuilt — today's app/async_context.rs
+│   ├── effects.rs           # deferred notifications, flush_deferred_invalidations
+│   └── globals.rs
+└── test_support/
+    └── mod.rs               # headless patch/reconcile/window testing, mirrors today's platform/test
+```
+
+### 3.2 `wgpui-layout` — Taffy, isolated
+
+```
+crates/wgpui-layout/src/
+├── lib.rs
+├── taffy_tree.rs        # persistent TaffyTree wrapper — today's taffy.rs, made ambient per §4.0
+├── measure.rs           # measured-layout closures (text/intrinsic-size leaves)
+├── containment.rs       # estimated_size / layout containment (SFD §0.-3)
+└── regular.rs           # detects §6.1-eligible ("regular") content; everything else stays here
+```
+
+### 3.3 `wgpui-text` — cosmic-text shaping, isolated (§6: not moving to the GPU)
+
+Mostly a move, not a rewrite — today's `text_system/` is already close to
+this shape.
+
+```
+crates/wgpui-text/src/
+├── lib.rs
+├── shaping.rs           # cosmic-text integration — today's text_system.rs core
+├── line.rs              # moved, not rebuilt
+├── line_wrapper.rs      # moved, not rebuilt
+├── line_layout.rs       # moved, not rebuilt
+├── fonts/
+│   ├── features.rs      # moved, not rebuilt — today's font_features.rs
+│   └── fallbacks.rs     # moved, not rebuilt — today's font_fallbacks.rs
+└── patch.rs             # shaped-run → patch conversion (Phase 5, closes §6.2's Img/StyledText gap)
+```
+
+### 3.4 `wgpui-widgets` — elements, split along `div.rs`'s own seams
+
+`div.rs` (4,528 lines) already shows four fairly distinct concerns living in
+one file — quoted directly so the split below isn't arbitrary: a ~456-line
+event-binding builder trait (`InteractiveElement`), a ~1,140-line
+`Interactivity` state-and-paint engine (the single largest block, interleaving
+style application, hitbox/dispatch registration, scroll handling, and layer
+paint), `Div`'s own `Element` impl plus its reconciliation fingerprint
+(~600 lines combined), and scroll/click retained-state types (~235 lines).
+
+```
+crates/wgpui-widgets/src/
+├── lib.rs
+├── div/
+│   ├── mod.rs               # Div, DivFrameState/DivPrepaintState — the small remainder
+│   ├── events.rs            # InteractiveElement (today's ~456-line trait block)
+│   ├── interactivity/
+│   │   ├── mod.rs
+│   │   ├── style.rs         # style application + classify_style_change (§6.2's engine)
+│   │   ├── hitbox.rs        # hitbox/dispatch-node registration
+│   │   └── layer_paint.rs   # boundary/paint plumbing (today's layer-paint slice of the ~1,140-line block)
+│   ├── diff.rs               # DivDiffKey / ReconcileKey impl
+│   └── scroll_state.rs        # ScrollAnchor/ScrollHandle (today's ~235-line block)
+├── text.rs
+├── styled_text.rs             # gets diff_key here (§6.2 invariant, Phase 5)
+├── img.rs                     # gets diff_key here (§6.2 invariant, Phase 5)
+├── svg.rs
+├── canvas.rs
+├── list/
+│   ├── mod.rs
+│   ├── list.rs
+│   ├── uniform_list.rs        # the CPU special case §6.1's GPU kernel generalizes
+│   ├── virtual_list.rs
+│   └── h_list.rs
+├── wgpu_surface.rs             # real identity + trivial diff_key (§5.5, Gap 1)
+├── animation.rs
+├── overlay/
+│   ├── anchored.rs
+│   └── deferred.rs
+├── scroll/
+│   ├── smooth_scroll.rs
+│   └── scroll_buffer.rs
+├── surface.rs
+└── image_cache.rs
+```
+
+### 3.5 `wgpui-wgpu` — the only crate touching a live device
+
+Two subtrees, genuinely distinct concerns that today live intermixed under
+`platform/cross/`: windowing (winit, input plumbing, OS integration) and
+rendering (device, pipelines, compute dispatch, atlas, textures).
+
+```
+crates/wgpui-wgpu/src/
+├── lib.rs
+├── window/
+│   ├── mod.rs               # winit window creation/event loop glue — today's platform/cross/window.rs
+│   ├── dispatcher.rs        # moved, not rebuilt
+│   ├── keyboard.rs          # moved, not rebuilt
+│   ├── resize_detector.rs   # moved, not rebuilt
+│   └── app_menu.rs          # moved, not rebuilt
+└── render/
+    ├── mod.rs
+    ├── device.rs            # device/queue creation, feature negotiation — today's render_context.rs
+    ├── buffers/
+    │   ├── slab_buffers.rs  # GPU-side buffer per slab kind
+    │   └── upload.rs        # delta-upload adjacency coalescing (§5.0)
+    ├── compute/
+    │   ├── ordering_pass.rs         # dispatches wgpui-core's ordering.wgsl (§5.1)
+    │   ├── occlusion_pass.rs        # dispatches occlusion.wgsl (§5.2)
+    │   ├── layout_pass.rs           # dispatches layout_uniform.wgsl (§6.1)
+    │   ├── tile_visibility_pass.rs  # dispatches tile_visibility.wgsl (§4.3)
+    │   └── indirect_args_pass.rs    # dispatches indirect_args.wgsl (§5.3)
+    ├── pipelines.rs         # render pipeline creation per kind (today's quads/shadows/.../paths)
+    ├── draw.rs              # indirect draw issuance + coalescing (today's OpenSlabRun logic)
+    ├── readback.rs          # CPU-readback fallback for indirect draw (§5.3) — macOS best-effort + WASM
+    ├── atlas.rs             # glyph/sprite atlas, etagere bin-packing — moved, not rebuilt
+    ├── textures/
+    │   ├── layer_texture.rs     # boundary texture-retention pool (today's LayerTextureEntry)
+    │   └── external_surface.rs  # unified WgpuSurface consumer entry (§5.5, Gap 2) — same type as layer_texture
+    ├── surface_registry.rs  # producer-side triple-buffer — UNCHANGED (§5.5, §9's explicit "don't touch this")
+    └── shaders/              # the hand-written render shaders, moved as-is
+        ├── quads.wgsl
+        ├── shadows.wgsl
+        ├── mono_sprites.wgsl
+        ├── poly_sprites.wgsl
+        ├── paths.wgsl
+        ├── underlines.wgsl
+        ├── backdrop_blur.wgsl
+        └── surfaces.wgsl
+```
+
+### 3.6 `wgpui-devtools` — moved wholesale, behind one small hook trait
+
+~9,000 lines across four files today — more than the renderer and every
+shader combined — of genuinely valuable, genuinely separable tooling
+(per-frame CPU/GPU flamegraphs, a RenderDoc-style capture-and-replay engine
+for the whole UI tree). None of it needs to live in the same compilation
+unit as the engine it profiles; it needs a handful of stable hook points
+(span push/pop, GPU timestamp write, frame-capture trigger) that
+`wgpui-core`/`wgpui-wgpu` expose as a small trait, the same shape `profiling`
+(already a dependency) uses for its own backend-agnostic design. Pure
+move-and-decouple, zero behavior change — Phase 7's gate (§8) is precisely
+that `wgpui-core` builds and runs with this crate absent entirely.
+
+```
+crates/wgpui-devtools/src/
+├── lib.rs
+├── hooks.rs             # the small trait wgpui-core/wgpui-wgpu expose into
+├── flamegraph/
+│   ├── cpu.rs           # moved, not rebuilt — today's flamegraph.rs
+│   ├── gpu.rs           # moved, not rebuilt — today's flamegraph_gpu.rs
+│   ├── replay.rs        # moved, not rebuilt — today's flamegraph_replay.rs
+│   └── ui_capture.rs    # moved, not rebuilt — today's flamegraph_ui_capture.rs
+├── render_stats.rs      # moved, not rebuilt
+├── inspector.rs         # moved, not rebuilt
+└── perf_ab_tests.rs     # moved, not rebuilt
+```
+
+### 3.7 The root crate's fate
+
+`src/` is not restructured during the migration — it is frozen (bugfixes
+only, per the Phase 1 risk-table entry) as the legacy backend, exactly as it
+exists today, until Phase 8's cutover collapses it to a thin re-export of
+`wgpui-core` + `wgpui-widgets` (plus whichever of `wgpui-layout`/`-text`/
+`-wgpu`/`-devtools` the public surface needs to name types from). No target
+file map for it here: by construction, at cutover it should be small enough
+not to need one.
+
+---
+
+## 4. Ambient reconciliation, and two symmetric manual primitives
+
+Three separate mechanisms, deliberately, where R-N/SFD had effectively one
+— that conflation is exactly what constraint 5 (§0) says to undo: reconciliation
+is always on (§4.0, no API), `.boundary()` opts a subtree *into* independent
+compositing (§4.1), and `.uncached()` opts a subtree *out of* reconciliation
+for the one content shape where diffing never pays off (§4.2).
+
+### 4.0 Reconciliation is ambient — ships in Phase 1, no API at all
+
+Every element in the window is reconciled via `diff_key`/`InstanceKey`
+(R-N §2, §2.3) every frame, whether or not it sits inside a `.boundary()`.
+A `div` three levels deep in an ordinary, unboundaried panel that renders
+identically to last frame skips `request_layout` (keeping its retained
+Taffy node — R-N §2.5/Phase 8's mechanism, made ambient), `prepaint`, and
+`paint`, exactly as if it were inside today's `.layer()`. There is no
+opt-in call, because there is nothing to opt into: this is simply what the
+window does with the description `render()` produces, the same way a
+browser diffs its DOM/style/layout state whether or not an element has
+`will-change: transform`. §6's "what stays on the CPU" content — Taffy for
+heterogeneous layout, hit-test/dispatch registration — is retained under
+this rule too, since retention there was always gated on the identical
+`diff_key`-proves-clean condition R-N Phase 7/8 already built; ambient
+reconciliation just stops fencing that condition to `.layer()` subtrees.
+
+This is also what actually resolves a case §4.1 (below) would otherwise
+need a dedicated mechanism for: a hover-driven style change on one element, under
+ambient reconciliation, produces exactly one instance's `DISPLAY`
+invalidation (via `classify_style_change`, `div.rs:2285-2353`) — ancestors
+above it were never rebuilding on that notification's account in the first
+place, because they were always subject to the same diff. No separate
+"auto sub-boundary for hover" mechanism is needed; it falls out of the
+general rule rather than requiring a special case reserved for later.
+
+**What this changes about R-N's own numbers.** R-N §2.6 called "is
+`render()` cheap relative to layout+paint" an assumption worth measuring,
+not proving. Under ambient reconciliation it stops being an assumption:
+regardless of whether `render()` reruns for a notified view (it always
+does — arbitrary user code can't be skipped, §6), the diff immediately
+downstream of it is what decides whether any layout/paint/GPU work happens,
+for *every* element it touches, not only elements an author remembered to
+wrap.
+
+**Risk this takes on, honestly.** Making reconciliation the ambient default
+means a reconciliation bug's blast radius is the whole application on day
+one, not one opted-in subtree — SFD's own kill-switch culture
+(`WGPUI_INSTANCES=0`, precedent at `view.rs:103`) exists for exactly this
+class of risk, and 2.0 keeps a kill switch for the same reason, but now
+gating the *default* path rather than an edge feature. See the risk table
+(§9).
+
+### 4.1 The single cache-boundary primitive
+
+`.boundary()` is what's left once reconciliation is no longer its job: a
+*compositing and buffering* policy for subtrees that benefit from being
+independently rasterized — a scrollable panel, a viewport, anything the
+old `.layer()`/`.layer_keyed()`/`.layer_with_policy()` triad targeted. It
+answers "does this region get its own GPU texture, an overdraw margin, and
+its own occlusion tier," never "does this region's content get diffed" —
+that question was already answered yes, for everything, in §4.0.
+
+Today, getting onto the fast path requires, together, on every scrollable or
+expensive subtree individually (SFD §0.1):
+
+```rust
+div()
+    .id("scroller")                          // silently required — SFD §0.2
+    .layer_keyed(content_key)                // a key you derive and keep correct
+    .layer_with_policy(LayerPolicy { .. })    // a margin you tune
+    .overflow_y_scroll()
+    .track_scroll(&handle)
+```
+
+plus `Panel::cacheable` as a separate manual opt-out mechanism for the old
+cache (R-N §0.2), plus `diff_key` as a separate per-element-type opt-in (R-N
+§2.3). Four mechanisms, each independently learnable, each independently
+capable of silently no-oping (SFD §0.2's finding: `.layer()` without `.id()`
+compiles, runs, and does nothing).
+
+2.0 replaces all four with one element:
+
+```rust
+div().id("properties-panel").boundary().child(expensive_content)
+```
+
+`.boundary()` takes an optional `BoundaryPolicy` for tuning only — never for
+correctness:
+
+```rust
+pub struct BoundaryPolicy {
+    /// Below this primitive count, stay primitive-retained (no texture).
+    /// Same role as R-N's `rasterize_above`; still complexity-driven,
+    /// still automatic below/above this line.
+    pub rasterize_above: usize,
+    /// How this boundary buffers ahead of scroll/pan. `Margin` is R-N/SFD's
+    /// existing mechanism, generalized only in name here — §4.3 is where the
+    /// second variant, and the reason this is an enum and not still a single
+    /// `Option<Size<Pixels>>`, actually gets used.
+    pub buffering: Buffering,
+}
+
+pub enum Buffering {
+    /// No buffer beyond the visible bounds.
+    None,
+    /// One rectangular region sized to viewport + margin, refilled wholesale
+    /// when scrolled past it (R-N §7/SFD's overscroll buffer, unchanged).
+    /// Right for linear content: lists, columns, anything scrolling along
+    /// one or two bounded axes with a defined content extent. Auto-sized
+    /// from the viewport when unset (SFD §7's own recommendation).
+    Margin(Option<Size<Pixels>>),
+    /// A grid of independently cached tiles (§4.3). Right for freeform,
+    /// arbitrarily-positioned, pannable-in-any-direction content — node
+    /// graphs, canvases, 2D level views — where `Margin` would have to grow
+    /// multiplicatively in both axes to avoid frequent whole-region refills.
+    Tiled { tile_size: Size<Pixels>, retain_radius: u32 },
+}
+```
+
+What makes a bare `.boundary()` safe by default, closing every gap SFD found
+in the opt-in version — note none of these are about *whether* content is
+diffed (§4.0 already answers that unconditionally); they're about a
+compositing boundary correctly locating and invalidating itself:
+
+- **Identity never requires `.id()`.** Positional identity (SFD §1.0 —
+  `ElementId::InstanceSlot(child_index)` for a boundary root, the same
+  mechanism `instance_id_stack` already applies one level down for a
+  layer's children) is the *only* identity path; an explicit `.id()` refines
+  it for cross-frame stability under reordering, it doesn't gate it. Where
+  R-N/SFD's `.id()` requirement gated reconciliation itself (so a forgotten
+  `.id()` meant silently no cheaper than a full rebuild), here a
+  forgotten `.id()` only costs a boundary its independent-compositing
+  benefit — the content underneath is reconciled regardless (§4.0), so the
+  failure mode shrinks from "silently as slow as no caching at all" to
+  "silently missing one specific optimization."
+- **Scroll is a distinguishable signal, not an inferred one, from day one.**
+  SFD §1.1 found this had to be built as `notify_scroll()` — a tagged
+  notification layers recognize as transform-only — because a generic
+  `cx.notify()` can't be told apart from "the data changed" after the fact.
+  2.0 builds this into the invalidation system's vocabulary from the start
+  (§5.4) rather than retrofitting it once `.boundary()` is already deployed
+  everywhere, which is the order SFD explicitly recommends against (SFD §1
+  intro: don't broadcast a known gap to every call site at once).
+- **Invalidation axes are always derived from the diff**, never
+  hand-declared (R-N §2.4, already shipped and kept unchanged in spirit) —
+  a `.boundary()` with no policy at all still gets exactly-correct
+  transform/display/hit/layout invalidation, because the reconciler tells it
+  what changed; the policy struct only ever tunes *how* a boundary that is
+  known to be dirty gets rasterized, never *whether* it's considered dirty.
+- **Hover/animation-driven content no longer needs a dedicated boundary
+  mechanism at all.** SFD §1.0 flagged this as "reserved, not built yet,"
+  reserved specifically because under R-N/SFD's model a hover-triggered
+  `cx.notify()` on the owning view was indistinguishable from any other
+  notify, and the only tool available to contain the damage was promoting
+  the hovered element to its own layer. Under §4.0's ambient reconciliation
+  this isn't a gap to close with a new mechanism — a hover-driven style
+  change already produces exactly one instance's `DISPLAY` invalidation via
+  `classify_style_change`, with or without a `.boundary()` anywhere nearby.
+  `.boundary()` remains available for a *different*, legitimate reason to
+  promote hovered content — e.g. a hover effect on a texture-retained panel
+  where recompositing (not rediffing) is the actual cost — but it is no
+  longer required for correctness the way SFD's finding implied.
+
+`Panel::cacheable` and its opt-out list are deleted outright — `on_frame`
+(R-N §2.4) already gives skipped-closure side effects a legal home, so there
+is no longer a category of element that needs to opt *out* of caching.
+
+### 4.2 The escape hatch: `.uncached()` for content that never benefits
+
+Ambient reconciliation (§4.0) is a bet that diffing pays for itself, and for
+almost all UI content it does — R-N §2.6's own accounting (description
+building is cheap; layout/paint/shaping are what's worth skipping) is why.
+The bet fails for one specific, identifiable shape: a subtree whose content
+is guaranteed to differ every single frame — a live telemetry HUD, an audio
+waveform, a per-frame physics/debug overlay, a node-graph editor's live
+value readouts during a simulation scrub. For that content, `diff_key`
+comparison is not "usually free, occasionally expensive" — it is
+*unconditionally* wasted work, because the outcome is always "rebuild
+anyway," and worse, the framework has been maintaining a retained
+`ElementInstance` + fingerprint for each of those elements for no reason:
+memory held for a comparison that will never once succeed.
+
+`.uncached()` is the deliberate, symmetric complement to `.boundary()` —
+where `.boundary()` opts a subtree *into* additional compositing benefits on
+top of always-on reconciliation, `.uncached()` opts a subtree *out of*
+reconciliation itself:
+
+```rust
+div().uncached().child(live_telemetry_panel)
+```
+
+Mechanically this is not new machinery — it's making an existing code path
+selectable on purpose. Every element type's `diff_key` already defaults to
+`None` (`element.rs:136-138`), and R-N §2.3 already specifies exactly what
+that means: "full rebuild, zero savings, zero risk," the same unconditional
+`request_layout`/`prepaint`/`paint` path the framework used before
+reconciliation existed at all. `.uncached()` pushes a scope flag (the same
+shape as the existing content-mask/text-style stacks threaded through
+`window.rs`) that forces every element inside it onto that path regardless
+of what its own `diff_key` impl would otherwise report — no `ElementInstance`
+is allocated for them, no fingerprint is retained, no comparison runs. It is
+strictly less bookkeeping than reconciling-and-always-losing, not merely a
+skip.
+
+**What it does not touch.** State retention (`use_state`, entity reads,
+focus, tab stops) is a separate mechanism keyed by `(GlobalElementId,
+TypeId)` (R-N §2.1's table draws this line explicitly: State is "already
+retained... unchanged" by any of Pillar I's mechanics). `.uncached()` only
+suppresses `ElementInstance`/`diff_key` reconciliation; a slider or text
+input living inside an `.uncached()` panel keeps its interactive state
+exactly as it would anywhere else. Occlusion culling (§5.2) and the GPU
+patch protocol (§2) are similarly untouched — an `.uncached()` subtree still
+emits ordinary patches every frame (always a full replace, never a delta),
+and the GPU-side pipeline has no way to tell, or reason to care, whether a
+patch arrived because a diff proved change or because diffing was skipped
+entirely. `.uncached()`'s effect is confined to the CPU reconciliation step;
+nothing below it changes.
+
+**Composes with `.boundary()`, and the combination matters.** These answer
+different questions — "should this be diffed" vs. "should this be its own
+compositing unit" — so both can apply to the same subtree. This is exactly
+the shape R-N §5.1's own sizing rule warns about: "a layer containing one
+high-frequency animating element and a thousand static ones will re-sort
+all thousand every frame." A live viewport HUD dropped into a large static
+panel wants both: `.boundary()` isolates its churn into its own
+independently-ordered, independently-composited region so it stops forcing
+the static content around it to re-sort, and `.uncached()` stops the
+framework from wasting a diff on content that was always going to redraw.
+Neither alone solves what the pair solves together.
+
+**Relationship to R-N's own deferred idea.** R-N §9's risk table already
+proposed an *adaptive* version of this — the framework tracking a per-subtree
+payoff ratio and automatically marking persistently-unprofitable subtrees
+`AlwaysRebuild` — but left it as a future mitigation, not a shipped
+mechanism. `.uncached()` is the deterministic, developer-asserted version:
+faster to build, correct on day one for the case a developer already knows
+about with certainty, and it does not preclude the adaptive heuristic from
+being added later as a *default* for subtrees nobody annotated — the two
+are complementary, not competing, the same relationship the original ask
+draws between "manual caching primitives for developers to assert" and "the
+framework can handle itself without developer intervention." Building the
+adaptive version is out of scope here (§10) precisely because the manual
+primitive is what a developer facing this problem today can reach for
+immediately, without waiting on a heuristic to prove itself trustworthy.
+
+### 4.3 Two-axis content: tile-based buffering
+
+`Buffering::Margin` (§4.1) is R-N/SFD's overscroll buffer, and it is the
+right mechanism for what it was built for: a list or column with a defined
+content extent, scrolling along one bounded axis. It is the wrong mechanism
+for content with no linear index at all — a node/blueprint graph editor, a
+whiteboard, an infinite canvas, a 2D level or world view — where children
+are placed at arbitrary positions on a plane the user can pan freely in
+*any* direction, not just up/down a list. Two concrete reasons a bigger
+margin doesn't fix this:
+
+- **The area grows multiplicatively, not additively.** A vertical list's
+  margin only has to extend along the scroll axis; a freely-pannable plane's
+  margin has to extend on both axes to avoid frequent refills, so a 50%
+  margin on each axis buffers 2.25× the visible area (`1.5²`), not 1.5×, and
+  the multiplier gets worse the more generously it's sized to avoid
+  refilling on a fast diagonal pan.
+- **"Refill" still means re-rendering the whole buffered rectangle**, per
+  R-N §7's own protocol: cross the margin and the *entire* viewport+margin
+  region re-renders, centred on the new position. For a list that's cheap
+  because list rows are cheap to re-lay-out (SFD's own containment work,
+  §0.-3, made this cheaper still). For a graph editor with thousands of
+  nodes, that's the exact "lay out the buffer range means laying out
+  everything in it" problem SFD §0.-1.3 already diagnosed for plain divs —
+  except here there's no `uniform_list`-style escape hatch to fall back on,
+  because the content has no uniform index to virtualize by.
+
+**`Buffering::Tiled`** is what browser compositors actually do for this
+case — divide the content's (potentially unbounded) plane into a grid of
+fixed-size tiles, each independently rendered and cached, so panning in any
+direction only requires producing the tiles newly revealed at the leading
+edge, never re-rendering what's already resident. This is the mechanism the
+original brief named directly ("browser rendering engines that use tile
+based scroll buffers"), and it turns out to need almost no new machinery:
+
+- **A tile is just a `Layer`, addressed one dimension further.** Everything
+  a tile needs — its own instance arena (§4.0), its own slab (§5.0), its own
+  place in occlusion culling (§5.2) and indirect draw issuance (§5.3) — is
+  what a `Layer` already is. The only new concept is the address:
+  `LayerKey` extends from "one key per boundary" to "one key per
+  `(boundary, TileCoord)` pair," a mechanical generalization of the same
+  positional-identity scheme §4.1 already builds for boundary roots.
+- **Visibility is a compute-shader-shaped problem, almost by definition.**
+  "Which tile coordinates intersect (viewport ∪ retain radius) at the
+  current pan offset" is a handful of integer divisions per tile — the kind
+  of cheap, uniform, parallel computation §5.3's indirect-draw-arg
+  generation already exists to drive. A compute pass computes tile
+  visibility directly from a pan-offset uniform and writes indirect draw
+  args only for in-range tiles; the CPU never enumerates tile candidates.
+  This is arguably the single cleanest example in this entire document of
+  "down to indirect dispatch" actually paying for itself, rather than being
+  reached for on principle.
+- **Panning is `TRANSFORM`-only for every resident tile** (§5.4) — sliding
+  the view within the currently-buffered grid recomposites existing tiles
+  at new offsets, zero render/reconcile/layout work. Crossing into a new
+  tile triggers `DISPLAY` for *that tile alone* (ambient reconciliation,
+  §4.0, applies inside it exactly as inside any other boundary) — not the
+  whole buffered region, which is the concrete advance over `Margin`'s
+  refill-everything behavior.
+- **Eviction is R-N §3.4's mark-and-sweep, spatially triggered.** A tile
+  whose coordinate falls outside (viewport ∪ retain radius) for
+  `evict_after_frames` returns its slab/texture to the pool — same
+  mechanism, same bounding argument, applied per tile instead of per layer.
+
+**Costs, stated honestly, not glossed over:**
+
+- **Tile size is a real tuning knob with a real tradeoff**, the same shape
+  as §5.0's write-granularity tradeoff: too small and per-tile overhead
+  (layer bookkeeping, draw-call count) dominates; too large and refill cost
+  approaches `Margin`'s whole-region-refill cost for content that happens
+  to sit in one still-large tile. There's no principled default without
+  measuring — Phase 0's spike discipline applies here too, picking a
+  starting size from common compositor practice (roughly 256–512px) and
+  validating it against a representative node-graph workload, not asserting
+  it.
+- **Content spanning multiple tiles needs a rule.** A wire/connection
+  between two nodes in different tiles either gets clipped and rasterized
+  into each tile it crosses (what browser tiling actually does for an
+  element spanning tile boundaries) or lives on an unbuffered overlay layer
+  above the tile grid — the same named pattern SFD §2 already proposes for
+  hover-resolved content that can't cleanly live inside a buffer. Reuse
+  that pattern rather than inventing a second one.
+- **Tile count needs its own memory budget, not just a per-tile timer.** An
+  erratic pan pattern (fast diagonal movement, frequent direction reversal)
+  can keep many tiles within "recently visited" simultaneously, which
+  `evict_after_frames` alone doesn't bound — a freeform 2D plane can have
+  far more live tiles than a typical UI ever had layers. A total resident-
+  tile cap with LRU eviction beyond it is the added mitigation R-N §3.4
+  didn't need because it never had more than one buffer per layer.
+
+Phase 4.5 (§8) is deliberately after indirect draw (Phase 4) and
+independent of text/regular-layout work (Phases 5–6.1): tiling needs
+addressable layers and GPU-computed draw-arg generation to be real, and it
+needs neither text shaping nor the uniform-content layout kernel.
+
+---
+
+## 5. GPU compute pipeline
+
+### 5.0 Upload granularity: what a patch actually guarantees
+
+This has to be stated as an explicit contract, not left implicit in "patches
+instead of full-range rewrites" (§2), because §1's table finding is exactly
+the trap: today's shipped mechanism already scopes `write_buffer` to a dirty
+*layer's* byte range, which reads like a delta upload and isn't one. A
+10,000-quad layer with one changed quad re-uploads all 10,000 quads' worth
+of bytes for that kind, because dirtiness is tracked per-layer, not
+per-primitive. That's real per-region invalidation — a genuine improvement
+over the pre-R-N global re-upload — but "only what changed inside a dirty
+region" and "only what changed" are different claims, and 2.0 needs to
+commit to the second one, not quietly settle for the first and call it
+done.
+
+**The commitment:** an update to a single primitive's value uploads O(1)
+bytes — one `write_buffer(offset, size)` call scoped to that primitive's own
+stable slot in the slab, never widened to cover its layer-mates. This
+requires naming a GPU-side address per primitive, not just a per-layer
+range — a small extension of the `InstanceKey` → slot mapping §4.0's
+reconciliation already needs, carried one step further into the patch list
+(§2) instead of stopping at "this layer is dirty."
+
+Three cases, stated honestly rather than as one blanket guarantee:
+
+- **Value updates** (a primitive's fields change, it keeps its slot): O(1)
+  — one small `write_buffer` per changed primitive, or one call covering
+  several if the changed primitives happen to be byte-adjacent in the slab
+  (the same adjacency-coalescing `OpenSlabRun` already does for draw calls,
+  `renderer.rs:1690-1723`, applied to writes instead of draws — reused
+  logic, not new logic).
+- **Insert/remove that forces the allocator to relocate a primitive** (a
+  size-class change or compaction, per `slab.rs`'s existing free-list/
+  generation model) costs a wider write for the primitives actually moved —
+  bounded by the layer's own slab, never the whole scene, but genuinely not
+  O(1). Disclosed here rather than glossed over, the same treatment R-N gave
+  its own fragmentation risk (R-N §4.3).
+- **A clean layer uploads zero bytes** — not "a small range," zero. Already
+  true today (R-N's shipped mechanism) and does not regress.
+
+**Risk this introduces, stated up front:** a burst of many small, scattered,
+non-adjacent primitive updates in one frame could regress into many tiny
+`write_buffer` calls, trading bytes-transferred for driver call-count
+overhead — a real cost on some backends. The mitigation is the same
+adjacency-coalescing rule as the value-update case above, and where
+coalescing doesn't help (genuinely scattered, unrelated primitives changing
+in the same frame), that's measured in Phase 0's spike alongside the
+ordering/occlusion/layout spikes, not assumed away.
+
+**Gate (Phase 1, §8):** changing one primitive's color in a 10,000-primitive
+layer issues exactly one `write_buffer` call sized to that primitive's
+stride — measured directly via a byte-count/call-count counter
+(`render_stats`-style, ported per §8's Phase 4 note), not inferred from
+"the test passed."
+
+### 5.1 Ordering
+
+Today: `BoundsTree::insert` (`bounds_tree.rs:61`) is a CPU AABB tree, one per
+ordering scope — each `.layer()` gets its own tree starting at 0, which is
+R-N §4.2's per-layer narrowing, already shipped. `Scene::finish`
+(`scene.rs:712-752`) then does nine separate `sort_by_key` calls, one per
+primitive array (`quads`, `shadows`, `paths`, `underlines`,
+`monochrome_sprites`, `polychrome_sprites`, `surfaces`,
+`backdrop_filters`/`filter_boundaries`, `layer_slab_spans`) — a standard
+single-threaded stable sort, run every frame a layer (or the legacy
+per-frame scene) is dirty.
+
+2.0 target: a compute pass over a dirty layer's slab computes pairwise
+overlap and emits a sort key per primitive (same information the CPU
+`BoundsTree` computes today, restated as a parallel bitonic/radix sort over
+GPU buffers already sitting in the storage-buffer layout the renderer uses
+today — §1's finding that instancing is already vertex-pulling means this
+compute pass writes into the exact buffers the existing draw calls already
+read, no pipeline restructuring required). A clean layer's sort key buffer
+is untouched and reused as-is, exactly matching R-N §5.1's rule ("order
+invalidation is per-layer") — 2.0 changes *where* the sort runs when it does
+run, not when it runs.
+
+### 5.2 Occlusion culling
+
+R-N §8 already designed this as a two-tier, provably-a-no-op system built on
+each layer's `BoundsTree` (layer-tier at composite time, instance-tier at
+emission time for dirty layers only), with a `WGPUI_OCCLUSION=validate`
+differential mode as the correctness backstop. That design does not change —
+it was already correctly scoped to avoid churning clean layers (R-N §8.2).
+What changes is that the instance-tier coverage test (R-N §8.3's conservative
+opaque-region test: solid background, opacity 1.0, corner-radius inset,
+border-opacity inset, no backdrop filter above, blur-margin exemption) runs
+as a compute pass over the layer's resident primitive buffer instead of a
+CPU loop, for the same reason as §5.1: it's the same computation, restated
+as data-parallel, run only when a layer is dirty (per R-N §8.2's rule, which
+2.0 keeps unchanged). The validate-mode safety net (R-N §8.5) is kept exactly
+as designed — for GPU-computed culling it's not optional, it's the only
+practical way to catch a compute-shader coverage bug, since there is no
+CPU-side result to eyeball.
+
+### 5.3 Indirect draw
+
+Today: the renderer computes `first_instance`/count ranges on the CPU
+(`quads_first_instance` and its siblings, `renderer.rs:3486-3492`) and issues
+one `pass.draw(0..4, first_instance..first_instance+count)` per (layer,
+primitive kind), already coalescing byte-contiguous same-layer runs into one
+call (`OpenSlabRun`, `renderer.rs:1690-1723`). 2.0 target: §5.1/§5.2's
+compute passes write those same two numbers — instance count, first
+instance — into a GPU buffer instead of a CPU local; the CPU issues a
+**fixed** sequence of `draw_indirect`/`multi_draw_indirect` calls — one per
+(layer, kind) slot that *could* be populated — every frame, regardless of
+how many are actually zero. A clean window's CPU-side draw-issuing cost
+becomes O(layer slots), not O(resident primitives) and not O(dirty layers)
+— the GPU decides how much work each indirect call expands to, including
+"none," without the CPU ever finding out the count.
+
+This is a smaller lift than it would be in most codebases: `render_context.rs:104-176`
+already requests and negotiates `INDIRECT_FIRST_INSTANCE` (hard-required on
+native outside macOS) and `MULTI_DRAW_INDIRECT_COUNT` (best-effort on
+macOS, hard-required elsewhere) at device creation, correctly split by
+platform, and the crate already has hard-won, documented experience with
+exactly the failure mode that matters — drivers silently dropping indirect
+draws with nonzero `firstInstance` (`README.md`, "Custom Device Gotcha",
+originally hit via externally-embedded Helio content). §1's table's
+sharpest finding is that this negotiation code has shipped and worked in
+production for a feature the crate's own primitive renderer has never used.
+2.0's job in this phase is narrower than "solve indirect dispatch" — it's
+"finally call the draw functions the device was already asked to support,"
+plus the one genuinely new piece: a CPU-readback fallback (compute writes
+the args, CPU reads them back and issues direct draws) for the macOS
+best-effort case and for WASM, which are the same fallback path per
+decision 2 (§0) and therefore one piece of work, not two.
+
+### 5.4 Invalidation vocabulary, extended — and one axis actually turned on
+
+R-N's four axes (`LAYOUT`/`DISPLAY`/`HIT`/`TRANSFORM`, R-N §3.2) and its
+typed `InvalidationRequest`/`InvalidationScope` (R-N §6) are kept unchanged —
+they're the right granularity and nothing above changes what gets
+invalidated, only how the resulting work is executed. But `TRANSFORM`
+specifically needs more than "keep it": per §1's table, it's a live bitflag
+(`Invalidation::TRANSFORM`, `window.rs:409-416`) that nothing in the crate
+sets — the crate's own comment says as much. That's not a rounding error;
+it's the specific bit that was supposed to make a scroll tick cost one
+matrix, and it has never fired. 2.0's compositing (§5.1–5.3, all
+GPU-resident and patch-driven) is what finally makes "independently
+composited" true in the sense R-N's own comment is waiting for, so wiring
+real `TRANSFORM`-only invalidation is folded into Phase 2 (§8) rather than
+left as a fifth thing to remember.
+
+One addition on top, pulled forward from SFD §1.1's "needs its own change,
+not bundled into scroll" note: a fifth *signal* kind (distinct from the four
+invalidation *axes* above), **`Reason::Scroll`**, distinguishable from
+`Reason::DataChanged` at the point invalidation is raised — not inferred
+after the fact by a key someone remembered to write, which is exactly what
+made this hard to retrofit safely in SFD's own telling. `.boundary()` (§4)
+consumes this directly to decide whether a notification can resolve to
+`TRANSFORM` alone; every other consumer of `cx.notify()` is unaffected.
+
+### 5.5 The obvious fast path this opens up: `WgpuSurface`
+
+`wgpu_surface()`/`WgpuSurfaceHandle` (`elements/wgpu_surface.rs`, 545 lines)
+is what the README calls "the unique capability that makes WGPUI suitable
+as a shell for 3D applications" — an external render thread renders into a
+triple-buffered texture at its own pace, and the compositor samples
+whatever's latest-ready whenever it draws. It is also, structurally, the
+single best-fitting case for everything §4/§5 build, and today it uses none
+of it. Two concrete gaps, both closeable, one of them essentially free once
+§5's general mechanism exists:
+
+**Gap 1 — it has no identity, so it gets none of §4.0's retention for free.**
+`WgpuSurface::id()` is hardcoded to return `None`
+(`wgpu_surface.rs:449-451`) — not a fundamental limitation, a specific
+historical choice — which means it can never be addressed by
+`InstanceKey`/`GlobalElementId` and so never participates in reconciliation,
+Taffy-node reuse, or `.boundary()` at all. Concretely, `request_layout`
+builds a fresh `Style::default()` and calls `window.request_layout`
+unconditionally every single frame (`wgpu_surface.rs:457-468`) — the *exact*
+"no `diff_key`, full rebuild" path §6.2 flags as acceptable only for
+third-party elements, except here it's forced, not chosen, because there is
+no identity to hang a `diff_key` on in the first place.
+
+This element is actually the cleanest possible case for reconciliation to
+handle, once it has identity: its pixel *content* is never part of the CPU
+description at all — it's produced by someone else's render loop and the
+compositor always samples whatever's currently `ready`, so the framework
+never needs to ask "did the texture change" the way it asks that question
+for a `div`'s children. A `diff_key` comparing only `(bounds, style,
+surface_id)` is sufficient and correct by construction, because those are
+the only three things that affect *its own* composite entry (Taffy leaf,
+order-tree position, indirect-draw slot). Give it real (positional, per
+SFD §1.0's mechanism) identity and that trivial `diff_key`, and an
+unmoved, unresized 3D viewport panel — the common case, e.g. sitting still
+while the user edits an unrelated inspector panel — costs the framework
+nothing per frame beyond confirming "unchanged," instead of rebuilding a
+style and re-registering a Taffy leaf unconditionally, forever. Panning a
+panel that contains a live viewport becomes a `TRANSFORM`-only, one-matrix
+update (§5.4) rather than touching layout/prepaint/paint every frame
+regardless of whether the panel moved. This is a small, self-contained fix
+— folded into Phase 2 (§8) alongside the rest of the positional-identity
+work it depends on — not a new mechanism.
+
+**Gap 2 — it composites through a second, parallel pipeline that duplicates
+what §5 already has to build.** `WgpuSurface::paint` pushes into
+`Scene.surfaces` via `window.paint_wgpu_surface` (`wgpu_surface.rs:517-530`),
+drawn through the dedicated `surfaces` pipeline backed by `SurfaceRegistry`
+(`surface_registry.rs`, 772 lines) — a triple-buffered, atomically-swapped,
+generation-tracked texture handoff built specifically for a render thread
+that runs independently of the compositor. That machinery is *correct and
+necessary* for its actual job (cross-thread producer/consumer pacing,
+backpressure via `has_unconsumed_frame`, GPU-synced swaps) and nothing here
+proposes touching it. But the *consuming* half — composite an
+already-rendered, externally-owned texture into the ordered scene, at the
+right z-position, GPU-side-transformed, occlusion-aware, via one indirect
+draw entry — is exactly the general mechanism §5.1–§5.3 already has to
+build for `.boundary()`'s texture-retained layers (today's
+`LayerTextureEntry`, `renderer.rs:2190-2201`, a *second*, single-buffered,
+framework-baked texture pool doing conceptually the same compositing job).
+Two composite pipelines exist today for one operation. 2.0 doesn't need a
+third — a `WgpuSurface` becomes the degenerate case of a compositing
+boundary: "here is a texture, produced externally instead of baked by the
+rasterizer, composite it exactly like a boundary's baked texture." Once
+that unification lands (folded into Phase 4, §8, where the general
+indirect-draw compositing entry is built), `WgpuSurface` content gets
+layer-tier occlusion culling for free (§5.2) — a 3D viewport fully covered
+by a modal stops being drawn at all, which it cannot today, since
+`Scene.surfaces` participates in ordering but not in the conservative-
+opaque-region occlusion sweep, which requires the layer-local `BoundsTree`
+identity Gap 1 is what actually blocks.
+
+Both gaps trace back to the same root cause — `id() -> None` — which is
+worth landing first (Phase 2) precisely because Gap 2's unification becomes
+easy to state and test once Gap 1 gives `WgpuSurface` a real place in the
+layer/order system to unify *into*.
+
+---
+
+## 6. What stays on the CPU, on purpose
+
+Not everything belongs on the GPU, and pretending otherwise produces the
+same failure class R-N explicitly rejected for other reasons (R-N §11):
+mechanisms whose correctness depends on an assumption nobody validated.
+
+- **Heterogeneous flexbox/grid layout stays on Taffy, on the CPU.** Taffy's
+  algorithm is recursive over children of arbitrary, data-dependent size —
+  that's inherently sequential in the general case and a poor compute-shader
+  target. 2.0 does not attempt to reimplement general flexbox in WGSL. What
+  moves to the GPU is narrower and concrete (§6.1).
+- **Text shaping stays on the CPU**, via `cosmic-text`, unchanged. Shaping
+  is branch-heavy, font/cache-dependent, and not a good data-parallel target
+  with today's tooling; GPU text-shaping techniques exist in research but
+  are not mature enough to gate this plan on (§9, Rejected). What *is*
+  data-parallel and already GPU-appropriate — placing already-shaped glyphs
+  as instanced sprites — stays exactly that, patched through the same
+  persistent-slab protocol as every other primitive (§2). This closes R-N's
+  self-documented gap (`Img`/`StyledText` never got `diff_key`, R-N Phase 7
+  table; SFD §3) as an ordinary consequence of giving every primitive kind
+  the same patch path, not as a special case.
+- **Hit-testing, focus, actions, and input dispatch stay on the CPU.** These
+  are small, latency-critical (must resolve within one input event, not one
+  frame), and already cheap — R-N §5.2's point-transform hit test (inverse-
+  transform the query point per layer, not every hitbox) is the right
+  design and is kept as-is.
+- **User code — `Render::render`, event handlers, `on_frame` — stays exactly
+  where it is and runs exactly as it does today.** This is not a limitation
+  to route around; it's the actual constraint that makes "frontend doesn't
+  change" possible at all. Arbitrary Rust closures cannot execute on a GPU
+  compute pipeline, and the frontend/backend boundary (§2) is deliberately
+  drawn *after* all such code has already run, so this requirement and "the
+  backend can do whatever it wants" are compatible by construction rather
+  than in tension.
+
+### 6.1 What does move: regular-content layout
+
+The scoped, real GPU-layout target is content whose position is a function
+computable independently per item, in parallel — exactly the case
+`uniform_list`/`h_list` already special-case on the CPU today (bypassing
+Taffy entirely, per `uniform_list.rs`'s own doc comment: "rather than use
+the full taffy layout system, uniform_list simply measures the first element
+and lays out all remaining elements in a line"). That CPU special case
+*already proves the content shape is regular enough* — 2.0's job is to give
+it a compute kernel instead of a CPU loop: item count, a per-item size
+(uniform, or from a size buffer computed once), and container bounds go in;
+final positions are written directly into the instance buffer, in parallel,
+with zero Taffy node creation. The same applies to a flex row/column of
+same-sized children generally, not just the two hand-built element types
+that special-case it today — a strict generalization, not a new concept.
+
+Any content that breaks the "position is independent per item" property
+(auto/content-dependent sizing that shifts later siblings, nested regular
+layouts inside heterogeneous ones) falls back to Taffy on the CPU, exactly
+as it does today for non-uniform content. This mirrors SFD §0.-3's own
+containment design (`estimated_size` → `None` falls back to real layout,
+never guessed) — the fallback is always "do it for real on the CPU," never
+a wrong GPU answer.
+
+### 6.2 The `diff_key`/`estimated_size` invariant
+
+Constraint 5 (§0) only pays off for an element type that actually
+implements `diff_key` — the trait's own default (`None`, `element.rs:136-
+138`) means "assume changed, rebuild," which is the correct, unavoidable
+default for a *third-party* `Element` impl (its purity can't be proven from
+outside), but today it is also the state of two of the framework's own
+built-in types: `Img` and `StyledText` never got one (R-N Phase 7's own
+table; SFD §3). Under R-N/SFD that was a bounded, documented gap. Under
+ambient reconciliation (§4.0) it stops being bounded — every `Img` or
+`StyledText` anywhere in the tree, boundaried or not, is now the one kind
+of node that still forces a full rebuild of itself on every notification of
+its owning view, which is precisely the two element kinds SFD §3 already
+identified as dominating real list rows (avatars, thumbnails, rich text).
+
+So this is elevated from a one-off fix (previously scoped to Phase 5) to a
+standing rule: **every first-party element type ships with `diff_key`
+implemented, and `estimated_size`/`on_frame` wherever they apply** — it is
+part of what "adding an element to this framework" means, checked the same
+way a new element's `Element` impl is checked for panics today, not treated
+as a follow-up someone gets to eventually. The permissive `None` default on
+the trait itself does not change — it stays exactly right for foreign code
+— only the bar for what ships inside `wgpui-widgets` does.
+
+---
+
+## 7. Frontend contract, made testable
+
+"The public API doesn't change" is enforced, not just stated:
+
+- Every existing example under `examples/learn/`, `examples/bench/`, and
+  `examples/legacy/` must compile and run unmodified against `wgpui-core`
+  once it's wired in as an alternate backend — not "mostly," not "with the
+  caveats listed here." A CI job builds every example against both backends.
+- Where feasible, a pinned snapshot of the real consuming application's UI
+  code (the one SFD's grep already sampled — "32 of 37 hand-rolled scroll
+  containers") compiles against both backends with zero source changes
+  beyond the dependency line. This is the test SFD's own findings say
+  matters: the framework's *usage* in a real app, not just its examples.
+- The only source-visible changes anywhere are the caching-primitive
+  replacement in §4 (`.layer()`/`.layer_keyed()`/`.layer_with_policy()`/
+  `Panel::cacheable` → `.boundary()` with its `BoundaryPolicy`/`Buffering`
+  enum (§4.1, §4.3), plus the new `.uncached()`, §4.2), which was explicitly
+  called out as in-scope. Everything else — `div()`, the `Styled` DSL, `Render`,
+  `Entity<T>`, `Context<T>`, actions, keymaps, `uniform_list()`/`list()`/
+  `virtual_list()`, `canvas()`, `wgpu_surface()` — is byte-for-byte the same
+  surface, verified by the compile check above, not by inspection.
+
+---
+
+## 8. Phasing
+
+Each phase has a falsifiable gate, following R-N's own discipline (R-N §10).
+Phases 1–3 are almost entirely additive (new crates, no behavior change to
+the default backend); the switch to `wgpui-core` as default happens only at
+Phase 8, after parity is demonstrated, not assumed.
+
+| Phase | Work | Gate |
+|---|---|---|
+| **0** | Workspace scaffold (`crates/wgpui-core`, `-layout`, `-text`, `-widgets`, `-devtools`, `-wgpu`, empty or thin). Port `flamegraph_gpu.rs`'s GPU timestamp capture as the baseline instrumentation. **Spike, not build**: a synthetic 100K-quad scene's ordering+occlusion as a compute pass vs. today's CPU `BoundsTree`; a 10,000-row uniform grid's layout as a compute kernel vs. today's CPU loop. | Numbers exist, on real target hardware, for the two spikes that decide whether Phases 3 and 6.1 are worth building at all. If a spike doesn't win, the corresponding phase is rescoped or dropped here, not discovered mid-build. |
+| **1** | `wgpui-core::patch` — the patch-list protocol (§2): insert/update/remove for primitives, layout inputs, hitboxes, dispatch nodes. `wgpui-core::scene` — persistent per-layer slabs (R-N Pillar III's concept, 2.0's mechanics), accepting patches instead of full-range rewrites. **Ambient reconciliation (§4.0) ships here, window-wide, with no `.boundary()` involved at all** — `diff_key`/`InstanceKey` reconciliation and Taffy node reuse apply to every element in the tree by construction, not fenced to any subtree. **`.uncached()` (§4.2) ships in this same phase, not later** — shipping the default without its escape hatch would leave high-frequency-update UIs (the game-engine-editor workloads this crate targets) with no way to opt out of reconciliation bookkeeping that provably never pays off for them. No compute yet; CPU-computed draw ranges, same as today, just through the new protocol. | A round-trip test: apply a patch sequence, read back the resident buffer, matches an equivalent full-rebuild reference exactly. **Separately, and just as load-bearing**: a plain, unboundaried three-level-deep div that renders identically to last frame keeps the same `LayoutId` and skips `prepaint`/`paint` — with zero `.boundary()`, zero `.id()`, zero API touched anywhere in the test. **A third, symmetric check**: a `.uncached()` subtree allocates no `ElementInstance` and its children's state (`use_state`, focus) survives across frames identically to a reconciled subtree's — proving the two mechanisms are actually decoupled, not just documented as such. **A fourth check, per §5.0**: changing one primitive's value inside a large layer issues one `write_buffer` call sized to that primitive's stride, not the layer's full range — the actual delta-upload guarantee, checked from Phase 1 rather than assumed to fall out of the compute phases later. |
+| **2** | `.boundary()` (§4.1) implemented as a pure compositing/buffering policy on top of Phase 1's already-ambient reconciliation: independent GPU texture retention, auto positional identity for the boundary root, and the `Reason::Scroll` signal (§5.4) from day one — not retrofitted. Old `.layer()`/`.layer_keyed()` etc. keep working unchanged in the legacy backend; `.boundary()` only exists in `wgpui-core`. **`WgpuSurface` gets real (positional) identity + a trivial `(bounds, style, surface_id)` `diff_key` here too (§5.5, Gap 1)** — it depends on the same positional-identity work this phase already builds, and unblocks Phase 4's compositing unification. | `.boundary()` with zero policy arguments reaches R-N's fast path (transform-only recomposite on scroll) on a plain `overflow_y_scroll` div with no other API touched — the exact test SFD Pass A's gate specifies, now true by default rather than by opt-in. Additionally: removing `.boundary()` from that same test case degrades the scroll case to a per-tick recomposite (no independent texture) but does **not** reintroduce full rebuild — confirming boundary and reconciliation are actually decoupled, not just documented as such. **`WgpuSurface` check**: an unmoved, unresized `wgpu_surface()` element skips `request_layout`/`prepaint`/`paint` across frames exactly like a reconciled `div` would. |
+| **3** | GPU compute ordering + occlusion (§5.1, §5.2) over Phase 1's slabs. `WGPUI_OCCLUSION=validate`-equivalent differential harness ported and run against the compute path. | Culled/unculled scenes match exactly over a scripted UI walk (R-N §8.5's bar, unchanged). Spike numbers from Phase 0 reproduced on the real pipeline, not just the synthetic case. |
+| **4** | Indirect draw-arg generation + `multi_draw_indirect` (§5.3), with the CPU-readback fallback for drivers/WASM that can't take it. **`WgpuSurface`/`SurfaceRegistry` compositing unification (§5.5, Gap 2)**: the *consuming* half of `SurfaceRegistry`'s composite path is folded into the same indirect-draw entry mechanism `.boundary()`'s texture-retained layers use; `SurfaceRegistry`'s producer-side triple-buffer, atomic generation tracking, and `gpu_submit_lock` cross-thread synchronization are untouched — nothing about how the external render thread paces itself changes. | A clean window's CPU-side draw-issuing work is O(layer slots), independent of resident primitive count, measured directly (same `render_stats`-style counters R-N used, ported into `wgpui-core`). **`WgpuSurface` check**: a viewport panel fully covered by a modal (occlusion-culled per §5.2/Phase 3) issues zero draws for its embedded 3D content, and `WgpuSurfaceHandle`'s existing concurrency tests (`submit_guard`, backpressure via `has_unconsumed_frame`) pass unmodified against the unified consumer path. |
+| **4.5** | `Buffering::Tiled` (§4.3): `LayerKey` extended to `(boundary, TileCoord)` addressing; tile-visibility compute pass driving indirect draw-arg generation for the in-range tile set (reusing Phase 4's mechanism directly); spatial mark-and-sweep eviction plus a total resident-tile budget with LRU eviction beyond it. | Panning a node-graph-style canvas across a tile boundary renders only the newly-revealed tile(s) — measured directly, not inferred — while panning within the resident grid costs one `TRANSFORM` update per visible tile and zero render/reconcile/layout work anywhere. |
+| **5** | `wgpui-text`: shaped-run → patch conversion; `Img`/`StyledText` get the `diff_key` R-N Phase 7 left undone — the first two elements checked off against §6.2's standing invariant, not a one-off fix (closing SFD §3). Atlas-eviction subscription for GPU-resident glyph/sprite tiles (R-N §4.3's hazard, same fix, new home). | Scroll-content-heavy scenes (avatars, multi-run text — SFD §3's stated motivation) hit the fast path with no per-refill shaping cost for unchanged rows, under ambient reconciliation (Phase 1), not because they're inside a `.boundary()`. |
+| **6.1** | GPU compute layout kernel for regular content (§6.1): uniform lists/grids and same-sized flex runs. Heterogeneous content is untouched, still Taffy/CPU. | `uniform_list`/`h_list`'s existing CPU special case and the new kernel produce identical positions on the same input (differential test, same philosophy as R-N's hit-test differential test) across a range of item counts; CPU cost for layout is O(1) dispatches, not O(item count). |
+| **7** | `wgpui-devtools` extraction (move, don't rewrite, the flamegraph/replay/inspector system onto a small hook trait `wgpui-core` exposes). File breakup of what remains monolithic in `wgpui-core`'s own modules (target: no file over ~1,000 lines). Can run in parallel with 1–6 — it's orthogonal risk — sequenced last here only because it's cheapest once most call sites have already been touched by the phases above. | `wgpui-core` compiles and runs with `wgpui-devtools` absent entirely (feature-gated), proving the dependency is genuinely one-directional. |
+| **8** | Parity checklist (§7) passes: every example, plus the pinned real-app snapshot where available, compiles and renders equivalently on both backends. `wgpui-core` becomes the default; root `gpui-ce` becomes a thin re-export. Legacy immediate-mode paths, `AnyView::cached`'s replay mechanism, and the `WGPUI_*` flag ladder are deleted — this is R-N's own never-finished Phase 12, finally safe to do because there is no longer a CPU path underneath it that anything still depends on. | No known workload needs the legacy backend as anything but a documented rollback tag. |
+
+Phases 1–2 are independently valuable and low-risk (new crate, no default
+change). **Phase 0 is the actual decision point** — if either spike doesn't
+show a real win on real hardware, that's the moment to descope, not five
+phases later. Phase 8 is the only phase that changes what a consumer gets by
+default, and it's gated on parity being demonstrated, not scheduled.
+
+---
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| GPU layout kernel diverges from Taffy's exact rounding/min-max/gap semantics for edge cases | Differential test against Taffy's own CPU output is the Phase 6.1 gate, not a follow-up; any regular-content case the kernel can't reproduce exactly falls back to Taffy, same discipline as SFD's `estimated_size` containment fallback (SFD §0.-3). |
+| Indirect-dispatch driver/feature gaps (older GPUs, some Vulkan/Linux drivers, WASM/WebGPU) — the crate has *already* hit this class of bug for externally-embedded content (`README.md`'s `INDIRECT_FIRST_INSTANCE` note) | Feature-detect at device creation; CPU-readback fallback (§5.3) is built as a first-class path from Phase 4, not a patch bolted on later, and doubles as the WASM path. |
+| GPU-resident state is much harder to introspect than a CPU `Vec` when something's wrong | The existing DeepCapture/replay system (`flamegraph_replay.rs`, "RenderDoc for our UI framework") already solves the actual problem — extend it to read back compute-written buffers, don't rebuild a debugging story from zero. This is the strongest argument for moving devtools (§3.6) rather than deleting any of it. |
+| Two backends live simultaneously for the length of the migration | Phase-gated parity checklist (§7/§8) with a hard, explicit cutover phase, not an indefinite dual-maintenance state; legacy backend is frozen (bugfixes only) once Phase 1 starts, so it's not a moving target. |
+| Scope creep — R-N's CPU-side retained rendering alone took from `#98` to `#148`, ~7 months of merged phase work, for a narrower goal than this one | Every phase above has a single falsifiable gate; Phase 0's spikes exist specifically to kill scope before it's committed to, not after. |
+| Public API compatibility silently breaks because an internal type (`LayerPolicy`, `Interactivity`, `ScrollHandle`) leaks GPU-shaped fields into the public surface | §7's compile-check CI job runs on every PR touching `wgpui-core`, not as a pre-release gate — catches the break at the commit that introduces it. |
+| **Ambient reconciliation (§4.0/constraint 5) means a `diff_key`/reconciliation bug's blast radius is the entire application from Phase 1 onward, not one opted-in subtree** — this is the direct cost of the correction that makes 2.0's default posture right | Kill switch from Phase 1 (`WGPUI_INSTANCES=0`'s precedent, `view.rs:103`, now gating the *default* path rather than an edge feature); the Phase 1 gate's second clause (a plain unboundaried div reusing its `LayoutId`) is a targeted regression test for exactly this, run continuously, not just once at Phase 1's landing. |
+| Unifying `WgpuSurface`'s composite path with `.boundary()`'s (§5.5, Gap 2) accidentally touches `SurfaceRegistry`'s cross-thread producer-side synchronization (`gpu_submit_lock`, atomic generation tracking, GPU-synced buffer swaps) — hard-won, carefully-documented concurrency code that has nothing to do with the bug being fixed | Scope Phase 4's change explicitly to the *consumer* side only — how an already-produced texture enters the ordered scene and gets drawn. `SurfaceRegistry`'s producer API (`back_buffer_view`, `present_synced`, `submit_guard`, backpressure) is untouched, and its existing tests are the gate (Phase 4's row, §8), not a new test suite reverse-engineered from the concurrency doc comments. |
+| `Buffering::Tiled` (§4.3) picks a tile size that's wrong for a given workload — too small inflates per-tile/draw-call overhead, too large approaches `Margin`'s whole-region-refill cost — and an erratic pan pattern keeps more tiles "recently visited" than a per-tile eviction timer alone bounds | Tile size starts from measured common-compositor practice (~256–512px) and is validated against a representative node-graph workload in Phase 4.5, not asserted (same Phase 0 spike discipline); a total resident-tile budget with LRU eviction is a first-class part of the mechanism, not a follow-up, exactly because R-N §3.4's per-layer timer alone was never designed for grid-many tiles. |
+
+---
+
+## 10. Rejected / explicitly deferred
+
+- **Reimplementing general flexbox/grid layout as a compute shader.**
+  Taffy's algorithm is recursive over heterogeneous, data-dependent content
+  — a poor data-parallel fit with current techniques, and reimplementing a
+  mature, correctness-tested layout engine from scratch is a multi-year
+  research project on its own, not a phase. Scope GPU layout to the regular
+  case (§6.1) where the payoff is real and the risk is bounded.
+- **GPU text shaping.** Real published techniques exist (SDF/MSDF-adjacent,
+  parallel shaping research), but they're not production-mature enough to
+  gate this plan on, and `cosmic-text`'s CPU shaping is not, on current
+  evidence, the bottleneck this crate has (R-N §2.6's own caveat: measure
+  before assuming a stage dominates). Revisit only if Phase 5's
+  instrumentation shows shaping actually dominating a real frame.
+- **A new layout/styling DSL.** Out of scope by explicit instruction — the
+  Tailwind-style `Styled` API and Taffy-based flexbox/grid model are the
+  frontend contract (§7), not implementation detail up for renegotiation.
+- **An automatic "always-dirty subtree" heuristic** (R-N §9's own sketch: the
+  framework tracks a per-subtree payoff ratio and marks persistently-
+  unprofitable subtrees `AlwaysRebuild` without being told). Real idea, not
+  dismissed — but it's an adaptive layer on top of the manual primitive
+  (§4.2), not a substitute for it, and it needs its own measurement story
+  (what payoff ratio, over what window, before auto-marking) before it's
+  trustworthy. Ship `.uncached()` first, since it's what a developer facing
+  this problem today can use immediately with certainty; revisit the
+  adaptive version once there's field data on how often developers actually
+  reach for it, which is also the data that would validate a heuristic.
+- **Forking Taffy.** Reuse the crate for the CPU-necessary cases (§6);
+  narrow its call sites, don't reimplement or fork it.
+- **Zoom-level/multi-resolution tiling** (browser compositors' practice of
+  caching the same tile at multiple mip-like resolutions so zooming doesn't
+  force a full re-render at the new scale). Real technique, genuinely more
+  than §4.3 needs to solve the problem as asked — 2-axis pan buffering, not
+  pan-and-zoom buffering. `Buffering::Tiled` re-renders at the current scale
+  on a zoom change, same as `Margin` does today; multi-resolution caching is
+  a legitimate later addition to the same tile-grid mechanism if zoom-heavy
+  workloads (e.g. a level editor's minimap) show it's worth the added
+  complexity, not a day-one requirement.
+- **In-place flag-ladder migration** (the R-N/SFD pattern of one
+  `WGPUI_*` env var per mechanism). Explicitly rejected per the workspace
+  decision in §0 — it's the mechanism SFD's own §0.1 finding blames for low
+  real-world adoption of a feature that already works.
+- **Gating native releases on WASM parity.** Per §0's decision, WASM
+  follows each phase with a CPU fallback; it never blocks native.
+- **Gating reconciliation/persistent layout behind an opt-in primitive**,
+  the R-N/SFD shape where `diff_key`-based skipping only applies inside a
+  `.layer()`/`.boundary()` subtree. Rejected directly by constraint 5 (§0):
+  opt-in retention with rebuild as the fallback is the exact shape SFD §0.1
+  measured as producing near-zero real adoption, and there is no correctness
+  reason reconciliation needs a subtree boundary — R-N's own `diff_key`
+  mechanism is unconditionally applicable per-element; §4.0 removes the
+  fence around it rather than widening the fence.
+
+---
+
+## 11. Immediate next actions
+
+This document is the plan; nothing above has been built. The concrete first
+steps, in order:
+
+1. Stand up the empty workspace (`[workspace]` in the root `Cargo.toml`,
+   empty `crates/wgpui-core` etc.) — mechanical, zero risk, unblocks
+   everything else being developed in parallel without touching `src/`.
+2. Run Phase 0's two spikes (GPU compute ordering+occlusion vs. CPU
+   `BoundsTree`; GPU layout kernel vs. `uniform_list`'s CPU loop) on
+   representative hardware, and write down the numbers before anything else
+   in this plan is built on top of them.
+3. Only after both spikes report back: start Phase 1 (the patch protocol),
+   since every later phase depends on it and it's independently low-risk
+   regardless of what the spikes show.

--- a/docs/phase-0-results.md
+++ b/docs/phase-0-results.md
@@ -1,0 +1,371 @@
+# Phase 0 Results — Workspace Scaffold + the Two Spikes
+
+Status: **Phase 0 executed.** This documents what was built, what was
+measured, and what a human still needs to check before treating this gate as
+closed. It follows `docs/gpu-native-architecture.md` ("2.0" below) §0, §3,
+§8's Phase 0 row, and §11. Nothing under `src/` changed in behavior; this
+work lives entirely in a new `[workspace]` member set alongside it, on
+branch `wgpui-2.0/phase-0-scaffold-and-spikes`.
+
+**Contents:** §1 Workspace scaffold · §2 Deviations from §3's file map, and
+why · §3 GPU adapter honesty check · §4 Spike A (ordering + occlusion) · §5
+Spike B (uniform-list layout) · §6 Gate assessment — is Phase 0 done?
+
+---
+
+## 1. Workspace scaffold
+
+The root `Cargo.toml` gained a `[workspace]` table (root package
+`gpui-ce`/lib `gpui` listed as a member, per 2.0 §3's requirement that its
+public surface not change) alongside six new members:
+
+```toml
+[workspace]
+members = [
+    ".",
+    "crates/wgpui-core",
+    "crates/wgpui-layout",
+    "crates/wgpui-text",
+    "crates/wgpui-widgets",
+    "crates/wgpui-wgpu",
+    "crates/wgpui-devtools",
+]
+```
+
+Each new crate follows this repo's own `AGENTS.md` conventions rather than
+2.0 §3's literal `mod.rs`-based trees: `[lib] name = "wgpui_core", path =
+"src/wgpui_core.rs"` (mirroring the root crate's own `gpui-ce` → `gpui` →
+`src/gpui.rs` pattern), and every module that 2.0 draws as `foo/mod.rs` is
+instead `foo.rs` sitting next to a `foo/` directory of submodules — the
+"prefer `src/some_module.rs` over `src/some_module/mod.rs`" rule. §2 below
+lists every place this required a judgment call. All 130 files under
+`crates/` are placeholder stubs: a module doc comment citing the exact
+2.0 section it implements, `#![allow(dead_code)]`, and no `todo!()` /
+`unimplemented!()` / `panic!()` anywhere (this repo's own clippy lints
+already `deny` `todo!()`). Each crate's `Cargo.toml` has empty
+`[dependencies]` except where a stub genuinely needs a type to compile —
+that turned out to be only `wgpui-wgpu`, and only in `[dev-dependencies]`/
+its own `[dependencies]` for the Phase 0 spike harnesses (§2 below).
+
+**Verification performed:**
+
+```
+cargo check --workspace --offline     → Finished, 0 errors (6 new crates + gpui-ce)
+cargo check -p gpui-ce --offline      → Finished, 72 warnings (identical count/content
+                                          to the pre-workspace baseline — confirmed by
+                                          running the same check before touching Cargo.toml)
+cargo check -p wgpui-wgpu --all-targets --offline
+                                        → Finished, includes the 3 new examples
+```
+
+The `gpui-ce` warning count (72) was diffed against a baseline run captured
+*before* any change in this branch — identical, confirming constraint 3
+("existing code keeps working, unmodified in behavior") held for the
+scaffold step. `cargo check --workspace` builds `libwgpui_core`,
+`libwgpui_layout`, `libwgpui_text`, `libwgpui_widgets`, `libwgpui_wgpu`,
+`libwgpui_devtools` (confirmed via `target/debug/.fingerprint/wgpui-*` and
+`target/debug/deps/libwgpui_*.rmeta` build artifacts) with zero warnings of
+their own.
+
+---
+
+## 2. Deviations from §3's file map, and why
+
+1. **No-`mod.rs` convention (`AGENTS.md`) applied throughout.** Every
+   `foo/mod.rs` in 2.0 §3.1–§3.6 became `foo.rs` + `foo/` (submodules).
+   Mechanical, and it's the repo's own standing rule, not a judgment call —
+   listed here for completeness rather than as a real deviation.
+2. **`wgpui-text/src/fonts/`** needed a declaring file 2.0 §3.3's tree
+   doesn't show (it lists `fonts/features.rs` and `fonts/fallbacks.rs` with
+   no `fonts/mod.rs`) — added `fonts.rs` since a directory of submodules
+   needs one under this repo's convention.
+3. **Shader files under `wgpui-core/src/shaders/*.wgsl` and
+   `wgpui-wgpu/src/render/shaders/*.wgsl` are placeholder text**, not the
+   literal move-as-is 2.0 §3.5 describes for the eight hand-written render
+   shaders. Moving ~/platform/cross/shaders/*.wgsl verbatim is mechanical
+   but out of scope for a stub pass whose job is the module skeleton, not
+   the content; each placeholder file states this directly. Both crates
+   gained a thin `shaders.rs` (not in 2.0's literal tree, which treats
+   `shaders/` as a bare asset directory) exposing each file via
+   `include_str!` — needed so the directory is reachable Rust-side at all
+   without adding a real shader-compilation dependency yet.
+4. **No inter-crate path dependencies wired yet.** 2.0 §3 implies
+   `wgpui-widgets` will eventually depend on `wgpui-core`/`-layout`/`-text`,
+   and `wgpui-wgpu` on `wgpui-core`. None of that exists yet — every stub
+   file compiles standalone, so nothing forced the dependency graph to be
+   real before Phase 1 needs it. Deliberate, not an oversight: Phase 1 is
+   where `wgpui-core::patch`/`scene` get real types other crates need to
+   name, and wiring the dependency edges now against empty modules would
+   only be discovered-wrong later.
+5. **`wgpui-wgpu` depends on `wgpu`/`pollster`/`bytemuck` already** (version
+   pins matching the root crate's own `Cargo.toml`), specifically because
+   Phase 0's spike harnesses live in this crate's `examples/` and need a
+   real device — the one deliberate exception to "empty deps at this
+   stage," and it's exactly the crate 2.0 §3.5 names as "the only crate that
+   touches a live `wgpu::Device`," so the dependency is architecturally
+   correct even though it arrived earlier than its first real caller.
+   `wgpui-core` (§3.1) stayed fully dependency-free — the "no live
+   `wgpu::Device` anywhere in this crate" rule is about the crate's shipped
+   library surface, and putting the wgpu-touching spike code in
+   `wgpui-wgpu` instead keeps that rule intact from day one rather than
+   needing a carve-out later.
+6. **Spikes are `examples/`, not `benches/`.** The task brief allowed
+   either. Plain `fn main()` examples avoid pulling in `criterion` (adds a
+   plotting/HTML-report dependency chain not otherwise needed) and match
+   this crate's own `examples/bench/*.rs` convention already used for
+   `plain_scroll_10k`, `paths_bench`, etc. Each spike is one command:
+   `cargo run -p wgpui-wgpu --example spike_a_ordering_occlusion --release`.
+
+None of these change any behavior under `src/`; all are additive,
+new-crate-only decisions.
+
+---
+
+## 3. GPU adapter honesty check
+
+Per the task's explicit instruction, this was checked **before** trusting
+any spike number: `crates/wgpui-wgpu/examples/adapter_probe.rs`, run via
+`cargo run -p wgpui-wgpu --example adapter_probe --offline`.
+
+**Result: a real discrete GPU is present on this machine.** This is not a
+headless CI sandbox — it's the developer machine this session ran on
+(Windows 11), and it has a real, driver-installed NVIDIA GPU:
+
+```
+== Adapters enumerated on VULKAN | DX12 ==
+  name="NVIDIA GeForce RTX 4060 Laptop GPU" backend=Vulkan device_type=DiscreteGpu driver="NVIDIA" driver_info="561.03" vendor=0x10de device_id=0x28e0
+  name="NVIDIA GeForce RTX 4060 Laptop GPU" backend=Dx12   device_type=DiscreteGpu driver="32.0.15.6103" vendor=0x10de device_id=0x28e0   (x3, one per DX12 feature-level probe)
+  name="Microsoft Basic Render Driver"      backend=Dx12   device_type=Cpu        driver="10.0.26100.8972" vendor=0x1414 device_id=0x8c
+
+== Picking the first adapter (this crate's established pattern) and requesting a device ==
+  Selected adapter: name="NVIDIA GeForce RTX 4060 Laptop GPU" backend=Vulkan device_type=DiscreteGpu driver_info="561.03"
+  software/CPU-fallback adapter: no
+  request_device: OK
+```
+
+Both spikes below picked the same adapter (first entry from
+`enumerate_adapters`, matching this codebase's own established pattern in
+`src/platform/cross/render_context.rs` / `src/flamegraph_gpu.rs` — no
+`compatible_surface` exists here to justify `request_adapter` instead).
+
+**What this does and doesn't establish.** This *is* real target hardware in
+the sense §8's gate means — a native Vulkan device on a real, currently-sold
+discrete GPU, not WARP/llvmpipe/a software rasterizer (the "Microsoft Basic
+Render Driver" `Cpu`-type adapter is enumerated but not selected by either
+spike). That said, it is **one adapter, one driver version, one OS, one
+class of GPU** (a laptop-class discrete NVIDIA part). It says nothing about:
+
+- Integrated GPUs (Intel/AMD APUs), which are a large fraction of real
+  desktop/laptop deployments and have materially different compute
+  throughput and driver behavior.
+- macOS/Metal or Linux/Vulkan-on-Mesa, which this crate also ships to.
+- Older or lower-end discrete GPUs.
+- The actual WASM/WebGPU path (§0 constraint 2's "best-effort" target),
+  which wasn't touched by this spike at all.
+
+A human should re-run both examples (`spike_a_ordering_occlusion`,
+`spike_b_uniform_layout`) on at least one integrated-GPU machine and one
+non-Windows target before treating the numbers below as representative of
+"real target hardware" in the full multi-platform sense, not just "not a
+software fallback."
+
+---
+
+## 4. Spike A — ordering + occlusion, GPU compute vs. CPU `BoundsTree`
+
+**Code:** `crates/wgpui-wgpu/examples/spike_a_ordering_occlusion.rs`. Run:
+`cargo run -p wgpui-wgpu --example spike_a_ordering_occlusion --release --offline`.
+
+**Scene:** 100,000 quads as 200 spatially disjoint "clusters" (a 20×10 grid
+of 200×200px regions), 500 quads/cluster: one opaque background quad, ~479
+small randomly placed/sized quads (80% translucent / 20% opaque — genuine
+local nesting and overlap), and 20 larger opaque "occluder" quads inserted
+last per cluster (so they sort above the nested content, and several
+genuinely cover multiple smaller quads beneath them). Clusters never overlap
+each other, so all overlap/occlusion structure is local — see §4's own
+"honest limitation" note below.
+
+**CPU path**: a faithful, standalone port of `src/bounds_tree.rs`'s
+`BoundsTree::insert` (identical AABB dynamic-tree structure and
+max-intersecting-order-plus-one rule), fed one quad at a time exactly as the
+real `Scene` does, then a `sort_by_key(order)` — the same shape as
+`Scene::finish` (`scene.rs:734`). Occlusion is a simplified CPU pass (single
+fully-containing, later-drawn, opaque rectangle — not R-N §8.3's full
+corner-radius/border/backdrop-filter-aware test, since this synthetic scene
+has none of those properties to test).
+
+**GPU path**, one command encoder, one submit: (1) `relax` — a WGSL compute
+pass solving `order[i] = 1 + max(order[j] : j<i in the same cluster,
+overlapping)` by fixed-point Jacobi relaxation over ping-ponged buffers
+(128 iterations); this is *the same recurrence* the CPU tree computes, not
+an approximation of it — verified below by exact readback comparison, not
+assumed. (2) `bitonic` — an in-place bitonic sort (153 stages for the
+131,072-padded array) replacing the CPU `sort_by_key`. (3) `cull` — the same
+per-cluster occluder containment test as the CPU reference, one invocation
+per quad. Reported GPU time spans buffer creation, the initial upload, all
+282 compute passes, and the final `poll(Wait)` — an end-to-end wall-clock
+number, not an isolated on-device kernel time. Readback for correctness
+validation happens *after* this window closes (a real Phase 3 consumer
+wouldn't round-trip through the CPU either).
+
+**Honest limitation of this synthetic scene, stated directly**: because
+clusters are non-overlapping by construction, the GPU relax/cull kernels
+bound their neighbor search to "the 500 quads in my own cluster" for free.
+A generic scene without this structure would need real spatial partitioning
+(a uniform grid, or literally the production `BoundsTree`) to get the same
+bound — that's real engineering work Phase 3 still has to do, not something
+this spike proves is free.
+
+**Results** (4 runs, same machine, same binary):
+
+| Run | CPU total | GPU total (end-to-end) | Speedup |
+|---|---|---|---|
+| 1 | 775.6 ms | 52.7 ms | 14.7x |
+| 2 | 803.6 ms | 117.1 ms | 6.9x |
+| 3 | 727.6 ms | 121.0 ms | 6.0x |
+| 4 | 746.6 ms | 135.1 ms | 5.5x |
+
+CPU breakdown (representative run): `BoundsTree` insert 739.6 ms,
+`sort_by_key` 0.8 ms, occlusion cull 8.2 ms — **the tree insert utterly
+dominates.** 41,896 / 100,000 quads (41.9%) were occlusion-culled, matching
+between CPU and GPU exactly.
+
+**Correctness, checked not assumed:** every run reports `order[]` and
+`culled[]` matching the CPU reference **bit-for-bit, 0 mismatches out of
+100,000**, and the relaxation's own convergence counter reads exactly 0 on
+its last iteration (the ping-ponged relaxation had fully settled well
+within the 128-iteration budget — the scene's actual max painter order was
+73).
+
+**Reading the variance honestly:** run 1's 52.7 ms is an outlier; runs 2–4
+cluster around 117–135 ms. This is almost certainly first-process shader/
+pipeline compilation and OS/driver cache state varying between separate
+`cargo run` invocations (each run is a fresh process — nothing here shares
+a pipeline cache across runs) rather than a real 2–3x swing in the
+underlying compute cost. **Treat ~6–7x as the reproducible number, not
+14x.** A production implementation, with pipelines built once at startup
+and reused every frame, should land close to or better than the low end of
+this range, not the outlier.
+
+**One more honest observation:** 739.6 ms for 100,000 `BoundsTree` inserts
+(~7.4 µs/insert) is slower than a simple O(n log n) estimate would suggest.
+This wasn't debugged further — the port was validated as *faithful* (exact
+match against the brute-force definition, same technique
+`bounds_tree.rs`'s own `test_random_iterations` uses), not tuned — but it's
+a real, reproducible property of the production algorithm applied to a
+scene shaped like this one (many small, spatially separated clusters across
+a wide canvas): the SAH-style half-perimeter heuristic doesn't obviously
+keep spatially distant clusters apart in the tree, so `find_max_ordering`'s
+pruning may be less effective than it would be for a single dense region.
+If real UIs with many independent panels/widgets across a wide canvas hit
+this same shape, it's an argument *for* Phase 3, not a benchmark artifact
+to explain away.
+
+---
+
+## 5. Spike B — uniform-list layout, GPU compute kernel vs. CPU loop
+
+**Code:** `crates/wgpui-wgpu/examples/spike_b_uniform_layout.rs`. Run:
+`cargo run -p wgpui-wgpu --example spike_b_uniform_layout --release --offline`.
+
+**CPU path**: the exact formula `uniform_list`'s `prepaint` uses today
+(`src/elements/uniform_list.rs:551-553`, `item_origin = padded_bounds.origin
++ visual_scroll_offset + point(0, item_height * ix)`), computed for all
+10,000 rows. (In production, `uniform_list` only computes the
+scrolled-into-view subset — this spike deliberately computes the full item
+count on *both* sides so the comparison is "N positions computed" on equal
+terms, not one crediting the CPU side for a virtualization optimization the
+GPU side isn't being asked to replicate.)
+
+**GPU path**: one compute pass, `ceil(10000/64)` = 157 workgroups, each
+invocation computing the identical formula from a 6-word uniform buffer
+(item count, item height, container origin, scroll offset). Timed
+end-to-end the same way as Spike A: buffer creation, the parameter upload,
+the single dispatch, submit, and `poll(Wait)`.
+
+**Results** (3 runs):
+
+| Run | CPU total | GPU total (end-to-end) | Ratio |
+|---|---|---|---|
+| 1 | 28.8 µs | 31.5 ms | GPU **1095x slower** |
+| 2 | 26.8 µs | 30.8 ms | GPU **1149x slower** |
+| 3 | 20.9 µs | 22.2 ms | GPU **1063x slower** |
+
+**Correctness:** `position[]` matches the CPU reference bit-for-bit,
+0 mismatches out of 10,000, on every run.
+
+**This spike does not win, and that is the honest, useful answer.** The
+per-item computation is a single multiply-add — nanoseconds of real work
+per row, ~20-29 µs total on the CPU for all 10,000 rows. A GPU dispatch's
+fixed cost (buffer/pipeline setup, driver command submission, the
+`poll(Wait)` round-trip to know the result is ready) is 20-32 **milliseconds**
+on this hardware — three orders of magnitude larger than the work being
+parallelized. No plausible per-item workload increase closes a 1000x gap;
+this isn't "the kernel needs tuning," it's "a single isolated dispatch for
+this problem shape cannot pay for itself here."
+
+**What this does and doesn't rule out for Phase 6.1.** It rules out
+"dispatch a GPU kernel per uniform-list layout, standalone, once per frame"
+as its own operation — that's a net loss at this item count on this
+hardware, almost certainly at any item count a real UI list actually
+reaches (the fixed dispatch cost doesn't shrink, and the CPU cost is already
+sub-microsecond-per-row). It does **not** rule out folding uniform-content
+layout into a compute pass that's *already resident and already dispatching
+anyway* — e.g. as one more pass inside the same command encoder Spike A's
+ordering/occlusion work already builds, paying zero additional dispatch
+overhead because the round-trip already exists for other reasons. That's a
+materially different question from the one this spike answers, and Phase
+6.1 should be scoped around it rather than around a standalone kernel.
+
+---
+
+## 6. Gate assessment
+
+§8's Phase 0 gate: *"Numbers exist, on real target hardware, for the two
+spikes that decide whether Phases 3 and 6.1 are worth building at all. If a
+spike doesn't win, the corresponding phase is rescoped or dropped here, not
+discovered mid-build."*
+
+**Spike A (feeds Phase 3, ordering + occlusion): wins, with real
+correctness validation, on real (if singular) hardware.** ~6-7x end-to-end
+speedup reproducibly, up to 14.7x on one run; exact bit-for-bit agreement
+with the production algorithm on both order and occlusion. Phase 3 is
+justified going into it. The caveat is breadth, not direction: this is one
+GPU, one driver, one OS — see §3's honesty note — and the synthetic scene's
+neighbor-search bound (via non-overlapping clusters) is a simplification
+that a real Phase 3 spatial-partitioning implementation still has to earn.
+
+**Spike B (feeds Phase 6.1, regular-content layout): does not win as a
+standalone operation, decisively (~1000x) and reproducibly, on the one
+piece of hardware tested.** Per §8's own instruction, this is the moment to
+rescope, not to discover this mid-build. Recommendation: **do not build a
+standalone GPU dispatch for uniform-list/regular-content layout.** Phase
+6.1 should instead be rescoped around folding regular-content position
+computation into the *same* compute pass/encoder Phase 3's ordering or
+indirect-arg-generation work already dispatches — the marginal cost of one
+more pass inside an already-justified round-trip is a fundamentally
+different (and still open) question this spike doesn't answer either way.
+If that folded-in version is worth building is a question for whoever scopes
+Phase 6.1's design, informed by Phase 3's actual shape once it exists — not
+answerable by a Phase 0 spike in isolation, since it depends on Phase 3
+infrastructure that doesn't exist yet.
+
+**Before Phase 1 starts, a human should:**
+
+1. Re-run both spikes (`cargo run -p wgpui-wgpu --example spike_a_ordering_occlusion --release`,
+   `...spike_b_uniform_layout --release`) on at least one non-discrete-NVIDIA
+   target — an integrated GPU and, ideally, macOS/Metal or Linux/Vulkan —
+   to confirm Spike A's win and Spike B's loss both hold outside this one
+   laptop's hardware/driver combination.
+2. Treat Spike A's reproducible ~6-7x, not the 14.7x outlier, as the number
+   that should inform Phase 3 scoping conversations.
+3. Decide, with Spike B's result in hand, whether Phase 6.1 is worth
+   scoping at all in its "folded into an existing pass" form, or whether
+   it should be dropped from the plan entirely until/unless Phase 3's shape
+   makes that folding concrete enough to spike again.
+
+**Workspace scaffold (Part 1): done, verified, zero deviation in behavior.**
+`cargo check --workspace` and the standalone `cargo check -p gpui-ce` both
+pass, with `gpui-ce`'s warning output byte-for-byte unchanged from the
+pre-workspace baseline. Phase 1 (the patch-list protocol, §8) can start
+without anything further here.


### PR DESCRIPTION
…PU spikes

Part 1 (mechanical scaffold, docs/gpu-native-architecture.md SS3/SS11):
- Convert root Cargo.toml to a [workspace]; gpui-ce stays a member with its public surface untouched (verified: cargo check -p gpui-ce produces the identical 72-warning baseline before and after).
- Add crates/wgpui-core, -layout, -text, -widgets, -wgpu, -devtools as thin stub skeletons matching SS3.1-3.6's file map, adapted to this repo's no-mod.rs convention (AGENTS.md). No todo!()/unimplemented!()/panic!(). Deviations from the literal file map are documented in docs/phase-0-results.md SS2.
- cargo check --workspace --offline passes with zero errors.

Part 2 (the two Phase 0 spikes, SS8's Phase 0 row):
- GPU adapter honesty check (examples/adapter_probe.rs): this environment has a real discrete NVIDIA RTX 4060 Laptop GPU via Vulkan, not a software/CI fallback.
- Spike A (examples/spike_a_ordering_occlusion.rs): 100K synthetic quads, GPU compute ordering (Jacobi relaxation + bitonic sort) + occlusion cull vs. a faithful port of src/bounds_tree.rs + src/scene.rs's CPU path. Result: GPU wins, ~6-7x reproducibly (up to 14.7x on one run), with exact bit-for-bit correctness validation against the CPU reference.
- Spike B (examples/spike_b_uniform_layout.rs): 10,000-row uniform-list layout as a single GPU compute dispatch vs. today's CPU loop (src/elements/uniform_list.rs). Result: GPU loses decisively and reproducibly (~1000x slower end-to-end) — dispatch/submit/poll overhead dwarfs the actual per-item work at this problem size. Phase 6.1 should be rescoped around folding into an already-dispatching pass, not a standalone kernel.
- Full methodology, honesty caveats (one adapter/one driver/one OS), and gate assessment in docs/phase-0-results.md.