### PR TITLE
Phase 4.5: the tile plane, its visibility predicate, and its budget

### DIFF
--- a/crates/wgpui-core/src/boundary.rs
+++ b/crates/wgpui-core/src/boundary.rs
@@ -22,6 +22,6 @@ pub mod compositor;
 pub mod identity;
 pub mod policy;
 
-pub use compositor::{BoundaryComposite, BoundaryState, Composite, Compositor};
+pub use compositor::{BoundaryComposite, BoundaryState, Composite, Compositor, TiledVisit};
 pub use identity::BoundaryIdentity;
 pub use policy::{BoundaryPolicy, Buffering, Pixels, Retention, Size};

--- a/crates/wgpui-core/src/boundary/compositor.rs
+++ b/crates/wgpui-core/src/boundary/compositor.rs
@@ -65,6 +65,7 @@ use crate::invalidation::axes::Invalidation;
 use crate::invalidation::reason::Reason;
 use crate::occlusion::coverage::{MAX_OCCLUDERS, OccluderStyle, fully_covered, opaque_region};
 use crate::scene::layer::{BoundaryId, LayerId, LayerKey, LayerTransform};
+use crate::scene::tile::{EvictedTile, TileCoord, TileGrid, TileResidency};
 use std::collections::HashMap;
 
 /// What a boundary does with its content this frame.
@@ -99,7 +100,11 @@ impl Composite {
 }
 
 /// One boundary's retained compositing state.
-#[derive(Copy, Clone, Debug, PartialEq)]
+///
+/// No longer `Copy` as of Phase 4.5: a tiled boundary carries its own
+/// [`TileResidency`], which owns a map. Every accessor still hands out a copy of
+/// the field it names, so nothing that read this type had to change.
+#[derive(Clone, Debug, PartialEq)]
 pub struct BoundaryState {
     policy: BoundaryPolicy,
     layer: LayerId,
@@ -107,6 +112,7 @@ pub struct BoundaryState {
     retention: Retention,
     primitive_count: usize,
     last_visited_frame: u64,
+    tiles: Option<TileResidency>,
 }
 
 impl BoundaryState {
@@ -139,6 +145,12 @@ impl BoundaryState {
     /// The last frame this boundary appeared in the tree.
     pub const fn last_visited_frame(&self) -> u64 {
         self.last_visited_frame
+    }
+
+    /// Which tiles of this boundary's content plane are resident, or `None` for
+    /// a boundary that is not tiled.
+    pub const fn tiles(&self) -> Option<&TileResidency> {
+        self.tiles.as_ref()
     }
 }
 
@@ -362,6 +374,67 @@ impl BoundaryComposite {
     }
 }
 
+/// What one tiled boundary's frame resolved to (§4.3).
+///
+/// Every field is a list of tiles the caller turns into ordinary layer work.
+/// Nothing here is a layer, a slab, or an invalidation — see
+/// [`Compositor::visit_tiled`] for why that separation is the phase's whole
+/// claim rather than a stylistic choice.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TiledVisit {
+    /// The boundary these tiles belong to.
+    pub boundary: BoundaryId,
+    /// Its grid.
+    pub grid: TileGrid,
+    /// The content-plane rectangle under the viewport at this pan offset.
+    pub content_viewport: Rect,
+    /// Every tile in range this frame, row-major and ascending.
+    pub visible: Vec<TileCoord>,
+    /// The tiles that were not resident before this frame — the `DISPLAY`
+    /// targets, and the number §8's Phase 4.5 gate measures on a crossing.
+    pub revealed: Vec<TileCoord>,
+    /// The tiles that left residency, and under which rule.
+    pub evicted: Vec<EvictedTile>,
+    /// Resident tiles the budget could not account for, all of them in range.
+    pub over_budget: usize,
+    /// How many tiles are resident after this frame's sweep.
+    pub resident: usize,
+}
+
+impl TiledVisit {
+    /// The layer holding one tile of this boundary.
+    pub fn tile_layer(&self, tile: TileCoord) -> LayerId {
+        LayerId::from_key(LayerKey::tiled(self.boundary, tile))
+    }
+
+    /// The unbuffered overlay layer holding content that spans tiles — see
+    /// [`crate::scene::TilePlacement`] for why that content is not clipped into
+    /// each tile instead.
+    ///
+    /// It is the boundary's plain untiled layer, which is the point: the overlay
+    /// is not a new kind of layer, it is the layer an untiled boundary would
+    /// have had anyway.
+    pub fn overlay_layer(&self) -> LayerId {
+        LayerId::from_key(LayerKey::untiled(self.boundary))
+    }
+
+    /// Every visible tile's layer, in draw order.
+    pub fn visible_layers(&self) -> Vec<LayerId> {
+        self.visible
+            .iter()
+            .map(|tile| self.tile_layer(*tile))
+            .collect()
+    }
+
+    /// Which layer a primitive with these content-plane bounds belongs in.
+    pub fn placement_layer(&self, bounds: Rect) -> LayerId {
+        match self.grid.placement(bounds) {
+            crate::scene::tile::TilePlacement::Tile(tile) => self.tile_layer(tile),
+            crate::scene::tile::TilePlacement::Overlay => self.overlay_layer(),
+        }
+    }
+}
+
 /// Every live compositing boundary, across frames.
 #[derive(Debug, Default)]
 pub struct Compositor {
@@ -398,10 +471,81 @@ impl Compositor {
                 retention: Retention::Primitives,
                 primitive_count: 0,
                 last_visited_frame: frame,
+                tiles: None,
             });
         state.policy = policy;
         state.last_visited_frame = frame;
         state.layer
+    }
+
+    /// Declare a [`crate::boundary::policy::Buffering::Tiled`] boundary and
+    /// resolve its live tile set for this frame.
+    ///
+    /// `viewport` is the boundary's visible rectangle in its own parent space;
+    /// the content-plane rectangle under it is derived from the transform the
+    /// boundary already has, so a caller pans by [`Compositor::set_transform`]
+    /// and this reports what that pan revealed.
+    ///
+    /// Returns `None` when the policy is not tiled, or when its tile size cannot
+    /// address the viewport at all — see [`crate::scene::TileSpan::MAX_TILES`].
+    /// Both mean the same thing to a caller: buffer this boundary the untiled
+    /// way, which [`Compositor::visit`] already did for it.
+    ///
+    /// # More than one `Layer` per boundary, and nothing else new
+    ///
+    /// §4.3's whole claim is that tiling "needs almost no new machinery," and
+    /// this method is where that is either true or not. What it does is call
+    /// [`crate::scene::TileGrid::visible_span`], hand the result to
+    /// [`TileResidency`], and name a [`LayerKey::tiled`] per surviving tile. It
+    /// creates no layer, allocates no slab, and raises no invalidation — every
+    /// one of those is the caller's ordinary machinery, applied to the layer
+    /// keys this returns:
+    ///
+    /// - A **revealed** tile becomes a layer nobody declared before, and
+    ///   [`crate::scene::layer::LayerTable::insert`] starts a new layer at
+    ///   `Invalidation::all()` on its own rule. That is §4.3's "crossing into a
+    ///   new tile triggers `DISPLAY` for *that tile alone*", and it needed no
+    ///   tile-specific code to happen.
+    /// - A **still-visible** tile is a layer that already exists, so declaring
+    ///   it again is idempotent and the pan reaches it as one
+    ///   [`crate::scene::layer::LayerTable::set_transform`] — `TRANSFORM` and
+    ///   nothing else, which is §5.4's path, live since Phase 2.
+    /// - An **evicted** tile is a layer the caller removes, releasing its slab
+    ///   through [`crate::scene::Scene::remove_layer`] like any other.
+    pub fn visit_tiled(
+        &mut self,
+        boundary: BoundaryId,
+        policy: BoundaryPolicy,
+        frame: u64,
+        viewport: Rect,
+    ) -> Option<TiledVisit> {
+        self.visit(boundary, policy, frame);
+        let grid = policy.buffering.tile_grid()?;
+        let state = self.boundaries.get_mut(&boundary)?;
+
+        let content_viewport = TileGrid::content_viewport(viewport, state.transform);
+        let span = grid.visible_span(content_viewport, policy.buffering.retain_radius())?;
+
+        let residency = state
+            .tiles
+            .get_or_insert_with(|| TileResidency::new(policy.resident_tile_budget));
+        // Re-applied every frame for the same reason `state.policy = policy`
+        // above is: a re-declared boundary's policy is the one it was declared
+        // with this frame, not the one it happened to be created with.
+        residency.set_budget(policy.resident_tile_budget);
+        let revealed = residency.mark(span, frame);
+        let evicted = residency.sweep(frame, policy.evict_after_frames);
+
+        Some(TiledVisit {
+            boundary,
+            grid,
+            content_viewport,
+            visible: span.tiles(),
+            revealed,
+            evicted,
+            over_budget: residency.over_budget(),
+            resident: residency.len(),
+        })
     }
 
     /// Move a boundary's content to `transform`, reporting whether that is a

--- a/crates/wgpui-core/src/boundary/compositor.rs
+++ b/crates/wgpui-core/src/boundary/compositor.rs
@@ -512,6 +512,26 @@ impl Compositor {
     ///   nothing else, which is §5.4's path, live since Phase 2.
     /// - An **evicted** tile is a layer the caller removes, releasing its slab
     ///   through [`crate::scene::Scene::remove_layer`] like any other.
+    ///
+    /// # Two ordering and lifetime facts worth knowing before calling this
+    ///
+    /// **Position the boundary after declaring it.**
+    /// [`Compositor::set_transform`] reports `false` rather than creating a
+    /// boundary, so moving one the compositor has never seen is inert and the
+    /// span below would resolve at the identity. On a boundary's first frame,
+    /// call [`Compositor::visit`] (or this method) before setting the transform
+    /// that positions it. Every later frame is unaffected.
+    ///
+    /// **A boundary switched away from `Tiled` keeps its tile layers until it is
+    /// swept.** This method returns `None` for a non-tiled policy without
+    /// touching the residency, so the tiles stay recorded and
+    /// [`Compositor::sweep`] still names them when the boundary itself is
+    /// evicted — nothing is lost, but nothing is released early either. Changing
+    /// a live boundary's buffering from `Tiled` to `Margin` therefore holds its
+    /// tile slabs until the boundary leaves the tree. Recorded rather than
+    /// fixed: releasing them here would mean this method returning layers on the
+    /// path where it reports having no tile set at all, and no caller in this
+    /// phase changes a boundary's buffering mid-life.
     pub fn visit_tiled(
         &mut self,
         boundary: BoundaryId,
@@ -637,12 +657,29 @@ impl Compositor {
     /// nothing else knows when the interval has elapsed.
     pub fn sweep(&mut self, frame: u64) -> Vec<LayerId> {
         let mut evicted = Vec::new();
-        self.boundaries.retain(|_, state| {
+        self.boundaries.retain(|boundary, state| {
             let elapsed = frame.saturating_sub(state.last_visited_frame);
             if elapsed <= u64::from(state.policy.evict_after_frames) {
                 return true;
             }
             evicted.push(state.layer);
+            // **Every** layer the boundary owned, not just its own. Before
+            // Phase 4.5 a boundary had exactly one layer and `state.layer` was
+            // the complete answer; a tiled boundary has one per resident tile,
+            // and dropping its `BoundaryState` here is what makes this the last
+            // moment anything knows those tiles existed. Returning only
+            // `state.layer` left every tile's slab reservation resident for the
+            // lifetime of the scene — this method's own doc is the argument for
+            // why: the layer entry "is the compositor's to release, and nothing
+            // else knows when the interval has elapsed."
+            if let Some(tiles) = &state.tiles {
+                evicted.extend(
+                    tiles
+                        .resident()
+                        .into_iter()
+                        .map(|tile| LayerId::from_key(LayerKey::tiled(*boundary, tile))),
+                );
+            }
             false
         });
         evicted
@@ -960,6 +997,150 @@ mod tests {
         assert_eq!(
             visible_composites(&[target, external]).first().copied(),
             Some(false)
+        );
+    }
+
+    fn tiled_policy() -> BoundaryPolicy {
+        BoundaryPolicy {
+            buffering: Buffering::Tiled {
+                tile_size: crate::boundary::policy::Size::pixels(256.0, 256.0),
+                retain_radius: 1,
+            },
+            ..BoundaryPolicy::default()
+        }
+    }
+
+    fn canvas_viewport() -> Rect {
+        Rect::from_origin_size([0.0, 0.0], [900.0, 600.0])
+    }
+
+    #[test]
+    fn a_tiled_boundary_resolves_a_visible_span_and_reveals_it_once() {
+        let mut compositor = Compositor::new();
+        let first = compositor
+            .visit_tiled(PANEL, tiled_policy(), 1, canvas_viewport())
+            .expect("a tiled policy with a usable tile size resolves");
+        assert!(first.visible.len() > 1, "a 900x600 viewport spans several tiles");
+        assert_eq!(
+            first.revealed.len(),
+            first.visible.len(),
+            "every tile is new on the first frame"
+        );
+        assert_eq!(first.resident, first.visible.len());
+        assert_eq!(first.over_budget, 0);
+
+        // The same frame again reveals nothing: residency is idempotent, the
+        // same way `visit` is.
+        let second = compositor
+            .visit_tiled(PANEL, tiled_policy(), 2, canvas_viewport())
+            .expect("still tiled");
+        assert!(second.revealed.is_empty());
+        assert_eq!(second.visible, first.visible);
+    }
+
+    #[test]
+    fn a_boundary_that_is_not_tiled_reports_no_tile_set_at_all() {
+        let mut compositor = Compositor::new();
+        assert!(
+            compositor
+                .visit_tiled(PANEL, BoundaryPolicy::default(), 1, canvas_viewport())
+                .is_none(),
+            "Margin(None) has no grid, so there is nothing to resolve"
+        );
+        assert!(
+            compositor
+                .visit_tiled(
+                    PANEL,
+                    BoundaryPolicy {
+                        buffering: Buffering::Tiled {
+                            tile_size: crate::boundary::policy::Size::pixels(0.0, 0.0),
+                            retain_radius: 1,
+                        },
+                        ..BoundaryPolicy::default()
+                    },
+                    1,
+                    canvas_viewport(),
+                )
+                .is_none(),
+            "an unusable tile size must fall back rather than resolve a grid"
+        );
+        // Either way the boundary itself is still declared — falling back means
+        // buffering it the untiled way, not dropping it.
+        assert!(compositor.state(PANEL).is_some());
+        assert!(
+            compositor
+                .state(PANEL)
+                .and_then(BoundaryState::tiles)
+                .is_none()
+        );
+    }
+
+    /// The bug this test exists because of: `sweep` returned only
+    /// `state.layer`, which was the complete answer when a boundary had exactly
+    /// one layer and silently leaked every tile's reservation once it could have
+    /// many.
+    #[test]
+    fn sweeping_a_tiled_boundary_names_every_layer_it_owned_not_just_its_own() {
+        let mut compositor = Compositor::new();
+        let visit = compositor
+            .visit_tiled(PANEL, tiled_policy(), 1, canvas_viewport())
+            .expect("a tiled boundary");
+        let tiles = visit.visible.clone();
+        assert!(tiles.len() > 4, "the premise: several tiles are resident");
+
+        let interval = u64::from(BoundaryPolicy::DEFAULT_EVICT_AFTER_FRAMES);
+        let evicted = compositor.sweep(2 + interval);
+        assert!(compositor.is_empty());
+
+        let expected: std::collections::BTreeSet<LayerId> = tiles
+            .iter()
+            .map(|tile| LayerId::from_key(LayerKey::tiled(PANEL, *tile)))
+            .chain(Some(LayerId::from_key(LayerKey::untiled(PANEL))))
+            .collect();
+        assert_eq!(
+            evicted.iter().copied().collect::<std::collections::BTreeSet<_>>(),
+            expected,
+            "an evicted tiled boundary must name its overlay and every resident \
+             tile, or their slab reservations outlive the scene"
+        );
+        assert_eq!(
+            evicted.len(),
+            tiles.len() + 1,
+            "and must not name any layer twice"
+        );
+    }
+
+    #[test]
+    fn panning_a_tiled_boundary_reveals_only_what_the_pan_uncovered() {
+        let mut compositor = Compositor::new();
+        // 8px in, so the viewport does not start on a tile boundary — see
+        // `ui_walk`'s gate for why that distinction is load-bearing.
+        compositor.set_transform(PANEL, LayerTransform::translated(-8.0, -8.0));
+        let first = compositor
+            .visit_tiled(PANEL, tiled_policy(), 1, canvas_viewport())
+            .expect("a tiled boundary");
+        assert!(
+            compositor.set_transform(PANEL, LayerTransform::translated(-8.0, -8.0)),
+            "the boundary now exists, so positioning it takes effect"
+        );
+
+        compositor.set_transform(PANEL, LayerTransform::translated(-264.0, -8.0));
+        let panned = compositor
+            .visit_tiled(PANEL, tiled_policy(), 2, canvas_viewport())
+            .expect("still tiled");
+        assert!(!panned.revealed.is_empty(), "one tile of pan reveals a column");
+        assert!(
+            panned.revealed.len() < first.visible.len(),
+            "a one-tile pan revealed {} of {} tiles, which is a refill",
+            panned.revealed.len(),
+            first.visible.len()
+        );
+        assert!(
+            panned
+                .revealed
+                .iter()
+                .all(|tile| !first.visible.contains(tile)),
+            "a tile already resident must not be reported as revealed"
         );
     }
 

--- a/crates/wgpui-core/src/boundary/policy.rs
+++ b/crates/wgpui-core/src/boundary/policy.rs
@@ -21,6 +21,8 @@
 //! their frozen counterparts have. Whichever phase moves geometry into the
 //! workspace replaces them and nothing else in this file changes.
 
+use crate::scene::tile::TileGrid;
+
 /// A length in logical pixels.
 #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
 pub struct Pixels(pub f32);
@@ -94,10 +96,15 @@ pub enum Buffering {
     /// arbitrarily-positioned, pannable-in-any-direction content, where
     /// `Margin` would have to grow multiplicatively in both axes.
     ///
-    /// **Not implemented in Phase 2.** A boundary declaring this is buffered as
-    /// `Margin(None)` today; see [`Buffering::is_implemented`].
+    /// Built in Phase 4.5: [`crate::scene::tile`] is the grid, the visibility
+    /// predicate, and the residency budget, and
+    /// [`crate::boundary::compositor::Compositor::visit_tiled`] is what a frame
+    /// calls to get this boundary's live tile set.
     Tiled {
         /// Edge length of one tile.
+        ///
+        /// [`crate::scene::TileGrid::DEFAULT_EDGE`] is the measured starting
+        /// point; see `docs/phase-4.5-results.md` for the sweep it came from.
         tile_size: Size<Pixels>,
         /// How many tiles beyond the viewport stay resident.
         retain_radius: u32,
@@ -120,25 +127,51 @@ impl Buffering {
     /// The overdraw margin this buffering asks for, given the boundary's
     /// viewport.
     ///
-    /// [`Buffering::Tiled`] reports the auto margin rather than a tile-derived
-    /// one: its own mechanism does not exist yet (Phase 4.5), and reporting
-    /// zero would silently make a boundary that asked for *more* buffering
-    /// receive *none*.
+    /// **[`Buffering::Tiled`] now reports its real margin**, which is its retain
+    /// radius measured in pixels — `retain_radius × tile_size` on each axis.
+    /// Until Phase 4.5 it reported the auto margin instead, as a placeholder
+    /// with a stated reason (reporting zero would have made a boundary asking
+    /// for *more* buffering receive none). That placeholder is closed: the
+    /// number below is what the mechanism actually keeps resident, so a caller
+    /// reading it gets an answer about this boundary rather than about the
+    /// variant it fell back to. A tile size this crate cannot build a grid from
+    /// still reports the auto margin, because such a boundary really does fall
+    /// back to untiled buffering — see
+    /// [`crate::boundary::compositor::Compositor::visit_tiled`].
     pub fn margin(self, viewport: Size<Pixels>) -> Size<Pixels> {
         match self {
             Buffering::None => Size::ZERO,
             Buffering::Margin(Some(margin)) => margin,
-            Buffering::Margin(None) | Buffering::Tiled { .. } => {
-                viewport.scaled(Self::AUTO_MARGIN_FRACTION)
-            }
+            Buffering::Margin(None) => viewport.scaled(Self::AUTO_MARGIN_FRACTION),
+            Buffering::Tiled {
+                tile_size,
+                retain_radius,
+            } => match TileGrid::new(tile_size) {
+                Some(_) => tile_size.scaled(retain_radius as f32),
+                None => viewport.scaled(Self::AUTO_MARGIN_FRACTION),
+            },
         }
     }
 
-    /// Whether this variant's own mechanism is built. `false` for
-    /// [`Buffering::Tiled`] until Phase 4.5, which is recorded here rather than
-    /// only in prose so a caller can assert on it.
-    pub const fn is_implemented(self) -> bool {
-        !matches!(self, Buffering::Tiled { .. })
+    /// The tile grid this buffering describes, or `None` for a variant that is
+    /// not tiled — or a tile size no grid can be built from.
+    ///
+    /// The two `None` cases are deliberately one: a caller's response to both is
+    /// the same, which is to buffer this boundary the untiled way.
+    pub fn tile_grid(self) -> Option<TileGrid> {
+        match self {
+            Buffering::Tiled { tile_size, .. } => TileGrid::new(tile_size),
+            _ => None,
+        }
+    }
+
+    /// How many tiles beyond the viewport this buffering keeps resident, or `0`
+    /// for a variant that has no tiles.
+    pub const fn retain_radius(self) -> u32 {
+        match self {
+            Buffering::Tiled { retain_radius, .. } => retain_radius,
+            _ => 0,
+        }
     }
 }
 
@@ -170,8 +203,19 @@ pub struct BoundaryPolicy {
     /// How this boundary buffers ahead of scroll or pan.
     pub buffering: Buffering,
     /// Frames a boundary may go unvisited before its retained resources are
-    /// returned to the pool (R-N §3.4's mark-and-sweep interval).
+    /// returned to the pool (R-N §3.4's mark-and-sweep interval). Under
+    /// [`Buffering::Tiled`] the same interval applies per tile, with "unvisited"
+    /// meaning "out of range" (§4.3).
     pub evict_after_frames: u32,
+    /// The total resident-tile cap for a [`Buffering::Tiled`] boundary, beyond
+    /// which the least recently visited tiles are evicted.
+    ///
+    /// §4.3 and §9's risk table both call this out as a first-class part of the
+    /// mechanism rather than a follow-up: `evict_after_frames` is a per-tile
+    /// timer, and an erratic pan can hold far more tiles inside that interval at
+    /// once than R-N's one-buffer-per-layer design ever had to bound. Ignored by
+    /// every other [`Buffering`] variant, which has one buffer and needs no cap.
+    pub resident_tile_budget: usize,
 }
 
 impl BoundaryPolicy {
@@ -180,6 +224,17 @@ impl BoundaryPolicy {
 
     /// R-N §3.4's default eviction interval, unchanged.
     pub const DEFAULT_EVICT_AFTER_FRAMES: u32 = 60;
+
+    /// The default resident-tile cap.
+    ///
+    /// Sized against what the default grid actually needs: a 2560×1440 viewport
+    /// at [`crate::scene::TileGrid::DEFAULT_EDGE`] with a retain radius of 1 is
+    /// 12×8 = 96 tiles in range, so a budget below that would be permanently
+    /// over-budget on an ordinary window. 256 leaves room for roughly two and a
+    /// half viewports' worth of recently-visited tiles beyond the live set,
+    /// which is what bounds a direction reversal without discarding the tiles it
+    /// is about to reverse back onto.
+    pub const DEFAULT_RESIDENT_TILE_BUDGET: usize = 256;
 
     /// Which retention a boundary holding `primitive_count` primitives gets.
     pub const fn retention_for(&self, primitive_count: usize) -> Retention {
@@ -197,6 +252,7 @@ impl Default for BoundaryPolicy {
             rasterize_above: Self::DEFAULT_RASTERIZE_ABOVE,
             buffering: Buffering::default(),
             evict_after_frames: Self::DEFAULT_EVICT_AFTER_FRAMES,
+            resident_tile_budget: Self::DEFAULT_RESIDENT_TILE_BUDGET,
         }
     }
 }
@@ -232,19 +288,42 @@ mod tests {
         );
     }
 
+    /// Phase 2 left this variant reporting `Margin(None)`'s auto margin with an
+    /// `is_implemented()` flag saying so. Phase 4.5 closes both: the margin is
+    /// now the retain radius in pixels, which is what the mechanism keeps.
     #[test]
-    fn tiled_is_declared_but_not_implemented_in_this_phase() {
+    fn a_tiled_boundarys_margin_is_its_retain_radius_in_pixels() {
         let tiled = Buffering::Tiled {
             tile_size: Size::pixels(256.0, 256.0),
-            retain_radius: 1,
+            retain_radius: 2,
         };
-        assert!(!tiled.is_implemented());
-        assert!(Buffering::default().is_implemented());
+        assert_eq!(tiled.margin(Size::pixels(800.0, 600.0)), Size::pixels(512.0, 512.0));
+        assert_eq!(tiled.retain_radius(), 2);
+        assert!(tiled.tile_grid().is_some());
+
+        let unbuffered = Buffering::Tiled {
+            tile_size: Size::pixels(256.0, 256.0),
+            retain_radius: 0,
+        };
+        assert_eq!(unbuffered.margin(Size::pixels(800.0, 600.0)), Size::ZERO);
+    }
+
+    #[test]
+    fn a_tile_size_no_grid_can_be_built_from_falls_back_to_the_auto_margin() {
+        // The fallback the Phase 2 placeholder's reasoning was right about, kept
+        // for the one case that still needs it: such a boundary really is
+        // buffered untiled, so reporting zero would still hand a boundary that
+        // asked for more buffering none at all.
+        let broken = Buffering::Tiled {
+            tile_size: Size::pixels(0.0, 0.0),
+            retain_radius: 4,
+        };
         assert_eq!(
-            tiled.margin(Size::pixels(800.0, 600.0)),
-            Buffering::Margin(None).margin(Size::pixels(800.0, 600.0)),
-            "an unbuilt variant must fall back to more buffering, never to none"
+            broken.margin(Size::pixels(800.0, 600.0)),
+            Buffering::Margin(None).margin(Size::pixels(800.0, 600.0))
         );
+        assert!(broken.tile_grid().is_none());
+        assert!(Buffering::default().tile_grid().is_none());
     }
 
     #[test]

--- a/crates/wgpui-core/src/scene.rs
+++ b/crates/wgpui-core/src/scene.rs
@@ -20,7 +20,10 @@ pub use primitive_store::{DrawRange, PrimitiveStore};
 pub use record::{DispatchNode, Hitbox, LayoutInput, RecordStore};
 pub use slab::{Reallocation, SlabAllocator, SlabOverflow};
 pub use slab_range::{SlabRange, UploadRange, coalesce_uploads, uploaded_byte_count};
-pub use tile::TileCoord;
+pub use tile::{
+    EvictedTile, TILE_DESCRIPTOR_STRIDE, TileCoord, TileDescriptor, TileEviction, TileGrid,
+    TilePlacement, TileResidency, TileSpan, TileVisibility, encode_tiles, tile_visibility,
+};
 
 use crate::indirect::{DrawSlot, SlotTable};
 use crate::patch::primitive::{GlyphRun, PrimitiveKind, Quad};

--- a/crates/wgpui-core/src/scene/tile.rs
+++ b/crates/wgpui-core/src/scene/tile.rs
@@ -218,6 +218,20 @@ impl TileGrid {
         }
     }
 
+    /// The smallest rectangle covering every tile in `tiles`, or
+    /// [`Rect::EMPTY`] for none.
+    pub fn bounds_of(&self, tiles: &[TileCoord]) -> Rect {
+        let mut bounds: Option<Rect> = None;
+        for tile in tiles {
+            let tile_bounds = self.tile_bounds(*tile);
+            bounds = Some(match bounds {
+                Some(existing) => existing.union(&tile_bounds),
+                None => tile_bounds,
+            });
+        }
+        bounds.unwrap_or(Rect::EMPTY)
+    }
+
     /// The tile containing a point on the content plane.
     pub fn containing(&self, point: [f32; 2]) -> TileCoord {
         TileCoord::new(
@@ -285,49 +299,101 @@ impl TileGrid {
     }
 
     /// Which layer a primitive with these bounds belongs in.
+    ///
+    /// A primitive no larger than a tile is **anchored** to the tile containing
+    /// its top-left corner, whether or not it overhangs into the neighbour.
+    /// Anything larger goes to the overlay. See [`TilePlacement`] for why that
+    /// is the rule, and [`TileGrid::overhang_is_covered`] for the one obligation
+    /// anchoring creates.
     pub fn placement(&self, bounds: Rect) -> TilePlacement {
-        match self.span(bounds) {
-            Some(span) if span.tile_count() == 1 => TilePlacement::Tile(span.min),
+        if bounds.is_empty() {
             // A degenerate primitive has no tile to be inside of, and putting it
             // on the overlay costs one never-visible instance rather than
             // needing a third case that means "nowhere".
-            _ => TilePlacement::Overlay,
+            return TilePlacement::Overlay;
         }
+        if bounds.width() > self.width || bounds.height() > self.height {
+            return TilePlacement::Overlay;
+        }
+        TilePlacement::Tile(self.containing([bounds.min_x, bounds.min_y]))
+    }
+
+    /// Whether a retain radius covers the overhang [`TileGrid::placement`]'s
+    /// anchoring can produce.
+    ///
+    /// **The correctness obligation anchoring creates, stated as a predicate
+    /// rather than as a comment.** An anchored primitive is at most one tile
+    /// wide, so it reaches at most one tile beyond the one it is anchored in. A
+    /// tile whose overhang is on screen must therefore still be resident, and a
+    /// retain radius of one or more guarantees exactly that: the tile behind the
+    /// visible edge is always in range. At radius zero it is not, and content
+    /// overhanging from the tile just off screen would go missing along that
+    /// edge.
+    ///
+    /// A caller that wants radius zero must have no anchored overhang, which in
+    /// practice means content strictly smaller than a tile *and* aligned to it —
+    /// so this returns `false` rather than trying to distinguish those.
+    pub const fn overhang_is_covered(retain_radius: u32) -> bool {
+        retain_radius >= 1
     }
 }
 
 /// Which of a tiled boundary's layers a primitive is emitted into.
 ///
-/// # The multi-tile content rule, chosen and stated once
+/// # The multi-tile content rule, chosen — and then corrected by measurement
 ///
-/// §4.3 offers two: clip a spanning primitive into each tile it crosses (what
-/// browser tiling does), or put it on an unbuffered overlay layer above the
-/// grid, "the same named pattern SFD §2 already proposes for hover-resolved
+/// §4.3 offers two options: clip a spanning primitive into each tile it crosses
+/// (what browser tiling does), or put it on an unbuffered overlay layer above
+/// the grid, "the same named pattern SFD §2 already proposes for hover-resolved
 /// content that can't cleanly live inside a buffer," with the instruction to
 /// "reuse that pattern rather than inventing a second one."
 ///
-/// **This picks the overlay**, for a reason that is about what exists rather
+/// **Clipping is not available here**, and that part is about what exists rather
 /// than about taste: per-tile clipping needs a per-primitive clip rectangle, and
-/// [`crate::patch::primitive::Quad`] does not have one — `docs/phase-1-results.md`
-/// §2 already recorded that absence. Clipping *geometrically* instead is not the
-/// same operation: shrinking a rounded, bordered quad's rectangle moves its
-/// corners and its border inward, so a node body straddling a tile edge would
-/// render as two differently-shaped halves. So clipping is not merely more work
-/// here, it is not yet expressible, and the version that is expressible is
-/// wrong.
+/// [`crate::patch::primitive::Quad`] does not have one —
+/// `docs/phase-1-results.md` §2 already recorded that absence. Clipping
+/// *geometrically* instead is a different operation: shrinking a rounded,
+/// bordered quad's rectangle moves its corners and its border inward, so a node
+/// body straddling a tile edge would render as two differently-shaped halves. So
+/// clipping is not merely more work, it is not yet expressible, and the version
+/// that is expressible is wrong.
 ///
-/// The overlay costs nothing new: it is [`crate::scene::layer::LayerKey::untiled`],
-/// the same layer an untiled boundary already uses, and it pans by `TRANSFORM`
-/// with the tiles. Its honest price is in `docs/phase-4.5-results.md`: overlay
-/// content is not tile-culled, so a graph whose wires are mostly long puts a
-/// growing always-resident layer above a well-bounded grid. Per-tile clipping
-/// becomes the better answer the moment `Quad` gains a content mask, and that is
-/// where the rule should be revisited.
+/// # Why "spanning ⇒ overlay" is not the rule, measured rather than reasoned
+///
+/// The obvious reading of the overlay option is "any primitive touching two
+/// tiles goes on the overlay." That was built first and it does not survive its
+/// own gate. On the node-graph workload — 130×70 nodes on a 256px grid — a node
+/// straddles a tile edge whenever its origin falls within 130px of one
+/// horizontally or 70px of one vertically, which is most of the tile: measured,
+/// **73% of the scene's primitives landed on the unbuffered layer**, and a tile
+/// crossing wrote 144 overlay primitives against 52 tile ones. The mechanism was
+/// technically working and buying almost nothing, because the layer that is not
+/// tile-culled held most of the content.
+///
+/// **So a primitive no larger than a tile is anchored to the tile holding its
+/// top-left corner, overhang and all**, and only genuinely oversized content —
+/// a wire spanning several columns, a group box around a whole subgraph —
+/// reaches the overlay. This is still the overlay pattern rather than a second
+/// one: the overlay exists, it holds what cannot be anchored, and it is
+/// [`crate::scene::layer::LayerKey::untiled`], the same layer an untiled
+/// boundary already has. What changed is only which content needs it.
+///
+/// Anchoring costs one obligation, and it is checkable rather than remembered:
+/// an anchored primitive reaches at most one tile past its own, so a tile must
+/// stay resident while its overhang is on screen. A retain radius of one or more
+/// guarantees that for free — see [`TileGrid::overhang_is_covered`].
+///
+/// The overlay's remaining price is in `docs/phase-4.5-results.md`: what sits
+/// there is not tile-culled, so a graph made mostly of very long wires still
+/// grows an always-resident layer. Per-tile clipping becomes the better answer
+/// the moment `Quad` gains a content mask, and that is where the rule should be
+/// revisited.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TilePlacement {
-    /// The primitive fits inside one tile and lives in that tile's layer.
+    /// The primitive is no larger than a tile and lives in the tile holding its
+    /// top-left corner, overhanging into the neighbour if it must.
     Tile(TileCoord),
-    /// The primitive spans more than one tile and lives on the boundary's
+    /// The primitive is larger than a tile and lives on the boundary's
     /// unbuffered overlay layer.
     Overlay,
 }
@@ -386,7 +452,7 @@ pub struct EvictedTile {
 /// next line of the frame is about to re-render would trade a memory bound for
 /// unbounded work. [`TileResidency::over_budget`] reports that state instead of
 /// hiding it.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TileResidency {
     tiles: HashMap<TileCoord, TileResidencyState>,
     budget: usize,
@@ -505,6 +571,12 @@ impl TileResidency {
     /// The resident-tile cap.
     pub const fn budget(&self) -> usize {
         self.budget
+    }
+
+    /// Change the cap. Takes effect at the next [`TileResidency::sweep`], so
+    /// lowering it never evicts anything the current frame is still using.
+    pub const fn set_budget(&mut self, budget: usize) {
+        self.budget = if budget > 1 { budget } else { 1 };
     }
 
     /// Whether this tile is resident.
@@ -815,7 +887,7 @@ mod tests {
     }
 
     #[test]
-    fn a_primitive_inside_one_tile_goes_to_that_tile_and_a_spanning_one_to_the_overlay() {
+    fn a_primitive_no_larger_than_a_tile_anchors_and_an_oversized_one_goes_to_the_overlay() {
         let grid = grid();
         assert_eq!(
             grid.placement(rect(10.0, 10.0, 40.0, 40.0)),
@@ -826,17 +898,68 @@ mod tests {
             TilePlacement::Tile(TileCoord::new(-1, -1))
         );
         assert_eq!(
-            grid.placement(rect(200.0, 10.0, 400.0, 10.0)),
-            TilePlacement::Overlay,
-            "a wire crossing a tile edge cannot be clipped without a content \
-             mask Quad does not have"
-        );
-        assert_eq!(
             grid.placement(rect(0.0, 0.0, 256.0, 256.0)),
             TilePlacement::Tile(TileCoord::ORIGIN),
-            "a primitive filling a tile exactly is inside it, not spanning"
+            "a primitive filling a tile exactly still fits in one"
+        );
+        // The correction this rule exists because of: a node straddling a tile
+        // edge anchors rather than falling out of the grid entirely.
+        assert_eq!(
+            grid.placement(rect(200.0, 10.0, 130.0, 70.0)),
+            TilePlacement::Tile(TileCoord::ORIGIN),
+            "a node overhanging into the next tile is anchored, not exiled to \
+             the overlay — see TilePlacement's doc for the 73% this measured"
+        );
+        assert_eq!(
+            grid.placement(rect(200.0, 10.0, 400.0, 10.0)),
+            TilePlacement::Overlay,
+            "a wire wider than a tile cannot be anchored without unbounded \
+             overhang"
+        );
+        assert_eq!(
+            grid.placement(rect(10.0, 10.0, 10.0, 300.0)),
+            TilePlacement::Overlay,
+            "oversized on either axis is enough"
         );
         assert_eq!(grid.placement(Rect::EMPTY), TilePlacement::Overlay);
+    }
+
+    /// Anchoring's one correctness obligation, checked rather than asserted in
+    /// prose: a primitive anchored in a tile that has itself gone out of view
+    /// must still be resident while the part of it that overhangs is on screen.
+    #[test]
+    fn an_anchored_primitives_overhang_is_still_resident_when_it_is_on_screen() {
+        let grid = grid();
+        assert!(TileGrid::overhang_is_covered(1));
+        assert!(!TileGrid::overhang_is_covered(0));
+
+        // A node anchored in tile (0,0), overhanging into (1,0).
+        let node = rect(200.0, 100.0, 130.0, 70.0);
+        let anchor = match grid.placement(node) {
+            TilePlacement::Tile(coord) => coord,
+            TilePlacement::Overlay => panic!("a 130x70 node fits in a 256px tile"),
+        };
+        assert_eq!(anchor, TileCoord::ORIGIN);
+        assert!(node.max_x > grid.tile_bounds(anchor).max_x, "it does overhang");
+
+        // A viewport showing only tile (1,0) — the overhang is visible and the
+        // tile it belongs to is not.
+        let viewport = grid.tile_bounds(TileCoord::new(1, 0));
+        let span = grid
+            .visible_span(viewport, 1)
+            .expect("one tile plus a ring is usable");
+        assert!(
+            span.contains(anchor),
+            "the retain radius must keep the anchoring tile resident, or the \
+             overhang goes missing along that edge"
+        );
+
+        // And at radius zero it genuinely would not, which is what makes
+        // `overhang_is_covered` a real constraint rather than a formality.
+        let bare = grid
+            .visible_span(viewport, 0)
+            .expect("one tile is usable");
+        assert!(!bare.contains(anchor));
     }
 
     #[test]

--- a/crates/wgpui-core/src/scene/tile.rs
+++ b/crates/wgpui-core/src/scene/tile.rs
@@ -201,7 +201,7 @@ impl TileGrid {
     pub fn new(tile_size: Size<Pixels>) -> Option<TileGrid> {
         let width = tile_size.width.value();
         let height = tile_size.height.value();
-        if !(width >= TileGrid::MIN_EDGE) || !(height >= TileGrid::MIN_EDGE) {
+        if !at_least_min_edge(width) || !at_least_min_edge(height) {
             return None;
         }
         Some(TileGrid { width, height })
@@ -729,6 +729,20 @@ pub fn tile_visibility(
         slots.push([tile.base, if visible { tile.count } else { 0 }, 0, 0]);
     }
     TileVisibility { slots, in_range }
+}
+
+/// Whether an edge length is usable, with NaN answering `false`.
+///
+/// Written against `partial_cmp` rather than as `!(edge >= MIN_EDGE)` for the
+/// reason [`Rect::is_empty`] gives for the same shape: the two spellings
+/// disagree on NaN, and this one has to answer "unusable" for it. A tile size
+/// that is not a number must produce no grid, not a grid whose arithmetic
+/// silently propagates NaN into every coordinate it computes.
+fn at_least_min_edge(edge: f32) -> bool {
+    matches!(
+        edge.partial_cmp(&TileGrid::MIN_EDGE),
+        Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
+    )
 }
 
 /// `f32::floor` narrowed to `i32`, saturating rather than wrapping.

--- a/crates/wgpui-core/src/scene/tile.rs
+++ b/crates/wgpui-core/src/scene/tile.rs
@@ -115,12 +115,23 @@ impl TileSpan {
     /// Every tile in the span, row-major and ascending — a deterministic order,
     /// so a caller that turns this into layers gets the same layer order every
     /// frame.
+    ///
+    /// **Stops at [`TileSpan::MAX_TILES`].** [`TileGrid::visible_span`] already
+    /// refuses to produce a span above that, so this cap is unreachable through
+    /// the path that resolves a frame's visibility. It exists because
+    /// [`TileSpan`] is two public coordinate pairs a caller can build directly,
+    /// and a span of a billion tiles would otherwise be a hang rather than an
+    /// error — which is a worse failure than a truncated list.
     pub fn tiles(&self) -> Vec<TileCoord> {
-        let mut tiles = Vec::with_capacity(self.tile_count().min(TileSpan::MAX_TILES) as usize);
+        let capacity = self.tile_count().min(TileSpan::MAX_TILES) as usize;
+        let mut tiles = Vec::with_capacity(capacity);
         let mut y = self.min.y;
         while y <= self.max.y {
             let mut x = self.min.x;
             while x <= self.max.x {
+                if tiles.len() >= capacity {
+                    return tiles;
+                }
                 tiles.push(TileCoord::new(x, y));
                 if x == i32::MAX {
                     break;
@@ -1161,6 +1172,19 @@ mod tests {
             visible - 8,
             "the shortfall is reported, not absorbed"
         );
+    }
+
+    #[test]
+    fn a_directly_built_span_of_a_billion_tiles_truncates_rather_than_hangs() {
+        // Unreachable through `visible_span`, which refuses such a span outright
+        // — but `TileSpan` is two public coordinate pairs, and a hang is a worse
+        // failure than a short list.
+        let span = TileSpan {
+            min: TileCoord::new(-1_000_000, -1_000_000),
+            max: TileCoord::new(1_000_000, 1_000_000),
+        };
+        assert!(span.tile_count() > TileSpan::MAX_TILES);
+        assert_eq!(span.tiles().len(), TileSpan::MAX_TILES as usize);
     }
 
     #[test]

--- a/crates/wgpui-core/src/scene/tile.rs
+++ b/crates/wgpui-core/src/scene/tile.rs
@@ -1,14 +1,37 @@
-//! `TileCoord` and the `(boundary, TileCoord)` half of a layer address.
+//! `TileCoord`, the tile plane's geometry, the visibility predicate, and the
+//! residency budget behind `Buffering::Tiled`.
 //! See docs/gpu-native-architecture.md §4.3.
 //!
-//! **Phase 1 defines the address, not the mechanism.** §4.3's tile grid — the
-//! visibility compute pass, spatial mark-and-sweep eviction, the resident-tile
-//! LRU budget — is Phase 4.5 work and none of it exists here. What exists is
-//! the observation §4.3 opens with: "a tile is just a `Layer`, addressed one
-//! dimension further." Making [`crate::scene::layer::LayerKey`] carry an
-//! optional tile coordinate from the start costs one field and means Phase 4.5
-//! extends a mechanism rather than reshaping the identity of every layer in a
-//! shipped scene.
+//! # A tile is a `Layer`, and that is the whole design
+//!
+//! §4.3 opens with the observation this file is built on: "a tile is just a
+//! `Layer`, addressed one dimension further." Everything a tile needs — its own
+//! instance arena, its own slab, its own place in occlusion culling and indirect
+//! draw issuance — is what a [`crate::scene::layer::Layer`] already is, so
+//! nothing here is a parallel tile-specific residency structure. What is here is
+//! only what a `Layer` cannot answer for itself:
+//!
+//! - **Where a tile sits on the content plane** ([`TileGrid`]), which is integer
+//!   arithmetic over a fixed edge length and nothing more.
+//! - **Which tiles are in range right now** ([`TileGrid::visible_span`]), which
+//!   is §4.3's "which tile coordinates intersect (viewport ∪ retain radius) at
+//!   the current pan offset" — the predicate `shaders/tile_visibility.wgsl`
+//!   transcribes and `wgpui-wgpu`'s differential checks for exact equality.
+//! - **Which tiles stay resident** ([`TileResidency`]), which is R-N §3.4's
+//!   mark-and-sweep triggered spatially instead of by visit, plus the total
+//!   resident-tile budget §4.3 and §9's risk table both call for.
+//!
+//! # Phase 1 defined the address; Phase 4.5 defines the mechanism
+//!
+//! [`TileCoord`] and [`crate::scene::layer::LayerKey::tiled`] shipped in Phase 1
+//! deliberately unused, so that this phase extends an addressing scheme rather
+//! than reshaping the identity of every layer in a shipped scene. Nothing about
+//! `LayerKey` changed here, which is the evidence that the bet paid.
+
+use crate::boundary::policy::{Pixels, Size};
+use crate::geometry::Rect;
+use crate::scene::layer::LayerTransform;
+use std::collections::HashMap;
 
 /// A tile's integer coordinate on its boundary's content plane.
 ///
@@ -34,13 +57,1072 @@ impl TileCoord {
     }
 }
 
+/// An inclusive rectangle of tile coordinates.
+///
+/// Inclusive rather than half-open because it is produced by rounding a float
+/// rectangle outward on both edges, and a half-open form would need one of the
+/// two roundings to be spelled differently from the other — which is exactly
+/// where an off-by-one lives.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct TileSpan {
+    /// Top-left tile, inclusive.
+    pub min: TileCoord,
+    /// Bottom-right tile, inclusive.
+    pub max: TileCoord,
+}
+
+impl TileSpan {
+    /// The largest tile count [`TileGrid::visible_span`] will produce.
+    ///
+    /// Not a tuning knob — a guard. A span is derived from a viewport divided by
+    /// an author-chosen tile size, so an author who asks for 1px tiles on a 4K
+    /// viewport asks for eight million layers. Every real configuration is far
+    /// under this: a 3840×2160 viewport with 256px tiles and a retain radius of
+    /// 2 is 19×13 = 247 tiles. A span that would exceed it is reported as
+    /// unusable rather than materialized, so the caller falls back to untiled
+    /// buffering instead of the process dying.
+    pub const MAX_TILES: u64 = 4_096;
+
+    /// The span holding exactly one tile.
+    pub const fn single(coord: TileCoord) -> TileSpan {
+        TileSpan {
+            min: coord,
+            max: coord,
+        }
+    }
+
+    /// How many tiles this span covers.
+    ///
+    /// `u64` because the two coordinates are `i32`s the caller chose and their
+    /// difference does not fit in one.
+    pub fn tile_count(&self) -> u64 {
+        let width = i64::from(self.max.x) - i64::from(self.min.x) + 1;
+        let height = i64::from(self.max.y) - i64::from(self.min.y) + 1;
+        if width <= 0 || height <= 0 {
+            return 0;
+        }
+        (width as u64).saturating_mul(height as u64)
+    }
+
+    /// Whether `coord` lies in this span.
+    pub fn contains(&self, coord: TileCoord) -> bool {
+        coord.x >= self.min.x
+            && coord.x <= self.max.x
+            && coord.y >= self.min.y
+            && coord.y <= self.max.y
+    }
+
+    /// Every tile in the span, row-major and ascending — a deterministic order,
+    /// so a caller that turns this into layers gets the same layer order every
+    /// frame.
+    pub fn tiles(&self) -> Vec<TileCoord> {
+        let mut tiles = Vec::with_capacity(self.tile_count().min(TileSpan::MAX_TILES) as usize);
+        let mut y = self.min.y;
+        while y <= self.max.y {
+            let mut x = self.min.x;
+            while x <= self.max.x {
+                tiles.push(TileCoord::new(x, y));
+                if x == i32::MAX {
+                    break;
+                }
+                x += 1;
+            }
+            if y == i32::MAX {
+                break;
+            }
+            y += 1;
+        }
+        tiles
+    }
+
+    /// This span grown by `radius` tiles on every side, saturating at the
+    /// coordinate space's edges.
+    pub fn expanded(&self, radius: u32) -> TileSpan {
+        let radius = i32::try_from(radius).unwrap_or(i32::MAX);
+        TileSpan {
+            min: TileCoord::new(
+                self.min.x.saturating_sub(radius),
+                self.min.y.saturating_sub(radius),
+            ),
+            max: TileCoord::new(
+                self.max.x.saturating_add(radius),
+                self.max.y.saturating_add(radius),
+            ),
+        }
+    }
+}
+
+/// Where a boundary's tiles sit on its content plane.
+///
+/// Holds one thing — the tile edge length — because that is the only degree of
+/// freedom §4.3 grants. Multi-resolution tiling is explicitly rejected (§10), so
+/// there is no scale here and a zoom change re-renders at the new scale exactly
+/// as `Buffering::Margin` does.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct TileGrid {
+    width: f32,
+    height: f32,
+}
+
+impl TileGrid {
+    /// The smallest tile edge that can produce a usable grid.
+    ///
+    /// Below a pixel a "tile" addresses less than one sample, and the span
+    /// arithmetic stops being meaningful before it stops being finite.
+    pub const MIN_EDGE: f32 = 1.0;
+
+    /// The starting tile edge, in logical pixels.
+    ///
+    /// §4.3 asks for "a starting size from common compositor practice (roughly
+    /// 256–512px)" *validated against a representative node-graph workload, not
+    /// asserted*. 256 is the low end of that range, and
+    /// `wgpui-wgpu/examples/phase45_tiling_bench.rs` is the validation — see
+    /// `docs/phase-4.5-results.md` for the measured sweep this number came out
+    /// of, which is the reason it is 256 and not 512.
+    pub const DEFAULT_EDGE: f32 = 256.0;
+
+    /// A grid of `tile_size` tiles, or `None` if that size cannot address a
+    /// plane.
+    ///
+    /// Fallible rather than clamping: a caller that asked for a zero or negative
+    /// tile size has a bug, and silently substituting a working size would hide
+    /// it behind a grid that quietly is not the one requested.
+    pub fn new(tile_size: Size<Pixels>) -> Option<TileGrid> {
+        let width = tile_size.width.value();
+        let height = tile_size.height.value();
+        if !(width >= TileGrid::MIN_EDGE) || !(height >= TileGrid::MIN_EDGE) {
+            return None;
+        }
+        Some(TileGrid { width, height })
+    }
+
+    /// A square grid of `edge`-pixel tiles.
+    pub fn square(edge: f32) -> Option<TileGrid> {
+        TileGrid::new(Size::pixels(edge, edge))
+    }
+
+    /// The tile edge lengths.
+    pub fn tile_size(&self) -> Size<Pixels> {
+        Size::pixels(self.width, self.height)
+    }
+
+    /// Where `coord`'s tile sits on the content plane.
+    pub fn tile_bounds(&self, coord: TileCoord) -> Rect {
+        let min_x = coord.x as f32 * self.width;
+        let min_y = coord.y as f32 * self.height;
+        Rect {
+            min_x,
+            min_y,
+            max_x: min_x + self.width,
+            max_y: min_y + self.height,
+        }
+    }
+
+    /// The tile containing a point on the content plane.
+    pub fn containing(&self, point: [f32; 2]) -> TileCoord {
+        TileCoord::new(
+            floor_to_i32(point[0] / self.width),
+            floor_to_i32(point[1] / self.height),
+        )
+    }
+
+    /// The tiles `region` intersects, or `None` when it encloses no area.
+    ///
+    /// **The edge rule matches [`Rect::intersects`] exactly**, and that is
+    /// load-bearing rather than incidental: a region whose right edge lands
+    /// exactly on a tile boundary does not reach into the next tile, the same
+    /// way two rectangles that merely touch along an edge do not intersect
+    /// anywhere else in this crate. `shaders/tile_visibility.wgsl` gets the same
+    /// answer by testing rectangles directly rather than by dividing, and
+    /// `visible_span_agrees_with_a_direct_rectangle_test` pins the two
+    /// formulations together.
+    pub fn span(&self, region: Rect) -> Option<TileSpan> {
+        if region.is_empty() {
+            return None;
+        }
+        Some(TileSpan {
+            min: TileCoord::new(
+                floor_to_i32(region.min_x / self.width),
+                floor_to_i32(region.min_y / self.height),
+            ),
+            max: TileCoord::new(
+                ceil_to_i32(region.max_x / self.width).saturating_sub(1),
+                ceil_to_i32(region.max_y / self.height).saturating_sub(1),
+            ),
+        })
+    }
+
+    /// The content-plane rectangle currently under `viewport`, given where the
+    /// boundary's layers composite.
+    ///
+    /// A layer transform displaces content, so the plane slides under a fixed
+    /// window by the negative of it. Spelled as its own function rather than
+    /// inlined at the two call sites because getting its sign wrong produces a
+    /// grid that pans the wrong way — visibly, but only once a real window
+    /// exists to see it in.
+    pub fn content_viewport(viewport: Rect, transform: LayerTransform) -> Rect {
+        let [x, y] = transform.translation;
+        Rect {
+            min_x: viewport.min_x - x,
+            min_y: viewport.min_y - y,
+            max_x: viewport.max_x - x,
+            max_y: viewport.max_y - y,
+        }
+    }
+
+    /// §4.3's visibility set: the tiles intersecting (viewport ∪ retain radius)
+    /// at the current pan offset.
+    ///
+    /// `None` when the viewport encloses no area, or when this tile size would
+    /// put more than [`TileSpan::MAX_TILES`] tiles in range — see that constant
+    /// for why the second case is reported rather than materialized.
+    pub fn visible_span(&self, content_viewport: Rect, retain_radius: u32) -> Option<TileSpan> {
+        let span = self.span(content_viewport)?.expanded(retain_radius);
+        if span.tile_count() > TileSpan::MAX_TILES {
+            return None;
+        }
+        Some(span)
+    }
+
+    /// Which layer a primitive with these bounds belongs in.
+    pub fn placement(&self, bounds: Rect) -> TilePlacement {
+        match self.span(bounds) {
+            Some(span) if span.tile_count() == 1 => TilePlacement::Tile(span.min),
+            // A degenerate primitive has no tile to be inside of, and putting it
+            // on the overlay costs one never-visible instance rather than
+            // needing a third case that means "nowhere".
+            _ => TilePlacement::Overlay,
+        }
+    }
+}
+
+/// Which of a tiled boundary's layers a primitive is emitted into.
+///
+/// # The multi-tile content rule, chosen and stated once
+///
+/// §4.3 offers two: clip a spanning primitive into each tile it crosses (what
+/// browser tiling does), or put it on an unbuffered overlay layer above the
+/// grid, "the same named pattern SFD §2 already proposes for hover-resolved
+/// content that can't cleanly live inside a buffer," with the instruction to
+/// "reuse that pattern rather than inventing a second one."
+///
+/// **This picks the overlay**, for a reason that is about what exists rather
+/// than about taste: per-tile clipping needs a per-primitive clip rectangle, and
+/// [`crate::patch::primitive::Quad`] does not have one — `docs/phase-1-results.md`
+/// §2 already recorded that absence. Clipping *geometrically* instead is not the
+/// same operation: shrinking a rounded, bordered quad's rectangle moves its
+/// corners and its border inward, so a node body straddling a tile edge would
+/// render as two differently-shaped halves. So clipping is not merely more work
+/// here, it is not yet expressible, and the version that is expressible is
+/// wrong.
+///
+/// The overlay costs nothing new: it is [`crate::scene::layer::LayerKey::untiled`],
+/// the same layer an untiled boundary already uses, and it pans by `TRANSFORM`
+/// with the tiles. Its honest price is in `docs/phase-4.5-results.md`: overlay
+/// content is not tile-culled, so a graph whose wires are mostly long puts a
+/// growing always-resident layer above a well-bounded grid. Per-tile clipping
+/// becomes the better answer the moment `Quad` gains a content mask, and that is
+/// where the rule should be revisited.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TilePlacement {
+    /// The primitive fits inside one tile and lives in that tile's layer.
+    Tile(TileCoord),
+    /// The primitive spans more than one tile and lives on the boundary's
+    /// unbuffered overlay layer.
+    Overlay,
+}
+
+/// One resident tile's bookkeeping.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct TileResidencyState {
+    /// The last frame this tile was in range.
+    pub last_visited_frame: u64,
+    /// A monotonic stamp, assigned in visit order.
+    ///
+    /// The LRU order is taken from this rather than from `last_visited_frame`
+    /// because a whole span shares one frame number, and an eviction order that
+    /// ties across a hundred tiles would be decided by hash iteration order —
+    /// which is to say, not decided. This makes it total and reproducible.
+    pub last_touch: u64,
+}
+
+/// Why a tile stopped being resident.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TileEviction {
+    /// It sat outside (viewport ∪ retain radius) for longer than
+    /// `evict_after_frames` — R-N §3.4's mark-and-sweep, triggered spatially.
+    OutOfRange,
+    /// It was the least recently visited tile still over the budget.
+    Budget,
+}
+
+/// One tile leaving residency.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EvictedTile {
+    /// Which tile.
+    pub coord: TileCoord,
+    /// Why.
+    pub reason: TileEviction,
+}
+
+/// Which tiles of one boundary are resident, and what leaves.
+///
+/// # Two mechanisms, because one was never enough
+///
+/// R-N §3.4's mark-and-sweep is a per-item timer, and §4.3 says plainly why it
+/// does not bound a tile grid on its own: "an erratic pan pattern (fast diagonal
+/// movement, frequent direction reversal) can keep many tiles within 'recently
+/// visited' simultaneously … a freeform 2D plane can have far more live tiles
+/// than a typical UI ever had layers." So there are two:
+///
+/// 1. [`TileResidency::sweep`] evicts tiles out of range for longer than the
+///    boundary's `evict_after_frames`. This is R-N's mechanism unchanged, with
+///    "unvisited" meaning "not in range" instead of "not in the tree".
+/// 2. The same call then evicts least-recently-visited tiles until the resident
+///    count is inside `budget`.
+///
+/// **A tile in range this frame is never evicted by either.** The budget cannot
+/// be honoured against a visible set larger than itself, and evicting a tile the
+/// next line of the frame is about to re-render would trade a memory bound for
+/// unbounded work. [`TileResidency::over_budget`] reports that state instead of
+/// hiding it.
+#[derive(Clone, Debug)]
+pub struct TileResidency {
+    tiles: HashMap<TileCoord, TileResidencyState>,
+    budget: usize,
+    next_touch: u64,
+    over_budget: usize,
+}
+
+impl TileResidency {
+    /// A residency holding nothing, capped at `budget` tiles.
+    pub fn new(budget: usize) -> TileResidency {
+        TileResidency {
+            tiles: HashMap::new(),
+            budget: budget.max(1),
+            next_touch: 0,
+            over_budget: 0,
+        }
+    }
+
+    /// Mark every tile of `span` in range as of `frame`, returning the ones that
+    /// were not resident before.
+    ///
+    /// Those are the newly-revealed tiles — §4.3's "crossing into a new tile
+    /// triggers `DISPLAY` for *that tile alone*". The caller turns each into a
+    /// `LayerKey::tiled` layer, and a brand-new layer starts fully invalidated
+    /// by [`crate::scene::layer::LayerTable::insert`]'s own rule, so nothing
+    /// here has to special-case a tile into being dirty.
+    ///
+    /// Returned sorted, so a frame's newly-revealed set is a reproducible list
+    /// rather than a hash order.
+    pub fn mark(&mut self, span: TileSpan, frame: u64) -> Vec<TileCoord> {
+        let mut revealed = Vec::new();
+        for coord in span.tiles() {
+            self.next_touch = self.next_touch.wrapping_add(1);
+            let touch = self.next_touch;
+            match self.tiles.get_mut(&coord) {
+                Some(state) => {
+                    state.last_visited_frame = frame;
+                    state.last_touch = touch;
+                }
+                None => {
+                    self.tiles.insert(
+                        coord,
+                        TileResidencyState {
+                            last_visited_frame: frame,
+                            last_touch: touch,
+                        },
+                    );
+                    revealed.push(coord);
+                }
+            }
+        }
+        revealed.sort_unstable();
+        revealed
+    }
+
+    /// Evict everything out of range for too long, then everything over budget.
+    ///
+    /// Returns what left, sorted, each with the rule that removed it. See this
+    /// type's doc for why a tile visited on `frame` survives both rules.
+    pub fn sweep(&mut self, frame: u64, evict_after_frames: u32) -> Vec<EvictedTile> {
+        let mut evicted = Vec::new();
+        self.tiles.retain(|coord, state| {
+            if state.last_visited_frame >= frame {
+                return true;
+            }
+            let elapsed = frame.saturating_sub(state.last_visited_frame);
+            if elapsed <= u64::from(evict_after_frames) {
+                return true;
+            }
+            evicted.push(EvictedTile {
+                coord: *coord,
+                reason: TileEviction::OutOfRange,
+            });
+            false
+        });
+
+        // LRU beyond the budget. Candidates are only tiles not in range this
+        // frame, so the loop terminates whether or not the budget can be met.
+        let mut candidates: Vec<(u64, TileCoord)> = self
+            .tiles
+            .iter()
+            .filter(|(_, state)| state.last_visited_frame < frame)
+            .map(|(coord, state)| (state.last_touch, *coord))
+            .collect();
+        candidates.sort_unstable();
+        let mut over = self.tiles.len().saturating_sub(self.budget);
+        for (_, coord) in candidates {
+            if over == 0 {
+                break;
+            }
+            if self.tiles.remove(&coord).is_some() {
+                evicted.push(EvictedTile {
+                    coord,
+                    reason: TileEviction::Budget,
+                });
+                over -= 1;
+            }
+        }
+        self.over_budget = over;
+
+        evicted.sort_unstable_by_key(|entry| entry.coord);
+        evicted
+    }
+
+    /// How many tiles the budget could not account for after the last
+    /// [`TileResidency::sweep`], because they were all in range.
+    ///
+    /// Non-zero means the visible set alone is larger than the budget, i.e. the
+    /// tile size is too small or the budget too tight for this viewport. Not an
+    /// error and not silently absorbed: a caller that wants to know it is paying
+    /// more than it asked for can read it.
+    pub const fn over_budget(&self) -> usize {
+        self.over_budget
+    }
+
+    /// The resident-tile cap.
+    pub const fn budget(&self) -> usize {
+        self.budget
+    }
+
+    /// Whether this tile is resident.
+    pub fn contains(&self, coord: TileCoord) -> bool {
+        self.tiles.contains_key(&coord)
+    }
+
+    /// One tile's bookkeeping.
+    pub fn state(&self, coord: TileCoord) -> Option<TileResidencyState> {
+        self.tiles.get(&coord).copied()
+    }
+
+    /// Every resident tile, sorted.
+    pub fn resident(&self) -> Vec<TileCoord> {
+        let mut tiles: Vec<TileCoord> = self.tiles.keys().copied().collect();
+        tiles.sort_unstable();
+        tiles
+    }
+
+    /// How many tiles are resident.
+    pub fn len(&self) -> usize {
+        self.tiles.len()
+    }
+
+    /// Whether no tile is resident.
+    pub fn is_empty(&self) -> bool {
+        self.tiles.is_empty()
+    }
+}
+
+/// One resident tile's descriptor, as `shaders/tile_visibility.wgsl` reads it.
+///
+/// Carries the tile's coordinate *and* its slab reservation, because the pass's
+/// whole job is to turn the first into a decision about the second without the
+/// CPU deciding which tiles draw.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct TileDescriptor {
+    /// Which tile.
+    pub coord: TileCoord,
+    /// Its layer's reservation base in the kind's arena.
+    pub base: u32,
+    /// Slots reserved there.
+    pub count: u32,
+}
+
+/// Bytes one [`TileDescriptor`] occupies on the device: `[x, y, base, count]`
+/// as a `vec4<u32>`, with the coordinate's two `i32`s bit-cast in place.
+pub const TILE_DESCRIPTOR_STRIDE: usize = 16;
+
+/// Encode tile descriptors for `shaders/tile_visibility.wgsl`.
+///
+/// Byte-oriented for the reason `patch/primitive.rs` gives: it keeps
+/// `wgpui-core` dependency-free and makes the GPU layout an explicit decision.
+pub fn encode_tiles(tiles: &[TileDescriptor], destination: &mut Vec<u8>) {
+    destination.clear();
+    destination.reserve(tiles.len() * TILE_DESCRIPTOR_STRIDE);
+    for tile in tiles {
+        for value in [
+            tile.coord.x as u32,
+            tile.coord.y as u32,
+            tile.base,
+            tile.count,
+        ] {
+            destination.extend_from_slice(&value.to_le_bytes());
+        }
+    }
+}
+
+/// What the tile-visibility pass decides, as plain data.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TileVisibility {
+    /// One `[base, count, 0, 0]` record per tile, in the order the descriptors
+    /// were given — exactly [`crate::indirect::encode_slots`]' layout, because
+    /// this *is* the slot table the indirect-arg pass then consumes.
+    ///
+    /// An out-of-range tile's `count` is zero, so Phase 4's `compact` writes it
+    /// a zero-instance argument record and `pack` drops it. Nothing new draws;
+    /// the existing mechanism simply finds nothing to draw for that tile.
+    pub slots: Vec<[u32; 4]>,
+    /// One flag per tile: `1` in range, `0` out. Not read by the draw path — it
+    /// exists so the differential can say *which* tile disagreed rather than
+    /// only that a slot did.
+    pub in_range: Vec<u32>,
+}
+
+impl TileVisibility {
+    /// How many tiles were in range.
+    pub fn visible_count(&self) -> usize {
+        self.in_range.iter().filter(|flag| **flag != 0).count()
+    }
+
+    /// The slot records, encoded as [`crate::indirect::encode_slots`] would.
+    pub fn encode_slots(&self, destination: &mut Vec<u8>) {
+        destination.clear();
+        destination.reserve(self.slots.len() * 16);
+        for slot in &self.slots {
+            for value in slot {
+                destination.extend_from_slice(&value.to_le_bytes());
+            }
+        }
+    }
+}
+
+/// The CPU reference `shaders/tile_visibility.wgsl` transcribes.
+///
+/// For each descriptor, decide whether its tile intersects the content-space
+/// viewport dilated by `retain_radius` tiles, and emit that tile's draw slot
+/// with its real reservation count if so and zero if not.
+///
+/// **The dilation is exact, not approximate.** Growing the viewport rectangle by
+/// `retain_radius × tile_size` on each side selects precisely the same tiles as
+/// growing [`TileGrid::span`]'s result by `retain_radius` coordinates, because
+/// tile edges sit at exact multiples of the tile size — so `floor((min - r·w)/w)`
+/// *is* `floor(min/w) - r`. That equivalence is what lets the shader test
+/// rectangles (cheap, branch-free, no division) while
+/// [`TileResidency`] works in coordinates, and
+/// `visible_span_agrees_with_a_direct_rectangle_test` asserts it rather than
+/// trusting this paragraph.
+pub fn tile_visibility(
+    grid: &TileGrid,
+    tiles: &[TileDescriptor],
+    content_viewport: Rect,
+    retain_radius: u32,
+) -> TileVisibility {
+    let margin_x = retain_radius as f32 * grid.width;
+    let margin_y = retain_radius as f32 * grid.height;
+    let range = Rect {
+        min_x: content_viewport.min_x - margin_x,
+        min_y: content_viewport.min_y - margin_y,
+        max_x: content_viewport.max_x + margin_x,
+        max_y: content_viewport.max_y + margin_y,
+    };
+    let mut slots = Vec::with_capacity(tiles.len());
+    let mut in_range = Vec::with_capacity(tiles.len());
+    for tile in tiles {
+        let bounds = grid.tile_bounds(tile.coord);
+        let visible = range.intersects(&bounds);
+        in_range.push(u32::from(visible));
+        slots.push([tile.base, if visible { tile.count } else { 0 }, 0, 0]);
+    }
+    TileVisibility { slots, in_range }
+}
+
+/// `f32::floor` narrowed to `i32`, saturating rather than wrapping.
+///
+/// `as` on an out-of-range float already saturates in Rust, and NaN becomes
+/// zero; both are spelled out here because a coordinate that silently wrapped
+/// would alias two distant tiles onto one address, which is the exact failure
+/// [`TileCoord`] being signed exists to prevent.
+fn floor_to_i32(value: f32) -> i32 {
+    if value.is_nan() {
+        return 0;
+    }
+    value.floor() as i32
+}
+
+fn ceil_to_i32(value: f32) -> i32 {
+    if value.is_nan() {
+        return 0;
+    }
+    value.ceil() as i32
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn grid() -> TileGrid {
+        TileGrid::square(256.0).expect("256px is a usable tile edge")
+    }
+
+    fn rect(x: f32, y: f32, width: f32, height: f32) -> Rect {
+        Rect::from_origin_size([x, y], [width, height])
+    }
 
     #[test]
     fn negative_coordinates_are_distinct_addresses() {
         assert_ne!(TileCoord::new(-1, 0), TileCoord::new(1, 0));
         assert_ne!(TileCoord::new(0, -1), TileCoord::ORIGIN);
+    }
+
+    #[test]
+    fn a_plane_has_no_origin_corner_so_panning_up_and_left_addresses_negatives() {
+        let grid = grid();
+        assert_eq!(grid.containing([-1.0, -1.0]), TileCoord::new(-1, -1));
+        assert_eq!(grid.containing([0.0, 0.0]), TileCoord::ORIGIN);
+        assert_eq!(grid.containing([-256.0, 0.0]), TileCoord::new(-1, 0));
+        assert_eq!(grid.containing([-257.0, 0.0]), TileCoord::new(-2, 0));
+        assert_eq!(
+            grid.tile_bounds(TileCoord::new(-1, -2)),
+            rect(-256.0, -512.0, 256.0, 256.0)
+        );
+    }
+
+    #[test]
+    fn a_region_ending_exactly_on_a_tile_edge_does_not_reach_into_the_next_tile() {
+        let grid = grid();
+        assert_eq!(
+            grid.span(rect(0.0, 0.0, 512.0, 256.0)),
+            Some(TileSpan {
+                min: TileCoord::ORIGIN,
+                max: TileCoord::new(1, 0),
+            }),
+            "the same strictness Rect::intersects has everywhere else in the crate"
+        );
+        assert_eq!(
+            grid.span(rect(0.0, 0.0, 513.0, 256.0)).map(|s| s.max),
+            Some(TileCoord::new(2, 0))
+        );
+        assert_eq!(grid.span(rect(10.0, 10.0, 0.0, 100.0)), None);
+    }
+
+    /// The equivalence `tile_visibility`'s doc rests on: dilating the rectangle
+    /// by `radius × tile_size` picks exactly the tiles that dilating the span by
+    /// `radius` coordinates picks. The shader does the first; residency does the
+    /// second. If they ever disagree, a tile draws that nothing rendered into.
+    #[test]
+    fn visible_span_agrees_with_a_direct_rectangle_test() {
+        let grid = grid();
+        for radius in 0..3u32 {
+            for step in 0..40 {
+                let viewport = rect(
+                    step as f32 * 37.0 - 400.0,
+                    step as f32 * 23.0 - 300.0,
+                    900.0,
+                    600.0,
+                );
+                let span = grid
+                    .visible_span(viewport, radius)
+                    .expect("a 900x600 viewport on a 256px grid is usable");
+                let descriptors: Vec<TileDescriptor> = span
+                    .expanded(2)
+                    .tiles()
+                    .into_iter()
+                    .map(|coord| TileDescriptor {
+                        coord,
+                        base: 0,
+                        count: 1,
+                    })
+                    .collect();
+                let visibility = tile_visibility(&grid, &descriptors, viewport, radius);
+                for (tile, flag) in descriptors.iter().zip(&visibility.in_range) {
+                    assert_eq!(
+                        *flag != 0,
+                        span.contains(tile.coord),
+                        "radius {radius} step {step} disagreed on {:?}",
+                        tile.coord
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_retain_radius_buys_a_ring_of_tiles_on_every_side() {
+        let grid = grid();
+        let viewport = rect(0.0, 0.0, 256.0, 256.0);
+        assert_eq!(
+            grid.visible_span(viewport, 0).map(|s| s.tile_count()),
+            Some(1)
+        );
+        assert_eq!(
+            grid.visible_span(viewport, 1).map(|s| s.tile_count()),
+            Some(9),
+            "one ring around a single visible tile is 3x3"
+        );
+        assert_eq!(
+            grid.visible_span(viewport, 2).map(|s| s.tile_count()),
+            Some(25)
+        );
+    }
+
+    #[test]
+    fn panning_moves_the_content_viewport_against_the_transform() {
+        let viewport = rect(0.0, 0.0, 800.0, 600.0);
+        // The user drags the canvas left, so content composites at a negative x
+        // and the plane under the window slides right.
+        let panned = TileGrid::content_viewport(viewport, LayerTransform::translated(-300.0, 0.0));
+        assert_eq!(panned.min_x, 300.0);
+        assert_eq!(panned.max_x, 1100.0);
+        assert_eq!(
+            TileGrid::content_viewport(viewport, LayerTransform::IDENTITY),
+            viewport
+        );
+    }
+
+    #[test]
+    fn an_unusable_tile_size_is_reported_rather_than_clamped() {
+        assert!(TileGrid::new(Size::pixels(0.0, 256.0)).is_none());
+        assert!(TileGrid::new(Size::pixels(256.0, -4.0)).is_none());
+        assert!(TileGrid::new(Size::pixels(f32::NAN, 256.0)).is_none());
+        assert!(TileGrid::square(TileGrid::MIN_EDGE).is_some());
+    }
+
+    #[test]
+    fn a_tile_size_that_would_put_millions_of_tiles_in_range_is_refused() {
+        let fine = TileGrid::square(1.0).expect("1px is the minimum, not an error");
+        assert_eq!(
+            fine.visible_span(rect(0.0, 0.0, 3840.0, 2160.0), 0),
+            None,
+            "a caller must fall back to untiled buffering rather than allocate \
+             eight million layers"
+        );
+        assert!(
+            grid().visible_span(rect(0.0, 0.0, 3840.0, 2160.0), 2).is_some(),
+            "the guard must not refuse a 4K viewport at the default tile size"
+        );
+    }
+
+    #[test]
+    fn a_primitive_inside_one_tile_goes_to_that_tile_and_a_spanning_one_to_the_overlay() {
+        let grid = grid();
+        assert_eq!(
+            grid.placement(rect(10.0, 10.0, 40.0, 40.0)),
+            TilePlacement::Tile(TileCoord::ORIGIN)
+        );
+        assert_eq!(
+            grid.placement(rect(-100.0, -100.0, 40.0, 40.0)),
+            TilePlacement::Tile(TileCoord::new(-1, -1))
+        );
+        assert_eq!(
+            grid.placement(rect(200.0, 10.0, 400.0, 10.0)),
+            TilePlacement::Overlay,
+            "a wire crossing a tile edge cannot be clipped without a content \
+             mask Quad does not have"
+        );
+        assert_eq!(
+            grid.placement(rect(0.0, 0.0, 256.0, 256.0)),
+            TilePlacement::Tile(TileCoord::ORIGIN),
+            "a primitive filling a tile exactly is inside it, not spanning"
+        );
+        assert_eq!(grid.placement(Rect::EMPTY), TilePlacement::Overlay);
+    }
+
+    #[test]
+    fn marking_reports_only_the_tiles_that_were_not_already_resident() {
+        let mut residency = TileResidency::new(64);
+        let first = residency.mark(
+            TileSpan {
+                min: TileCoord::ORIGIN,
+                max: TileCoord::new(1, 1),
+            },
+            1,
+        );
+        assert_eq!(first.len(), 4);
+        assert_eq!(
+            first,
+            vec![
+                TileCoord::new(0, 0),
+                TileCoord::new(1, 0),
+                TileCoord::new(0, 1),
+                TileCoord::new(1, 1),
+            ]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+        );
+
+        // Pan one column right: only the new column is revealed.
+        let second = residency.mark(
+            TileSpan {
+                min: TileCoord::new(1, 0),
+                max: TileCoord::new(2, 1),
+            },
+            2,
+        );
+        assert_eq!(
+            second,
+            vec![TileCoord::new(2, 0), TileCoord::new(2, 1)],
+            "§4.3: crossing into a new tile reveals that tile alone"
+        );
+        assert_eq!(residency.len(), 6);
+    }
+
+    #[test]
+    fn a_tile_out_of_range_survives_its_interval_and_then_does_not() {
+        let mut residency = TileResidency::new(64);
+        residency.mark(TileSpan::single(TileCoord::ORIGIN), 1);
+        residency.mark(TileSpan::single(TileCoord::new(9, 9)), 2);
+
+        // Visited on frame 1, so it survives an elapsed count of exactly 60 and
+        // goes on 61 — the same boundary `Compositor::sweep` draws.
+        assert!(residency.sweep(1 + 60, 60).is_empty());
+        assert_eq!(residency.len(), 2);
+        assert_eq!(
+            residency.sweep(2 + 60, 60),
+            vec![EvictedTile {
+                coord: TileCoord::ORIGIN,
+                reason: TileEviction::OutOfRange,
+            }],
+            "R-N §3.4's interval, with 'unvisited' meaning 'out of range'"
+        );
+        assert!(residency.contains(TileCoord::new(9, 9)));
+    }
+
+    #[test]
+    fn the_budget_evicts_the_least_recently_visited_tiles_and_never_a_visible_one() {
+        let mut residency = TileResidency::new(4);
+        // Eight tiles visited in a known order, one frame each, so the LRU order
+        // is unambiguous.
+        for index in 0..8i32 {
+            residency.mark(TileSpan::single(TileCoord::new(index, 0)), index as u64 + 1);
+        }
+        assert_eq!(residency.len(), 8);
+
+        // Frame 9 leaves only the last two in range.
+        residency.mark(
+            TileSpan {
+                min: TileCoord::new(6, 0),
+                max: TileCoord::new(7, 0),
+            },
+            9,
+        );
+        let evicted = residency.sweep(9, 60);
+        assert_eq!(residency.len(), 4);
+        assert_eq!(
+            evicted,
+            vec![
+                EvictedTile {
+                    coord: TileCoord::new(0, 0),
+                    reason: TileEviction::Budget
+                },
+                EvictedTile {
+                    coord: TileCoord::new(1, 0),
+                    reason: TileEviction::Budget
+                },
+                EvictedTile {
+                    coord: TileCoord::new(2, 0),
+                    reason: TileEviction::Budget
+                },
+                EvictedTile {
+                    coord: TileCoord::new(3, 0),
+                    reason: TileEviction::Budget
+                },
+            ],
+            "the four oldest go, and the two in range this frame never do"
+        );
+        assert!(residency.contains(TileCoord::new(6, 0)));
+        assert!(residency.contains(TileCoord::new(7, 0)));
+        assert_eq!(residency.over_budget(), 0);
+    }
+
+    #[test]
+    fn a_visible_set_larger_than_the_budget_is_reported_rather_than_thrashed() {
+        let mut residency = TileResidency::new(2);
+        residency.mark(
+            TileSpan {
+                min: TileCoord::ORIGIN,
+                max: TileCoord::new(2, 1),
+            },
+            1,
+        );
+        let evicted = residency.sweep(1, 60);
+        assert!(
+            evicted.is_empty(),
+            "evicting a tile this frame is about to render is not a memory bound"
+        );
+        assert_eq!(residency.len(), 6);
+        assert_eq!(residency.over_budget(), 4);
+    }
+
+    /// §9's risk table's exact shape: "fast diagonal movement, frequent
+    /// direction reversal" keeping many tiles inside the eviction interval at
+    /// once, which the per-tile timer alone does not bound.
+    ///
+    /// The claim is comparative on purpose. A test that only checked "the
+    /// resident count stayed under the budget" would pass just as well against a
+    /// pan that never had many tiles live in the first place, which would make
+    /// the budget untested rather than proven. So the same walk runs twice —
+    /// once with a budget, once with one large enough to be inert — and the
+    /// timer-only arm is asserted to blow past what the bounded arm holds.
+    #[test]
+    fn the_resident_tile_budget_is_what_bounds_an_erratic_pan_not_the_timer() {
+        let grid = grid();
+        let walk = |budget: usize| {
+            let mut residency = TileResidency::new(budget);
+            let mut peak = 0usize;
+            for frame in 0..400u64 {
+                let phase = frame as f32 * 0.37;
+                let viewport = rect(phase.sin() * 4_000.0, phase.cos() * 4_000.0, 900.0, 600.0);
+                let span = grid
+                    .visible_span(viewport, 1)
+                    .expect("a 900x600 viewport is usable at 256px");
+                residency.mark(span, frame);
+                residency.sweep(frame, 60);
+                peak = peak.max(residency.len());
+            }
+            (peak, residency.over_budget())
+        };
+
+        let (bounded_peak, over) = walk(96);
+        let (timer_only_peak, _) = walk(1_000_000);
+
+        assert!(
+            bounded_peak <= 96,
+            "the budget did not bound an erratic pan: peak {bounded_peak}"
+        );
+        assert_eq!(
+            over, 0,
+            "96 is above this viewport's in-range set, so nothing should be \
+             left unaccounted"
+        );
+        assert!(
+            timer_only_peak > bounded_peak * 2,
+            "the timer-only arm peaked at {timer_only_peak} against the bounded \
+             arm's {bounded_peak}, so this walk does not exercise what the \
+             budget is for"
+        );
+    }
+
+    /// The other half of the same story, and the honest one: a budget *below*
+    /// the in-range set cannot be met, and the mechanism says so rather than
+    /// evicting tiles the same frame is about to render.
+    #[test]
+    fn a_budget_under_the_viewports_own_tile_count_reports_itself_unmet() {
+        let grid = grid();
+        let mut residency = TileResidency::new(8);
+        let viewport = rect(0.0, 0.0, 900.0, 600.0);
+        let span = grid
+            .visible_span(viewport, 1)
+            .expect("a 900x600 viewport is usable at 256px");
+        let visible = span.tile_count() as usize;
+        assert!(visible > 8, "the premise: this viewport needs more than 8 tiles");
+
+        residency.mark(span, 1);
+        residency.sweep(1, 60);
+        assert_eq!(residency.len(), visible);
+        assert_eq!(
+            residency.over_budget(),
+            visible - 8,
+            "the shortfall is reported, not absorbed"
+        );
+    }
+
+    #[test]
+    fn tile_descriptors_encode_as_one_padded_vec4_each_with_signed_coordinates() {
+        let mut bytes = Vec::new();
+        encode_tiles(
+            &[TileDescriptor {
+                coord: TileCoord::new(-3, 7),
+                base: 64,
+                count: 12,
+            }],
+            &mut bytes,
+        );
+        assert_eq!(bytes.len(), TILE_DESCRIPTOR_STRIDE);
+        assert_eq!(&bytes[0..4], &(-3i32).to_le_bytes());
+        assert_eq!(&bytes[4..8], &7i32.to_le_bytes());
+        assert_eq!(&bytes[8..12], &64u32.to_le_bytes());
+        assert_eq!(&bytes[12..16], &12u32.to_le_bytes());
+    }
+
+    #[test]
+    fn an_out_of_range_tile_gets_a_zero_count_slot_and_keeps_its_base() {
+        let grid = grid();
+        let tiles = [
+            TileDescriptor {
+                coord: TileCoord::ORIGIN,
+                base: 0,
+                count: 10,
+            },
+            TileDescriptor {
+                coord: TileCoord::new(40, 0),
+                base: 10,
+                count: 7,
+            },
+        ];
+        let visibility = tile_visibility(&grid, &tiles, rect(0.0, 0.0, 256.0, 256.0), 0);
+        assert_eq!(visibility.slots, vec![[0, 10, 0, 0], [10, 0, 0, 0]]);
+        assert_eq!(visibility.in_range, vec![1, 0]);
+        assert_eq!(visibility.visible_count(), 1);
+    }
+
+    #[test]
+    fn the_slot_encoding_is_byte_identical_to_the_indirect_pass_own() {
+        use crate::indirect::{DrawSlot, encode_slots};
+        use crate::patch::primitive::PrimitiveKind;
+        use crate::scene::layer::LayerId;
+
+        let grid = grid();
+        let tiles = [
+            TileDescriptor {
+                coord: TileCoord::ORIGIN,
+                base: 0,
+                count: 10,
+            },
+            TileDescriptor {
+                coord: TileCoord::new(40, 0),
+                base: 10,
+                count: 7,
+            },
+        ];
+        let visibility = tile_visibility(&grid, &tiles, rect(0.0, 0.0, 256.0, 256.0), 0);
+        let mut ours = Vec::new();
+        visibility.encode_slots(&mut ours);
+
+        // The same records as the slot table Phase 4 already encodes, so the
+        // tile pass genuinely feeds the existing mechanism rather than a
+        // parallel one that happens to look similar.
+        let mut theirs = Vec::new();
+        encode_slots(
+            &[
+                DrawSlot {
+                    layer: LayerId::from_raw(1),
+                    kind: PrimitiveKind::Quad,
+                    base: 0,
+                    count: 10,
+                },
+                DrawSlot {
+                    layer: LayerId::from_raw(2),
+                    kind: PrimitiveKind::Quad,
+                    base: 10,
+                    count: 0,
+                },
+            ],
+            &mut theirs,
+        );
+        assert_eq!(ours, theirs);
     }
 }

--- a/crates/wgpui-core/src/shaders/tile_visibility.wgsl
+++ b/crates/wgpui-core/src/shaders/tile_visibility.wgsl
@@ -1,1 +1,97 @@
-// Placeholder — tile-visibility compute pass for Buffering::Tiled. See docs/gpu-native-architecture.md §4.3.
+// Tile visibility (§4.3): which tiles of a `Buffering::Tiled` boundary are in
+// range at the current pan offset, and — the part that matters — the draw slots
+// the indirect-arg pass then generates arguments from.
+//
+// This is a transcription of `wgpui_core::scene::tile::tile_visibility`, checked
+// against it for exact equality by `wgpui-wgpu/tests/tile_visibility.rs`. Read
+// that function's doc for what the computation is and why the rectangle
+// dilation is exact rather than approximate; this file is only how it is spelled
+// for the GPU.
+//
+// # This is not a drawing pipeline, and that is the design
+//
+// §4.3 asks for "a compute pass [that] computes tile visibility directly from a
+// pan-offset uniform and writes indirect draw args only for in-range tiles; the
+// CPU never enumerates tile candidates." What that turns into here is one
+// invocation per resident tile writing one `vec4<u32>` — because the record it
+// writes, `[base, count, 0, 0]`, is *exactly* the slot record
+// `indirect_args.wgsl` already consumes (`wgpui_core::indirect::encode_slots`'
+// layout, asserted byte-identical in `scene/tile.rs`'s own tests).
+//
+// So an out-of-range tile is a slot with a zero count, and Phase 4's existing
+// `compact` turns that into a zero-instance argument record while `pack` drops
+// it from the multi-draw entirely. Nothing new draws, no second mechanism
+// decides what draws, and the entire tile-visibility feature is this file plus
+// the buffer it writes into. That is §4.3's "tiling needs almost no new
+// machinery" being true rather than being claimed.
+//
+// # What the CPU still enumerates, honestly
+//
+// The draw path is as §4.3 describes: the CPU hands over resident tile
+// descriptors and learns nothing about which of them draw. But *residency* is
+// still CPU-side, and has to be — a newly-revealed tile needs its content
+// rendered into it, which is CPU work no visibility kernel can do. So
+// `TileResidency` runs the same predicate on the CPU for the tiles it keeps,
+// while this kernel decides what draws. The two are the same rule and are
+// checked against each other; see `docs/phase-4.5-results.md`.
+
+struct Params {
+    // Tile edge lengths in logical pixels.
+    tile_size: vec2<f32>,
+    // The boundary's layer transform: where its content composites. The plane
+    // slides under a fixed window by the negative of this.
+    pan: vec2<f32>,
+    // The boundary's visible rectangle in window space: min_x, min_y, max_x,
+    // max_y.
+    viewport: vec4<f32>,
+    // Resident tiles in this dispatch.
+    tile_count: u32,
+    // How many tiles beyond the viewport stay in range.
+    retain_radius: u32,
+    pad_0: u32,
+    pad_1: u32,
+};
+
+@group(0) @binding(0) var<uniform> params: Params;
+// [coord.x, coord.y, base, count] per resident tile. The two coordinates are
+// `i32`s bit-cast in place — a plane has no origin corner, so they are signed.
+@group(0) @binding(1) var<storage, read> tiles: array<vec4<u32>>;
+// [base, count, 0, 0] per tile, in `indirect_args.wgsl`'s slot layout.
+@group(0) @binding(2) var<storage, read_write> slots: array<vec4<u32>>;
+// 1 in range, 0 out. Not read by the draw path — it exists so a differential can
+// name the tile that disagreed rather than only the slot.
+@group(0) @binding(3) var<storage, read_write> in_range: array<u32>;
+
+@compute @workgroup_size(64)
+fn tile_visibility(@builtin(global_invocation_id) id: vec3<u32>) {
+    let index = id.x;
+    if (index >= params.tile_count) {
+        return;
+    }
+    let tile = tiles[index];
+    let coord = vec2<f32>(f32(bitcast<i32>(tile.x)), f32(bitcast<i32>(tile.y)));
+    let tile_min = coord * params.tile_size;
+    let tile_max = tile_min + params.tile_size;
+
+    // The content-plane rectangle under the viewport, dilated by the retain
+    // radius. Dilating the rectangle by `radius * tile_size` selects exactly the
+    // tiles that dilating the coordinate span by `radius` selects, because tile
+    // edges sit at exact multiples of the tile size — which is what lets this
+    // kernel test rectangles while residency works in coordinates.
+    let margin = f32(params.retain_radius) * params.tile_size;
+    let range_min = params.viewport.xy - params.pan - margin;
+    let range_max = params.viewport.zw - params.pan + margin;
+
+    // `Rect::intersects`, edge for edge: strict on every side, so a tile the
+    // range merely touches along an edge is out of range. The Rust reference
+    // reaches the same predicate through `Rect::intersects` itself, and the
+    // differential compares the results for exact equality rather than for
+    // approximate agreement.
+    let overlaps = range_min.x < tile_max.x
+        && tile_min.x < range_max.x
+        && range_min.y < tile_max.y
+        && tile_min.y < range_max.y;
+
+    in_range[index] = select(0u, 1u, overlaps);
+    slots[index] = vec4<u32>(tile.z, select(0u, tile.w, overlaps), 0u, 0u);
+}

--- a/crates/wgpui-core/src/test_support/ui_walk.rs
+++ b/crates/wgpui-core/src/test_support/ui_walk.rs
@@ -1356,6 +1356,17 @@ mod tests {
                 "every layer this frame touched carries TRANSFORM and nothing else"
             );
             assert!(stats.is_transform_only());
+            if step == 1 {
+                println!(
+                    "gate (within grid): {} visible tiles, {} TRANSFORM updates, \
+                     {} primitives written, {} upload bytes, {} layers displayed",
+                    stats.visible_tiles,
+                    stats.transform_updates,
+                    stats.primitives_written,
+                    stats.upload_bytes,
+                    stats.display_layers.len(),
+                );
+            }
             canvas.settle();
         }
         Ok(())
@@ -1447,6 +1458,16 @@ mod tests {
             canvas.resident_primitives() > resident_after_first,
             "the newly-revealed tiles added residency"
         );
+        println!(
+            "gate (crossing): {} of {} tiles revealed, {} primitives written \
+             ({} in tiles, {} on the overlay), against {} resident before",
+            stats.revealed.len(),
+            stats.visible_tiles,
+            stats.primitives_written,
+            tile_written,
+            stats.overlay_primitives_written,
+            resident_after_first,
+        );
         Ok(())
     }
 
@@ -1510,6 +1531,52 @@ mod tests {
              doc discloses",
             with_wires.overlay_primitives(),
             with_wires.resident_primitives()
+        );
+        Ok(())
+    }
+
+    /// What the overlay actually costs while panning, across many crossings
+    /// rather than the one the crossing gate happens to sample.
+    ///
+    /// The single crossing that gate measures wrote nothing to the overlay,
+    /// which would be a misleading number to report on its own — it means no
+    /// oversized wire entered the visible region on *that* frame, not that the
+    /// overlay is free. This walks twenty crossings and reports the totals, so
+    /// the claim in `docs/phase-4.5-results.md` is about the distribution rather
+    /// than about one lucky frame.
+    #[test]
+    fn the_overlays_share_of_a_long_pans_work_is_small_but_not_zero()
+    -> Result<(), PatchError> {
+        let mut canvas = canvas();
+        canvas.pan_to([-8.0, -8.0])?;
+        canvas.settle();
+
+        let mut tile_written = 0usize;
+        let mut overlay_written = 0usize;
+        let mut frames_touching_the_overlay = 0usize;
+        for step in 1..=20u32 {
+            let stats = canvas.pan_to([-8.0 - step as f32 * TileGrid::DEFAULT_EDGE, -8.0])?;
+            tile_written += stats.primitives_written - stats.overlay_primitives_written;
+            overlay_written += stats.overlay_primitives_written;
+            if stats.overlay_primitives_written > 0 {
+                frames_touching_the_overlay += 1;
+            }
+            canvas.settle();
+        }
+        println!(
+            "overlay over 20 crossings: {overlay_written} primitives on {frames_touching_the_overlay} \
+             frames, against {tile_written} written into tiles"
+        );
+        assert!(
+            overlay_written > 0,
+            "twenty tile crossings never touched the overlay, so the oversized-\
+             content path is not being exercised at all"
+        );
+        assert!(
+            overlay_written * 2 < tile_written,
+            "the overlay wrote {overlay_written} against the tiles' {tile_written} \
+             across a long pan — spanning content is dominating, which is the \
+             failure mode TilePlacement's doc discloses"
         );
         Ok(())
     }

--- a/crates/wgpui-core/src/test_support/ui_walk.rs
+++ b/crates/wgpui-core/src/test_support/ui_walk.rs
@@ -33,12 +33,17 @@
 //! consume. Going through `wgpui-widgets` would add a layer neither gate asks
 //! about between the generator and the thing under test.
 
+use crate::boundary::compositor::Compositor;
+use crate::boundary::policy::{BoundaryPolicy, Buffering, Size};
 use crate::geometry::Rect;
+use crate::invalidation::axes::Invalidation;
 use crate::occlusion::{CoverageItem, PoisonRegion, quad_coverage_item};
 use crate::patch::apply::{ScenePatch, UploadPlan, apply};
 use crate::patch::primitive::Quad;
 use crate::patch::{PatchError, RecordKey};
-use crate::scene::{BoundaryId, LayerId, LayerKey, Scene};
+use crate::scene::layer::{Layer, LayerTransform};
+use crate::scene::{BoundaryId, LayerId, LayerKey, Scene, TileCoord, TileGrid};
+use std::collections::HashMap;
 
 /// What one frame of the walk looks like.
 #[derive(Clone, Debug, PartialEq)]
@@ -733,6 +738,434 @@ impl MultiLayerSceneDriver {
     }
 }
 
+/// A node-graph canvas on an unbounded content plane, driven through
+/// `Buffering::Tiled` into a real [`Scene`].
+/// See docs/gpu-native-architecture.md §4.3, §8 Phase 4.5.
+///
+/// # Why this is a second generator rather than a `UiSceneSpec` flag
+///
+/// [`build_frame`]'s scene is an *editor*: everything in it is positioned
+/// relative to a window, and its viewport is one panel among several. §4.3's
+/// case is the opposite shape — content at arbitrary positions on a plane with
+/// no origin corner, a window that moves over it, and no linear index to
+/// virtualize by. Bolting a pan offset onto the editor spec would produce a
+/// scene whose content still fundamentally lives in window space, which is the
+/// exact thing `Buffering::Margin` already handles and `Tiled` exists because it
+/// does not.
+///
+/// # What it measures, and why it measures it this way
+///
+/// Every frame emits patches for **every visible tile**, not only the revealed
+/// ones. That is deliberate and it is what makes the gate a measurement rather
+/// than a restatement: if the driver skipped resident tiles, "panning costs zero
+/// render work" would be true because the harness declined to do any. Instead
+/// the harness offers the work every frame and the patch protocol's own
+/// cross-frame addressing (§5.0) is what reduces it to nothing — so a
+/// [`TiledFrameStats`] reading zero is a fact about the mechanism.
+pub struct TiledCanvasDriver {
+    /// The scene under test.
+    pub scene: Scene,
+    /// The compositor holding this boundary's tile residency.
+    pub compositor: Compositor,
+    /// The boundary the canvas lives in.
+    pub boundary: BoundaryId,
+    /// The policy it was declared with.
+    pub policy: BoundaryPolicy,
+    /// The window rectangle the canvas is seen through.
+    pub viewport: Rect,
+    graph: NodeGraph,
+    resident: HashMap<LayerId, usize>,
+    frame: u64,
+}
+
+/// What one frame of a tiled pan cost, in the terms §8's Phase 4.5 gate is
+/// written in.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TiledFrameStats {
+    /// Tiles newly in range this frame — the ones that must render.
+    pub revealed: Vec<TileCoord>,
+    /// Tiles in range this frame.
+    pub visible_tiles: usize,
+    /// Tiles resident after the sweep.
+    pub resident_tiles: usize,
+    /// Tiles evicted this frame.
+    pub evicted: usize,
+    /// Resident tiles the budget could not account for.
+    pub over_budget: usize,
+    /// Layers whose composite transform this frame changed — **one per visible
+    /// tile on a pan**, which is the gate's own wording.
+    pub transform_updates: usize,
+    /// Layers this frame created, i.e. tiles that became layers.
+    pub layers_created: usize,
+    /// Layers this frame destroyed.
+    pub layers_removed: usize,
+    /// Primitives written into the scene this frame — inserts plus updates.
+    /// **The render/reconcile work the gate requires to be zero on a pan inside
+    /// the resident grid.**
+    pub primitives_written: usize,
+    /// How many of [`TiledFrameStats::primitives_written`] landed on the
+    /// unbuffered overlay rather than in a tile.
+    ///
+    /// Tracked separately because of what it turned out to be worth: a tile
+    /// crossing dirties the overlay as well as the revealed tiles, since a wire
+    /// reaching into the new column is spanning content and spanning content
+    /// lives there. That is a real consequence of the rule
+    /// [`crate::scene::TilePlacement`] picks, and separating the two counts is
+    /// what lets the gate state it instead of averaging it away.
+    pub overlay_primitives_written: usize,
+    /// Bytes §5.0's upload instructions cover this frame.
+    pub upload_bytes: u64,
+    /// Layers that ended the frame carrying `DISPLAY`.
+    pub display_layers: Vec<LayerId>,
+    /// Layers that ended the frame carrying `TRANSFORM` and nothing else.
+    pub transform_only_layers: usize,
+}
+
+impl TiledFrameStats {
+    /// Whether this frame did no rendering, reconciling, or uploading at all.
+    pub fn is_transform_only(&self) -> bool {
+        self.primitives_written == 0
+            && self.upload_bytes == 0
+            && self.display_layers.is_empty()
+            && self.layers_created == 0
+    }
+}
+
+/// The graph's content, laid out once on the plane and never re-laid-out.
+struct NodeGraph {
+    quads: Vec<(Rect, Quad)>,
+}
+
+/// How big a node-graph canvas is and what is on it.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct NodeGraphSpec {
+    /// How many node columns the plane holds.
+    pub columns: u32,
+    /// How many node rows.
+    pub rows: u32,
+    /// Horizontal distance between node origins.
+    pub column_pitch: f32,
+    /// Vertical distance between node origins.
+    pub row_pitch: f32,
+    /// Whether wires between horizontally adjacent nodes are emitted. Wires are
+    /// the content that genuinely spans tiles, so turning them off is what
+    /// isolates the overlay's cost.
+    pub wires: bool,
+}
+
+impl NodeGraphSpec {
+    /// A plane large enough that no realistic pan ever sees all of it.
+    pub fn large() -> NodeGraphSpec {
+        NodeGraphSpec {
+            columns: 40,
+            rows: 40,
+            column_pitch: 220.0,
+            row_pitch: 180.0,
+            wires: true,
+        }
+    }
+}
+
+const GRAPH_NODE_WIDTH: f32 = 130.0;
+const GRAPH_NODE_HEIGHT: f32 = 70.0;
+
+impl NodeGraph {
+    fn build(spec: &NodeGraphSpec) -> NodeGraph {
+        let mut quads = Vec::new();
+        let mut push = |bounds: Rect, quad: Quad| quads.push((bounds, quad));
+        let origin_of = |column: u32, row: u32| {
+            // Centred on the plane's origin, so panning in every direction
+            // reaches content and negative tile coordinates are ordinary rather
+            // than an edge case.
+            let x = (column as f32 - spec.columns as f32 * 0.5) * spec.column_pitch
+                + jitter(column.wrapping_mul(31).wrapping_add(row), spec.column_pitch * 0.25);
+            let y = (row as f32 - spec.rows as f32 * 0.5) * spec.row_pitch
+                + jitter(row.wrapping_mul(17).wrapping_add(column), spec.row_pitch * 0.2);
+            [x, y]
+        };
+
+        for row in 0..spec.rows {
+            for column in 0..spec.columns {
+                let [x, y] = origin_of(column, row);
+                let body = rect(x, y, GRAPH_NODE_WIDTH, GRAPH_NODE_HEIGHT);
+                push(
+                    body,
+                    Quad {
+                        origin: [body.min_x, body.min_y],
+                        size: [body.width(), body.height()],
+                        background: solid(0.19, 0.20, 0.24),
+                        border_color: translucent(0.55, 0.58, 0.66, 0.5),
+                        corner_radius: 6.0,
+                        border_width: 1.0,
+                    },
+                );
+                let header = rect(x + 6.0, y + 6.0, GRAPH_NODE_WIDTH - 12.0, 16.0);
+                push(header, plain(header, solid(0.28, 0.32, 0.42)));
+                for index in 0..3u32 {
+                    let port = rect(x - 4.0, y + 30.0 + index as f32 * 12.0, 8.0, 8.0);
+                    push(
+                        port,
+                        Quad {
+                            origin: [port.min_x, port.min_y],
+                            size: [port.width(), port.height()],
+                            background: solid(0.72, 0.66, 0.30),
+                            border_color: [0.0, 0.0, 0.0, 0.0],
+                            corner_radius: 4.0,
+                            border_width: 0.0,
+                        },
+                    );
+                }
+
+                // Wires. This is the content §4.3 names as needing a rule, and
+                // a real graph has both lengths: most connections are to the
+                // next column along and fit inside a tile, and some skip
+                // several columns and cannot fit in any tile at all. Both are
+                // generated, because the placement rule has a different answer
+                // for each and a workload with only one kind would leave half of
+                // it untested.
+                if spec.wires && column + 1 < spec.columns {
+                    let [next_x, next_y] = origin_of(column + 1, row);
+                    let start_x = x + GRAPH_NODE_WIDTH;
+                    let wire = rect(
+                        start_x,
+                        y + 34.0,
+                        (next_x - start_x).max(1.0),
+                        (next_y - y).abs().max(2.0),
+                    );
+                    push(wire, plain(wire, translucent(0.60, 0.66, 0.78, 0.8)));
+                }
+                if spec.wires && column % 7 == 0 && column + 4 < spec.columns {
+                    let [far_x, far_y] = origin_of(column + 4, row);
+                    let start_x = x + GRAPH_NODE_WIDTH;
+                    let wire = rect(
+                        start_x,
+                        y + 46.0,
+                        (far_x - start_x).max(1.0),
+                        (far_y - y).abs().max(2.0),
+                    );
+                    push(wire, plain(wire, translucent(0.70, 0.60, 0.50, 0.8)));
+                }
+            }
+        }
+        NodeGraph { quads }
+    }
+
+    /// Every primitive whose bounds intersect `region`, in plane order.
+    fn quads_in(&self, region: Rect) -> Vec<(Rect, Quad)> {
+        self.quads
+            .iter()
+            .filter(|(bounds, _)| bounds.intersects(&region))
+            .copied()
+            .collect()
+    }
+}
+
+impl TiledCanvasDriver {
+    /// A canvas over an empty scene, at the identity pan.
+    pub fn new(spec: &NodeGraphSpec, viewport: Rect, policy: BoundaryPolicy) -> TiledCanvasDriver {
+        TiledCanvasDriver {
+            scene: Scene::new(),
+            compositor: Compositor::new(),
+            boundary: BoundaryId::from_raw(1),
+            policy,
+            viewport,
+            graph: NodeGraph::build(spec),
+            resident: HashMap::new(),
+            frame: 0,
+        }
+    }
+
+    /// The policy a node-graph canvas is declared with by default.
+    pub fn tiled_policy(tile_edge: f32, retain_radius: u32, budget: usize) -> BoundaryPolicy {
+        BoundaryPolicy {
+            buffering: Buffering::Tiled {
+                tile_size: Size::pixels(tile_edge, tile_edge),
+                retain_radius,
+            },
+            resident_tile_budget: budget,
+            ..BoundaryPolicy::default()
+        }
+    }
+
+    /// Pan the canvas so its content composites at `translation`, and bring the
+    /// scene up to date. Returns what that frame cost.
+    ///
+    /// The order is the one a real frame would run in: move, resolve visibility,
+    /// create the revealed tiles' layers, offer every visible tile its content,
+    /// slide every visible tile, then release what was evicted.
+    pub fn pan_to(&mut self, translation: [f32; 2]) -> Result<TiledFrameStats, PatchError> {
+        self.frame += 1;
+        let frame = self.frame;
+        let transform = LayerTransform::translated(translation[0], translation[1]);
+        // Declared before it is moved, and the order matters on the first frame
+        // only: `Compositor::set_transform` is documented to report `false`
+        // rather than create a boundary, so positioning one the compositor has
+        // never seen is inert. Written the other way round, this driver's first
+        // frame silently resolved its tile span at the identity and the next
+        // frame's ordinary pan then looked like a tile crossing.
+        self.compositor.visit(self.boundary, self.policy, frame);
+        self.compositor.set_transform(self.boundary, transform);
+
+        let Some(visit) =
+            self.compositor
+                .visit_tiled(self.boundary, self.policy, frame, self.viewport)
+        else {
+            return Ok(TiledFrameStats::default());
+        };
+
+        let mut stats = TiledFrameStats {
+            revealed: visit.revealed.clone(),
+            visible_tiles: visit.visible.len(),
+            resident_tiles: visit.resident,
+            evicted: visit.evicted.len(),
+            over_budget: visit.over_budget,
+            ..TiledFrameStats::default()
+        };
+
+        // Layers for tiles that became visible. A brand-new layer starts fully
+        // invalidated on `LayerTable::insert`'s own rule — nothing here marks a
+        // tile dirty, which is §4.3's point that this is ordinary machinery.
+        for tile in &visit.revealed {
+            let key = LayerKey::tiled(self.boundary, *tile);
+            if !self.scene.layers.contains(LayerId::from_key(key)) {
+                stats.layers_created += 1;
+            }
+            self.scene.layer(key);
+        }
+        let overlay = visit.overlay_layer();
+        if !self.scene.layers.contains(overlay) {
+            stats.layers_created += 1;
+        }
+        self.scene.layer(LayerKey::untiled(self.boundary));
+
+        // Offer every visible tile its content, plus the overlay. A resident
+        // tile's content is unchanged, so this produces no patch at all — which
+        // is the property the gate reads, established by the protocol rather
+        // than by this loop declining to run.
+        let mut patch = ScenePatch::new();
+        let mut written = 0usize;
+        for tile in &visit.visible {
+            let layer = visit.tile_layer(*tile);
+            let bounds = visit.grid.tile_bounds(*tile);
+            let quads: Vec<Quad> = self
+                .graph
+                .quads_in(bounds)
+                .into_iter()
+                .filter(|(quad_bounds, _)| visit.placement_layer(*quad_bounds) == layer)
+                .map(|(_, quad)| quad)
+                .collect();
+            written += self.stage_layer(&mut patch, layer, &quads);
+        }
+        let overlay_region = visit.grid.bounds_of(&visit.visible);
+        let overlay_quads: Vec<Quad> = self
+            .graph
+            .quads_in(overlay_region)
+            .into_iter()
+            .filter(|(quad_bounds, _)| visit.placement_layer(*quad_bounds) == overlay)
+            .map(|(_, quad)| quad)
+            .collect();
+        let overlay_written = self.stage_layer(&mut patch, overlay, &overlay_quads);
+        written += overlay_written;
+
+        let plan = apply(&mut self.scene, &patch)?;
+        stats.primitives_written = written;
+        stats.overlay_primitives_written = overlay_written;
+        stats.upload_bytes = plan.byte_count();
+
+        // Slide every visible tile, and the overlay with them. `set_transform`
+        // raises TRANSFORM and nothing else, and is inert when the layer is
+        // already there — so a frame that did not move counts zero.
+        for layer in visit.visible_layers().into_iter().chain(Some(overlay)) {
+            let before = self.scene.layers.get(layer).map(Layer::transform);
+            self.scene.layers.set_transform(layer, transform);
+            if before != Some(transform) {
+                stats.transform_updates += 1;
+            }
+        }
+
+        for evicted in &visit.evicted {
+            let layer = visit.tile_layer(evicted.coord);
+            if self.scene.remove_layer(layer) {
+                stats.layers_removed += 1;
+                self.resident.remove(&layer);
+            }
+        }
+
+        for layer in self.scene.layers.ids() {
+            let Some(record) = self.scene.layers.get(layer) else {
+                continue;
+            };
+            let invalidation = record.invalidation();
+            if invalidation.contains(Invalidation::DISPLAY) {
+                stats.display_layers.push(layer);
+            } else if invalidation == Invalidation::TRANSFORM {
+                stats.transform_only_layers += 1;
+            }
+        }
+        stats.display_layers.sort_unstable();
+        Ok(stats)
+    }
+
+    /// Mark every layer clean, as the end of a rendered frame would.
+    pub fn settle(&mut self) {
+        for layer in self.scene.layers.ids() {
+            self.scene.layers.mark_clean(layer);
+        }
+    }
+
+    /// Stage one layer's content, returning how many primitives were actually
+    /// written — inserted or changed, never merely offered.
+    fn stage_layer(&mut self, patch: &mut ScenePatch, layer: LayerId, quads: &[Quad]) -> usize {
+        let resident = self.resident.get(&layer).copied().unwrap_or(0);
+        let mut written = 0usize;
+        let shared = resident.min(quads.len());
+        for position in 0..shared {
+            let key = RecordKey::from_raw(position as u64 + 1);
+            let Some(quad) = quads.get(position) else {
+                continue;
+            };
+            if self.scene.quads.get(layer, key) != Some(quad) {
+                patch.quads.update(layer, key, *quad);
+                written += 1;
+            }
+        }
+        for position in shared..quads.len() {
+            let Some(quad) = quads.get(position) else {
+                continue;
+            };
+            patch.quads.append(
+                layer,
+                RecordKey::from_raw(position as u64 + 1),
+                u32::try_from(position).unwrap_or(u32::MAX),
+                *quad,
+            );
+            written += 1;
+        }
+        for position in (quads.len()..resident).rev() {
+            patch
+                .quads
+                .remove(layer, RecordKey::from_raw(position as u64 + 1));
+            written += 1;
+        }
+        self.resident.insert(layer, quads.len());
+        written
+    }
+
+    /// How many primitives the whole scene currently holds.
+    pub fn resident_primitives(&self) -> usize {
+        self.resident.values().sum()
+    }
+
+    /// How many primitives sit on the unbuffered overlay layer — the honest
+    /// price of [`crate::scene::TilePlacement::Overlay`].
+    pub fn overlay_primitives(&self) -> usize {
+        self.resident
+            .get(&LayerId::from_key(LayerKey::untiled(self.boundary)))
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -855,6 +1288,261 @@ mod tests {
             !frame.poison.is_empty(),
             "no filter region: poisoning and the blur margin are untested"
         );
+    }
+
+    fn canvas() -> TiledCanvasDriver {
+        TiledCanvasDriver::new(
+            &NodeGraphSpec::large(),
+            rect(0.0, 0.0, 1024.0, 768.0),
+            TiledCanvasDriver::tiled_policy(TileGrid::DEFAULT_EDGE, 1, 256),
+        )
+    }
+
+    /// §8's Phase 4.5 gate, second clause: *panning within the resident grid
+    /// costs one `TRANSFORM` update per visible tile and zero render/reconcile/
+    /// layout work anywhere.*
+    ///
+    /// The pan is deliberately sub-tile — 24px on a 256px grid — and repeated,
+    /// so the frame genuinely moves without the visible span changing. The
+    /// harness offers every visible tile its content on every one of these
+    /// frames (see [`TiledCanvasDriver`]); the zeros below are what the patch
+    /// protocol makes of that offer, not what the harness declined to do.
+    ///
+    /// **The baseline pan is 8px, not zero, and that is not cosmetic.** A
+    /// 1024×768 viewport at the identity has both its right and bottom edges on
+    /// exact multiples of 256, so it starts perfectly tile-aligned and the very
+    /// first pixel of any pan reveals a whole new column — which is a tile
+    /// crossing, i.e. the *other* gate. Starting 8px into a tile is what makes
+    /// the eight steps below land inside the resident grid, and it is the
+    /// condition the first assertion in the loop checks rather than assumes.
+    #[test]
+    fn gate_panning_inside_the_resident_grid_is_transform_only() -> Result<(), PatchError> {
+        let mut canvas = canvas();
+        let first = canvas.pan_to([-8.0, -8.0])?;
+        assert!(
+            first.layers_created > 0 && first.primitives_written > 0,
+            "the first frame must actually render, or the comparison is empty"
+        );
+        canvas.settle();
+
+        for step in 1..=8u32 {
+            let stats = canvas.pan_to([-8.0 - step as f32 * 24.0, -8.0])?;
+            assert_eq!(
+                stats.revealed,
+                Vec::<TileCoord>::new(),
+                "step {step} crossed a tile boundary, so it is not this gate's case"
+            );
+            assert_eq!(
+                stats.primitives_written, 0,
+                "step {step} re-rendered {} primitives for a pan",
+                stats.primitives_written
+            );
+            assert_eq!(stats.upload_bytes, 0, "step {step} uploaded bytes for a pan");
+            assert_eq!(stats.layers_created, 0);
+            assert_eq!(
+                stats.display_layers,
+                Vec::<LayerId>::new(),
+                "step {step} left a layer needing re-display"
+            );
+            assert_eq!(
+                stats.transform_updates,
+                stats.visible_tiles + 1,
+                "one TRANSFORM per visible tile, plus the overlay"
+            );
+            assert_eq!(
+                stats.transform_only_layers,
+                stats.transform_updates,
+                "every layer this frame touched carries TRANSFORM and nothing else"
+            );
+            assert!(stats.is_transform_only());
+            canvas.settle();
+        }
+        Ok(())
+    }
+
+    /// §8's Phase 4.5 gate, first clause: *panning across a tile boundary
+    /// renders only the newly-revealed tile(s) — measured directly, not
+    /// inferred.*
+    ///
+    /// "Measured directly" is the load-bearing phrase, so the assertion is not
+    /// that the count is small — it is that the set of *tile* layers carrying
+    /// `DISPLAY` after the frame is exactly the set belonging to the revealed
+    /// tiles, no more and no fewer.
+    ///
+    /// # One layer beyond the revealed tiles re-displays, and it is the overlay
+    ///
+    /// This is what running the gate found rather than what writing it assumed.
+    /// A crossing dirties the revealed tiles *and the unbuffered overlay*,
+    /// because a wire reaching into the newly-revealed column is content that
+    /// spans tiles, and [`crate::scene::TilePlacement`]'s rule puts spanning
+    /// content on the overlay. So the gate's "only the newly-revealed tile(s)"
+    /// is exactly true of the tile grid and not quite true of the boundary: the
+    /// overlay is a third thing, and it re-renders whenever the visible region's
+    /// spanning content changes.
+    ///
+    /// The test asserts both halves separately rather than widening the first
+    /// one to fit — the tile set is exact, and the overlay's share of the
+    /// frame's work is measured and bounded, because an overlay that re-rendered
+    /// most of the scene on every crossing would defeat the mechanism while
+    /// still passing an "exactly the revealed tiles" check on the tiles alone.
+    #[test]
+    fn gate_crossing_a_tile_boundary_renders_only_the_revealed_tiles() -> Result<(), PatchError> {
+        let mut canvas = canvas();
+        canvas.pan_to([-8.0, -8.0])?;
+        canvas.settle();
+        let resident_after_first = canvas.resident_primitives();
+
+        // A whole tile's worth of pan to the left, so a new column is revealed
+        // on the right and nothing else changes.
+        let stats = canvas.pan_to([-8.0 - TileGrid::DEFAULT_EDGE, -8.0])?;
+        assert!(
+            !stats.revealed.is_empty(),
+            "the pan did not cross a tile boundary, so this gate tested nothing"
+        );
+        assert!(
+            stats.revealed.len() < stats.visible_tiles,
+            "a whole-tile pan revealed {} of {} visible tiles, which is a refill, \
+             not a tile crossing",
+            stats.revealed.len(),
+            stats.visible_tiles
+        );
+
+        let overlay = LayerId::from_key(LayerKey::untiled(canvas.boundary));
+        let revealed_layers: std::collections::BTreeSet<LayerId> = stats
+            .revealed
+            .iter()
+            .map(|tile| LayerId::from_key(LayerKey::tiled(canvas.boundary, *tile)))
+            .collect();
+        let displayed_tiles: std::collections::BTreeSet<LayerId> = stats
+            .display_layers
+            .iter()
+            .copied()
+            .filter(|layer| *layer != overlay)
+            .collect();
+        assert_eq!(
+            displayed_tiles, revealed_layers,
+            "exactly the revealed tiles re-displayed — no more, and no fewer"
+        );
+        assert!(
+            stats.primitives_written > 0,
+            "the revealed tiles rendered nothing, so the crossing is not real"
+        );
+
+        // The overlay half, disclosed rather than folded into the count above.
+        let tile_written = stats.primitives_written - stats.overlay_primitives_written;
+        assert!(
+            tile_written > 0,
+            "every primitive the crossing wrote landed on the overlay, which \
+             would mean the tile grid is not carrying the content at all"
+        );
+        assert!(
+            stats.overlay_primitives_written < tile_written,
+            "the overlay wrote {} primitives against the tiles' {tile_written}; \
+             spanning content has become the dominant cost of a crossing, which \
+             is the failure mode TilePlacement's doc discloses",
+            stats.overlay_primitives_written
+        );
+        assert!(
+            canvas.resident_primitives() > resident_after_first,
+            "the newly-revealed tiles added residency"
+        );
+        Ok(())
+    }
+
+    /// The comparison that makes the crossing a *win* rather than a number: the
+    /// same pan under `Buffering::Margin`'s rule re-renders the whole buffered
+    /// region, which is §4.3's stated complaint about it.
+    ///
+    /// Modelled rather than run through a second mechanism, and the model is the
+    /// honest one — R-N §7's refill is "the *entire* viewport+margin region
+    /// re-renders", so the comparison is against the primitive count of the
+    /// whole visible span. That count is read out of this same scene, so the
+    /// ratio is a fact about this workload rather than a quoted constant.
+    #[test]
+    fn a_tile_crossing_renders_a_small_fraction_of_what_a_margin_refill_would()
+    -> Result<(), PatchError> {
+        let mut canvas = canvas();
+        canvas.pan_to([-8.0, -8.0])?;
+        canvas.settle();
+        let whole_region = canvas.resident_primitives();
+
+        let stats = canvas.pan_to([-8.0 - TileGrid::DEFAULT_EDGE, -8.0])?;
+        assert!(
+            stats.primitives_written * 4 < whole_region,
+            "a crossing wrote {} primitives against a refill's {whole_region}; \
+             tiling is supposed to be much better than that, not marginally",
+            stats.primitives_written
+        );
+        Ok(())
+    }
+
+    /// The overlay's price, measured rather than asserted — see
+    /// [`crate::scene::TilePlacement`] for why spanning content goes there.
+    #[test]
+    fn wires_are_what_lands_on_the_overlay_and_nodes_are_not() -> Result<(), PatchError> {
+        let viewport = rect(0.0, 0.0, 1024.0, 768.0);
+        let policy = TiledCanvasDriver::tiled_policy(TileGrid::DEFAULT_EDGE, 1, 256);
+
+        let mut with_wires =
+            TiledCanvasDriver::new(&NodeGraphSpec::large(), viewport, policy);
+        with_wires.pan_to([0.0, 0.0])?;
+
+        let mut without_wires = TiledCanvasDriver::new(
+            &NodeGraphSpec {
+                wires: false,
+                ..NodeGraphSpec::large()
+            },
+            viewport,
+            policy,
+        );
+        without_wires.pan_to([0.0, 0.0])?;
+
+        assert!(
+            with_wires.overlay_primitives() > without_wires.overlay_primitives(),
+            "wires are the spanning content; if they do not reach the overlay, \
+             the placement rule is not being exercised"
+        );
+        assert!(
+            with_wires.overlay_primitives() * 3 < with_wires.resident_primitives(),
+            "the overlay holds {} of {} primitives — the unbuffered layer has \
+             become most of the scene, which is the failure mode this rule's \
+             doc discloses",
+            with_wires.overlay_primitives(),
+            with_wires.resident_primitives()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_pan_far_enough_to_leave_the_grid_evicts_the_tiles_behind_it()
+    -> Result<(), PatchError> {
+        let mut canvas = TiledCanvasDriver::new(
+            &NodeGraphSpec::large(),
+            rect(0.0, 0.0, 1024.0, 768.0),
+            BoundaryPolicy {
+                evict_after_frames: 2,
+                ..TiledCanvasDriver::tiled_policy(TileGrid::DEFAULT_EDGE, 1, 256)
+            },
+        );
+        canvas.pan_to([0.0, 0.0])?;
+        canvas.settle();
+        let mut evicted_total = 0usize;
+        let mut removed_total = 0usize;
+        for step in 1..=12u32 {
+            let stats = canvas.pan_to([-(step as f32) * 512.0, 0.0])?;
+            evicted_total += stats.evicted;
+            removed_total += stats.layers_removed;
+            canvas.settle();
+        }
+        assert!(
+            evicted_total > 0,
+            "panning right across six tiles left everything behind it resident"
+        );
+        assert_eq!(
+            evicted_total, removed_total,
+            "every evicted tile must actually release its layer"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/wgpui-core/src/test_support/ui_walk.rs
+++ b/crates/wgpui-core/src/test_support/ui_walk.rs
@@ -42,7 +42,7 @@ use crate::patch::apply::{ScenePatch, UploadPlan, apply};
 use crate::patch::primitive::Quad;
 use crate::patch::{PatchError, RecordKey};
 use crate::scene::layer::{Layer, LayerTransform};
-use crate::scene::{BoundaryId, LayerId, LayerKey, Scene, TileCoord, TileGrid};
+use crate::scene::{BoundaryId, LayerId, LayerKey, Scene, TileCoord};
 use std::collections::HashMap;
 
 /// What one frame of the walk looks like.
@@ -1170,6 +1170,7 @@ impl TiledCanvasDriver {
 mod tests {
     use super::*;
     use crate::occlusion::keep_mask;
+    use crate::scene::TileGrid;
 
     #[test]
     fn the_estimate_bounds_a_frame_without_wildly_overshooting_it() {

--- a/crates/wgpui-wgpu/examples/phase45_tiling_bench.rs
+++ b/crates/wgpui-wgpu/examples/phase45_tiling_bench.rs
@@ -1,0 +1,301 @@
+//! §4.3's tile-size tradeoff, measured against a representative node-graph
+//! workload rather than asserted.
+//! See docs/gpu-native-architecture.md §4.3, §8 Phase 4.5, §9's risk table.
+//!
+//! Run with `cargo run -p wgpui-wgpu --release --example phase45_tiling_bench`.
+//!
+//! # Why this exists
+//!
+//! §4.3 is explicit that the tile size is "a real tuning knob with a real
+//! tradeoff … There's no principled default without measuring — Phase 0's spike
+//! discipline applies here too, picking a starting size from common compositor
+//! practice (roughly 256–512px) and validating it against a representative
+//! node-graph workload, not asserting it." §9's risk table names the failure
+//! mode in both directions: "too small inflates per-tile/draw-call overhead, too
+//! large approaches `Margin`'s whole-region-refill cost."
+//!
+//! So this sweeps the edge length across and beyond that range and reports both
+//! sides of the tradeoff for each, on one workload, with the numbers that would
+//! make a size wrong.
+//!
+//! # What is measured, and what each column means
+//!
+//! - **slots/frame** — draw slots the fixed sequence issues, which is one per
+//!   visible tile plus the overlay. This is the "too small inflates draw-call
+//!   overhead" axis, and Phase 4's gate already established that CPU draw-issue
+//!   cost is linear in it.
+//! - **crossing** — primitives written when a pan crosses one tile boundary.
+//!   This is the "too large approaches `Margin`'s refill cost" axis.
+//! - **refill** — primitives a whole-region refill would write, i.e. what
+//!   `Buffering::Margin` costs for the same pan per R-N §7. The comparison the
+//!   whole mechanism exists to win.
+//! - **overlay** — share of resident primitives on the unbuffered overlay
+//!   layer, which is content the tile grid does not cull. Rises as tiles shrink,
+//!   because a primitive larger than a tile cannot be anchored
+//!   (`scene::TilePlacement`).
+//! - **resident** — tiles held after the sweep, against the budget.
+//! - **visibility** — GPU wall clock for the tile-visibility dispatch. Reported
+//!   because a pass that decided visibility more slowly than the work it saved
+//!   would be a bad trade, and nothing else in this phase would have shown it.
+//!
+//! # Methodology, carried over from Phases 3 and 4 unchanged
+//!
+//! Two warm-up runs discarded and disclosed; median and best both reported, with
+//! the median the lower middle of an even count so every printed number was
+//! actually observed; the adapter named before any number is printed, and a
+//! software rasterizer called out loudly.
+
+use std::time::{Duration, Instant};
+
+use wgpui_core::boundary::policy::BoundaryPolicy;
+use wgpui_core::geometry::Rect;
+use wgpui_core::indirect::{FirstInstance, QUAD_VERTEX_COUNT};
+use wgpui_core::scene::{TileDescriptor, encode_tiles};
+use wgpui_core::test_support::ui_walk::{NodeGraphSpec, TiledCanvasDriver};
+use wgpui_wgpu::render::compute::indirect_args_pass::{IndirectArgsBuffers, IndirectArgsPass};
+use wgpui_wgpu::render::compute::tile_visibility_pass::{
+    TileViewport, TileVisibilityBuffers, TileVisibilityPass,
+};
+use wgpui_wgpu::render::device::{ComputeContext, headless_compute_context};
+
+const VIEWPORT_WIDTH: f32 = 1600.0;
+const VIEWPORT_HEIGHT: f32 = 900.0;
+const RETAIN_RADIUS: u32 = 1;
+const BUDGET: usize = 256;
+const WARM_UP: usize = 2;
+const RUNS: usize = 12;
+
+/// Edge lengths swept. 128 and 1024 sit outside §4.3's suggested 256–512 band on
+/// purpose: a sweep that only covered the band could not show that the band is
+/// the right place to be.
+const EDGES: [f32; 5] = [128.0, 256.0, 384.0, 512.0, 1024.0];
+
+fn viewport() -> Rect {
+    Rect::from_origin_size([0.0, 0.0], [VIEWPORT_WIDTH, VIEWPORT_HEIGHT])
+}
+
+fn main() {
+    let context = match headless_compute_context() {
+        Ok(context) => context,
+        Err(error) => {
+            eprintln!(
+                "NO ADAPTER: {error}\n\
+                 No number below would mean anything without one, so none is printed."
+            );
+            return;
+        }
+    };
+    println!("== Adapter ==");
+    println!("  {}", context.describe());
+    if context.is_software() {
+        println!(
+            "  !! SOFTWARE RASTERIZER — every timing below is a CPU emulation of a \
+             GPU and must not be quoted as hardware."
+        );
+    }
+    println!(
+        "\n== §4.3 tile-size tradeoff — node graph, {VIEWPORT_WIDTH:.0}x{VIEWPORT_HEIGHT:.0} \
+         viewport, retain radius {RETAIN_RADIUS}, budget {BUDGET} =="
+    );
+    println!(
+        "  {WARM_UP} warm-up runs discarded, {RUNS} timed; median is the lower middle of \
+         an even count."
+    );
+    println!(
+        "\n  {:>5}  {:>6}  {:>7}  {:>8}  {:>8}  {:>7}  {:>8}  {:>9}  {:>9}",
+        "edge", "tiles", "slots", "crossing", "refill", "ratio", "overlay", "vis med", "vis best"
+    );
+    println!("  {}", "-".repeat(84));
+
+    for edge in EDGES {
+        match measure(&context, edge) {
+            Some(row) => println!(
+                "  {:>5.0}  {:>6}  {:>7}  {:>8}  {:>8}  {:>6.1}x  {:>7.1}%  {:>8.1}µs  {:>8.1}µs   \
+                 ({:.2}x viewport)",
+                edge,
+                row.resident_tiles,
+                row.slots_per_frame,
+                row.crossing_primitives,
+                row.refill_primitives,
+                row.refill_primitives as f64 / row.crossing_primitives.max(1) as f64,
+                row.overlay_share * 100.0,
+                micros(row.visibility_median),
+                micros(row.visibility_best),
+                row.buffered_area_ratio,
+            ),
+            None => println!(
+                "  {edge:>5.0}  unusable at this viewport — see TileSpan::MAX_TILES"
+            ),
+        }
+    }
+
+    println!(
+        "\n  crossing = primitives written when a pan crosses one tile boundary.\n  \
+         refill   = primitives a whole-region refill writes, i.e. what Buffering::Margin\n             \
+         costs for the same pan (R-N §7). ratio is refill/crossing — higher is better.\n  \
+         overlay  = share of resident primitives on the unbuffered overlay layer, which\n             \
+         the tile grid does not cull.\n  \
+         vis      = GPU wall clock for the tile-visibility dispatch, including its\n             \
+         parameter upload and submit."
+    );
+    println!(
+        "\n  READ THE RATIO COLUMN WITH THE AREA IN BRACKETS. `refill` is the whole\n  \
+         resident region, and that region is not the same size across the sweep: a\n  \
+         retain radius of one tile buffers a ring whose width *is* the tile size. So a\n  \
+         large tile inflates its own refill baseline, and the ratio is only a like-for-\n  \
+         like comparison against Buffering::Margin(None) — which buffers 2.25x the\n  \
+         viewport (1.5 on each axis, §4.1) — where the bracketed area is near 2.25x.\n  \
+         Rows far above that are comparing against a bigger buffer than Margin would\n  \
+         have kept, and their ratio flatters tiling."
+    );
+    println!(
+        "\n  AND READ THE `vis` COLUMN AS A CEILING, NOT AS THE KERNEL'S COST. It ends in\n  \
+         Device::poll(wait_indefinitely), which waits for everything already submitted —\n  \
+         the same effect docs/phase-4-results.md §5 records for the readback path. The\n  \
+         dispatch itself is one workgroup per 64 tiles over a few dozen tiles; what these\n  \
+         numbers mostly measure is one submit-and-synchronize round trip, which is why\n  \
+         they barely move with the tile count. A real frame pipelines this dispatch with\n  \
+         the rest of its work and never polls it, so nothing here should be read as a\n  \
+         per-frame cost. It is reported to show the pass is not accidentally expensive,\n  \
+         and it is not: the whole column is flat and the variance between rows is noise\n  \
+         (see the 384 row's median against its own best)."
+    );
+}
+
+struct Row {
+    resident_tiles: usize,
+    slots_per_frame: usize,
+    crossing_primitives: usize,
+    refill_primitives: usize,
+    overlay_share: f64,
+    /// The resident region's area as a multiple of the viewport's — what makes
+    /// the `refill` baseline comparable across rows, or not. See the note the
+    /// table prints beneath itself.
+    buffered_area_ratio: f64,
+    visibility_median: Duration,
+    visibility_best: Duration,
+}
+
+fn measure(context: &ComputeContext, edge: f32) -> Option<Row> {
+    let policy = BoundaryPolicy {
+        // Long enough that the sweep's own pan never evicts, so the resident
+        // count reported is the grid's shape rather than the eviction interval's.
+        evict_after_frames: 240,
+        ..TiledCanvasDriver::tiled_policy(edge, RETAIN_RADIUS, BUDGET)
+    };
+    let mut canvas = TiledCanvasDriver::new(&NodeGraphSpec::large(), viewport(), policy);
+
+    // Settle at a deliberately tile-unaligned offset: a viewport whose edges sit
+    // on exact multiples of the tile size crosses a boundary on its first pixel
+    // of pan, which would make the "crossing" column measure the wrong frame.
+    let first = canvas.pan_to([-8.0, -8.0]).ok()?;
+    if first.visible_tiles == 0 {
+        return None;
+    }
+    canvas.settle();
+
+    let refill_primitives = canvas.resident_primitives();
+    let overlay_share = if refill_primitives == 0 {
+        0.0
+    } else {
+        canvas.overlay_primitives() as f64 / refill_primitives as f64
+    };
+    let slots_per_frame = first.visible_tiles + 1;
+
+    let crossing = canvas.pan_to([-8.0 - edge, -8.0]).ok()?;
+    canvas.settle();
+
+    let visibility = time_visibility(context, &canvas, edge)?;
+
+    // The ring a retain radius of one buffers is one tile wide on every side, so
+    // the buffered area grows with the tile size — which is exactly why the
+    // `refill` column is not comparable across rows without this number.
+    let buffered_width = VIEWPORT_WIDTH + 2.0 * RETAIN_RADIUS as f64 as f32 * edge;
+    let buffered_height = VIEWPORT_HEIGHT + 2.0 * RETAIN_RADIUS as f64 as f32 * edge;
+    let buffered_area_ratio = (buffered_width as f64 * buffered_height as f64)
+        / (VIEWPORT_WIDTH as f64 * VIEWPORT_HEIGHT as f64);
+
+    Some(Row {
+        resident_tiles: crossing.resident_tiles,
+        slots_per_frame,
+        crossing_primitives: crossing.primitives_written,
+        refill_primitives,
+        overlay_share,
+        buffered_area_ratio,
+        visibility_median: visibility.0,
+        visibility_best: visibility.1,
+    })
+}
+
+/// Time the visibility dispatch over this grid's resident tile set.
+///
+/// The clock covers the parameter upload, the descriptor upload, the dispatch,
+/// and a `poll` that waits for it — so it is GPU work included, not command
+/// encoding alone. That is deliberate here and different from Phase 4's
+/// draw-issue clock: the question this column answers is whether deciding
+/// visibility costs less than the rendering it avoids, and only a wall clock
+/// that includes the device can answer it.
+fn time_visibility(
+    context: &ComputeContext,
+    canvas: &TiledCanvasDriver,
+    edge: f32,
+) -> Option<(Duration, Duration)> {
+    let state = canvas.compositor.state(canvas.boundary)?;
+    let residency = state.tiles()?;
+    let resident = residency.resident();
+    let tiles: Vec<TileDescriptor> = resident
+        .iter()
+        .enumerate()
+        .map(|(index, coord)| TileDescriptor {
+            coord: *coord,
+            base: index as u32 * 32,
+            count: 32,
+        })
+        .collect();
+    let arena_slots = tiles.len() as u32 * 32;
+    let mut tile_bytes = Vec::new();
+    encode_tiles(&tiles, &mut tile_bytes);
+
+    let pass = TileVisibilityPass::new(&context.device);
+    let indirect = IndirectArgsPass::new(&context.device);
+    let buffers = TileVisibilityBuffers::new(&context.device, tiles.len() as u32);
+    let args = IndirectArgsBuffers::new(&context.device, arena_slots, tiles.len() as u32 + 1);
+    let view = viewport();
+    let params = TileViewport {
+        tile_size: [edge, edge],
+        pan: [-8.0 - edge, -8.0],
+        viewport: [view.min_x, view.min_y, view.max_x, view.max_y],
+        retain_radius: RETAIN_RADIUS,
+    };
+
+    let mut samples = Vec::with_capacity(RUNS);
+    for run in 0..WARM_UP + RUNS {
+        let started = Instant::now();
+        pass.run_into_args(
+            &context.device,
+            &context.queue,
+            &buffers,
+            &indirect,
+            &args,
+            &tile_bytes,
+            params,
+            QUAD_VERTEX_COUNT,
+            FirstInstance::Zero,
+        )
+        .ok()?;
+        context.device.poll(wgpu::PollType::wait_indefinitely()).ok()?;
+        let elapsed = started.elapsed();
+        if run >= WARM_UP {
+            samples.push(elapsed);
+        }
+    }
+    samples.sort_unstable();
+    Some((
+        samples.get(samples.len().saturating_sub(1) / 2).copied()?,
+        samples.first().copied()?,
+    ))
+}
+
+fn micros(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}

--- a/crates/wgpui-wgpu/examples/phase45_tiling_bench.rs
+++ b/crates/wgpui-wgpu/examples/phase45_tiling_bench.rs
@@ -54,7 +54,7 @@ use wgpui_core::scene::{TileDescriptor, encode_tiles};
 use wgpui_core::test_support::ui_walk::{NodeGraphSpec, TiledCanvasDriver};
 use wgpui_wgpu::render::compute::indirect_args_pass::{IndirectArgsBuffers, IndirectArgsPass};
 use wgpui_wgpu::render::compute::tile_visibility_pass::{
-    TileViewport, TileVisibilityBuffers, TileVisibilityPass,
+    ArgsTarget, TileViewport, TileVisibilityBuffers, TileVisibilityPass,
 };
 use wgpui_wgpu::render::device::{ComputeContext, headless_compute_context};
 
@@ -275,12 +275,14 @@ fn time_visibility(
             &context.device,
             &context.queue,
             &buffers,
-            &indirect,
-            &args,
+            ArgsTarget {
+                pass: &indirect,
+                buffers: &args,
+                vertex_count: QUAD_VERTEX_COUNT,
+                first_instance: FirstInstance::Zero,
+            },
             &tile_bytes,
             params,
-            QUAD_VERTEX_COUNT,
-            FirstInstance::Zero,
         )
         .ok()?;
         context.device.poll(wgpu::PollType::wait_indefinitely()).ok()?;

--- a/crates/wgpui-wgpu/src/render/compute/indirect_args_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/indirect_args_pass.rs
@@ -162,6 +162,22 @@ impl IndirectArgsBuffers {
     }
 }
 
+/// A slot table that lives on the device, and how many records it holds.
+///
+/// The two travel together because neither is checkable against the other once
+/// the CPU has stopped reading the table: a count from one pass paired with
+/// another pass's buffer would generate arguments for records that are not
+/// there, silently. Same reasoning as Phase 4's `CompositePlan` — see
+/// `docs/phase-4-results.md` §1 — and the same resolution to the same clippy
+/// finding, which is to make the pairing a type rather than a convention.
+#[derive(Copy, Clone)]
+pub struct GeneratedSlots<'a> {
+    /// One `[base, count, 0, 0]` record per slot.
+    pub buffer: &'a wgpu::Buffer,
+    /// How many records the buffer holds.
+    pub count: u32,
+}
+
 /// What one dispatch decided, as far as the CPU is allowed to know it without
 /// asking.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -319,8 +335,10 @@ impl IndirectArgsPass {
             device,
             queue,
             buffers,
-            &slot_buffer,
-            slot_count,
+            GeneratedSlots {
+                buffer: &slot_buffer,
+                count: slot_count,
+            },
             vertex_count,
             first_instance,
         );
@@ -355,22 +373,13 @@ impl IndirectArgsPass {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         buffers: &IndirectArgsBuffers,
-        slot_buffer: &wgpu::Buffer,
-        slot_count: u32,
+        slots: GeneratedSlots<'_>,
         vertex_count: u32,
         first_instance: FirstInstance,
     ) -> IndirectArgsOutput {
-        self.dispatch_with_slots(
-            device,
-            queue,
-            buffers,
-            slot_buffer,
-            slot_count,
-            vertex_count,
-            first_instance,
-        );
+        self.dispatch_with_slots(device, queue, buffers, slots, vertex_count, first_instance);
         IndirectArgsOutput {
-            slot_count,
+            slot_count: slots.count,
             first_instance,
             vertex_count,
         }
@@ -381,11 +390,11 @@ impl IndirectArgsPass {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         buffers: &IndirectArgsBuffers,
-        slot_buffer: &wgpu::Buffer,
-        slot_count: u32,
+        slots: GeneratedSlots<'_>,
         vertex_count: u32,
         first_instance: FirstInstance,
     ) {
+        let slot_count = slots.count;
         let params = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("indirect args params"),
             size: 16,
@@ -408,7 +417,7 @@ impl IndirectArgsPass {
             layout: &self.layout,
             entries: &[
                 binding(0, &params),
-                binding(1, slot_buffer),
+                binding(1, slots.buffer),
                 binding(2, &buffers.draw_order),
                 binding(3, &buffers.culled),
                 binding(4, &buffers.visible),

--- a/crates/wgpui-wgpu/src/render/compute/indirect_args_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/indirect_args_pass.rs
@@ -315,12 +315,100 @@ impl IndirectArgsPass {
             queue.write_buffer(&slot_buffer, 0, slots);
         }
 
+        self.dispatch_with_slots(
+            device,
+            queue,
+            buffers,
+            &slot_buffer,
+            slot_count,
+            vertex_count,
+            first_instance,
+        );
+        Ok(IndirectArgsOutput {
+            slot_count,
+            first_instance,
+            vertex_count,
+        })
+    }
+
+    /// Generate arguments from a slot table **the GPU wrote**, rather than one
+    /// the CPU uploaded.
+    ///
+    /// This is the seam §4.3's tile-visibility pass plugs into, and the reason
+    /// tiling needed no draw path of its own. `slot_buffer` holds one
+    /// `[base, count, 0, 0]` record per slot in exactly
+    /// [`wgpui_core::indirect::encode_slots`]' layout — which is what
+    /// `tile_visibility.wgsl` writes, with an out-of-range tile's count zeroed.
+    /// Everything downstream is unchanged: `compact` turns a zero count into a
+    /// zero-instance record and `pack` drops it, so a tile that is out of range
+    /// simply has nothing to draw.
+    ///
+    /// **The caller validates, because the CPU no longer can.** [`Self::run`]
+    /// checks each slot's reservation against the arena before dispatching; a
+    /// GPU-written table cannot be read without a readback, which is the whole
+    /// thing this path exists to avoid. The caller knows each tile's base and
+    /// count — it wrote the tile descriptors — so it validates those instead.
+    /// [`crate::render::compute::tile_visibility_pass::TileVisibilityPass::run`]
+    /// does exactly that.
+    pub fn run_with_slots(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffers: &IndirectArgsBuffers,
+        slot_buffer: &wgpu::Buffer,
+        slot_count: u32,
+        vertex_count: u32,
+        first_instance: FirstInstance,
+    ) -> IndirectArgsOutput {
+        self.dispatch_with_slots(
+            device,
+            queue,
+            buffers,
+            slot_buffer,
+            slot_count,
+            vertex_count,
+            first_instance,
+        );
+        IndirectArgsOutput {
+            slot_count,
+            first_instance,
+            vertex_count,
+        }
+    }
+
+    fn dispatch_with_slots(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffers: &IndirectArgsBuffers,
+        slot_buffer: &wgpu::Buffer,
+        slot_count: u32,
+        vertex_count: u32,
+        first_instance: FirstInstance,
+    ) {
+        let params = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("indirect args params"),
+            size: 16,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut params_bytes = Vec::with_capacity(16);
+        for value in [
+            slot_count,
+            first_instance.as_u32(),
+            vertex_count,
+            buffers.arena_slots,
+        ] {
+            params_bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        queue.write_buffer(&params, 0, &params_bytes);
+
         let group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("indirect args"),
             layout: &self.layout,
             entries: &[
                 binding(0, &params),
-                binding(1, &slot_buffer),
+                binding(1, slot_buffer),
                 binding(2, &buffers.draw_order),
                 binding(3, &buffers.culled),
                 binding(4, &buffers.visible),
@@ -345,12 +433,6 @@ impl IndirectArgsPass {
         // compaction has to stay order-preserving across the whole table.
         dispatch(&mut encoder, &self.pack, &group, 1);
         queue.submit(Some(encoder.finish()));
-
-        Ok(IndirectArgsOutput {
-            slot_count,
-            first_instance,
-            vertex_count,
-        })
     }
 
     /// Read the argument records back — the differential harness's use, and the

--- a/crates/wgpui-wgpu/src/render/compute/tile_visibility_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/tile_visibility_pass.rs
@@ -1,3 +1,429 @@
 //! Dispatches `wgpui_core::shaders::TILE_VISIBILITY_WGSL` (§4.3).
 //! See docs/gpu-native-architecture.md §4.3, §8 Phase 4.5.
-#![allow(dead_code)]
+//!
+//! # What this pass produces, and what it deliberately is not
+//!
+//! One `[base, count, 0, 0]` slot record per resident tile, with the count
+//! zeroed for tiles outside (viewport ∪ retain radius). That record layout is
+//! not a coincidence and not a convention this file invented — it is exactly
+//! [`wgpui_core::indirect::encode_slots`]' layout, the input
+//! `indirect_args.wgsl`'s `compact` already reads.
+//!
+//! So this pass has no draw path, no pipeline, and no output buffer of its own
+//! beyond the one it hands straight to
+//! [`IndirectArgsPass::run_with_slots`]. An out-of-range tile becomes a
+//! zero-instance argument record through Phase 4's machinery untouched, and
+//! `pack` drops it from a `multi_draw_indirect_count` entirely. §4.3 claims
+//! tiling "needs almost no new machinery"; this file is how much that turned out
+//! to be.
+//!
+//! # The computation is written once, in Rust
+//!
+//! [`wgpui_core::scene::tile::tile_visibility`] is the reference and
+//! `tile_visibility.wgsl` is its transcription, compared for exact equality by
+//! `tests/tile_visibility.rs`. Phase 3's discipline unchanged, and for the same
+//! reason: there is no CPU-side result to eyeball.
+//!
+//! # Where the CPU is still involved, stated rather than glossed
+//!
+//! §4.3's wording is that "the CPU never enumerates tile candidates," and on the
+//! draw path that is exactly true — the CPU hands over resident tile descriptors
+//! and never learns which of them drew. It is not true of *residency*, and
+//! cannot be: a newly-revealed tile has to have content rendered into it, which
+//! is CPU work no visibility kernel can do. `wgpui_core`'s `TileResidency` runs
+//! the same predicate on the CPU for the tiles it keeps resident. The two are
+//! the same rule, checked against each other, and `docs/phase-4.5-results.md`
+//! says so rather than letting the shader's existence imply otherwise.
+
+use std::num::NonZeroU64;
+
+use wgpui_core::indirect::{DRAW_SLOT_STRIDE, FirstInstance};
+use wgpui_core::ordering::BLOCK_SIZE;
+use wgpui_core::scene::TILE_DESCRIPTOR_STRIDE;
+
+use crate::render::compute::indirect_args_pass::{
+    IndirectArgsBuffers, IndirectArgsOutput, IndirectArgsPass,
+};
+use crate::render::readback::{ReadbackError, read_u32_buffer};
+
+/// Bytes the shader's `Params` uniform occupies.
+const PARAMS_SIZE: u64 = 48;
+
+/// Why a tile-visibility dispatch failed.
+#[derive(Debug)]
+pub enum TileVisibilityError {
+    /// The encoded descriptor table's length is not a whole number of tiles.
+    MalformedTiles {
+        /// Bytes supplied.
+        bytes: usize,
+        /// Bytes one descriptor occupies.
+        stride: usize,
+    },
+    /// A tile's reservation runs past the arena it claims to be in.
+    ///
+    /// [`IndirectArgsPass::run`] makes this check against a CPU-uploaded slot
+    /// table; the whole point of this pass is that the slot table is written on
+    /// the device, so the check moves here, onto the descriptors the caller
+    /// *did* write. Dropping it rather than moving it would hand
+    /// `copy_buffer_to_buffer` and the compaction an out-of-range base, which is
+    /// an uncaptured device error and by default aborts the process.
+    TileOutsideArena {
+        /// Which descriptor.
+        index: usize,
+        /// Its last slot index.
+        end: u64,
+        /// Slots the arena holds.
+        arena_slots: u32,
+    },
+    /// More tiles than the argument buffers are sized for.
+    TooManyTiles {
+        /// Descriptors supplied.
+        tiles: u32,
+        /// Slots the buffers hold.
+        capacity: u32,
+    },
+    /// A readback failed.
+    Readback(ReadbackError),
+}
+
+impl std::fmt::Display for TileVisibilityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TileVisibilityError::MalformedTiles { bytes, stride } => write!(
+                formatter,
+                "tile descriptor table is {bytes} bytes, not a multiple of the \
+                 {stride}-byte stride"
+            ),
+            TileVisibilityError::TileOutsideArena {
+                index,
+                end,
+                arena_slots,
+            } => write!(
+                formatter,
+                "tile {index} ends at arena slot {end}, past the arena's {arena_slots}"
+            ),
+            TileVisibilityError::TooManyTiles { tiles, capacity } => write!(
+                formatter,
+                "{tiles} resident tiles against argument buffers sized for {capacity} slots"
+            ),
+            TileVisibilityError::Readback(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for TileVisibilityError {}
+
+impl From<ReadbackError> for TileVisibilityError {
+    fn from(error: ReadbackError) -> Self {
+        TileVisibilityError::Readback(error)
+    }
+}
+
+/// Where a tiled boundary's content sits relative to its window, this frame.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct TileViewport {
+    /// Tile edge lengths in logical pixels.
+    pub tile_size: [f32; 2],
+    /// The boundary's layer transform — where its content composites.
+    pub pan: [f32; 2],
+    /// The boundary's visible rectangle in window space: min, then max.
+    pub viewport: [f32; 4],
+    /// How many tiles beyond the viewport stay in range.
+    pub retain_radius: u32,
+}
+
+/// The buffers one tile-visibility dispatch writes.
+///
+/// Held across frames by the caller for the same reason
+/// [`IndirectArgsBuffers`] is: the resident tile set changes slowly, and
+/// reallocating per frame would put an allocation in front of a pass whose whole
+/// purpose is that the CPU stops doing per-frame work.
+pub struct TileVisibilityBuffers {
+    /// `[base, count, 0, 0]` per tile — the slot table
+    /// [`IndirectArgsPass::run_with_slots`] consumes.
+    pub slots: wgpu::Buffer,
+    /// `1` in range, `0` out, per tile.
+    pub in_range: wgpu::Buffer,
+    /// Tiles these buffers are sized for.
+    pub tile_capacity: u32,
+}
+
+impl TileVisibilityBuffers {
+    /// Allocate for at most `tile_capacity` resident tiles.
+    pub fn new(device: &wgpu::Device, tile_capacity: u32) -> TileVisibilityBuffers {
+        let capacity = tile_capacity.max(1);
+        TileVisibilityBuffers {
+            slots: storage_buffer(
+                device,
+                "tile visibility slots",
+                u64::from(capacity) * DRAW_SLOT_STRIDE as u64,
+            ),
+            in_range: storage_buffer(device, "tile visibility mask", u64::from(capacity) * 4),
+            tile_capacity: capacity,
+        }
+    }
+
+    /// Whether these buffers can serve `tiles` tiles without being reallocated.
+    pub fn fits(&self, tiles: u32) -> bool {
+        self.tile_capacity >= tiles
+    }
+}
+
+/// The compiled tile-visibility pipeline. Build once, dispatch once per tiled
+/// boundary per frame.
+pub struct TileVisibilityPass {
+    layout: wgpu::BindGroupLayout,
+    visibility: wgpu::ComputePipeline,
+}
+
+impl TileVisibilityPass {
+    /// Compile `tile_visibility.wgsl`.
+    pub fn new(device: &wgpu::Device) -> TileVisibilityPass {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("wgpui tile visibility"),
+            source: wgpu::ShaderSource::Wgsl(wgpui_core::shaders::TILE_VISIBILITY_WGSL.into()),
+        });
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("tile visibility"),
+            entries: &[
+                uniform_entry(0, PARAMS_SIZE),
+                storage_entry(1, true),
+                storage_entry(2, false),
+                storage_entry(3, false),
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("tile visibility"),
+            bind_group_layouts: &[Some(&layout)],
+            immediate_size: 0,
+        });
+        TileVisibilityPass {
+            visibility: device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tile_visibility"),
+                layout: Some(&pipeline_layout),
+                module: &module,
+                entry_point: Some("tile_visibility"),
+                compilation_options: Default::default(),
+                cache: None,
+            }),
+            layout,
+        }
+    }
+
+    /// Decide which tiles are in range and write their draw slots.
+    ///
+    /// `tiles` is [`wgpui_core::scene::encode_tiles`]' output for the boundary's
+    /// resident tile set. Returns nothing about which tiles drew — that is the
+    /// point, and it is the same shape as
+    /// [`crate::render::draw::DrawStats::instances_known_to_cpu`] being `None`
+    /// on every indirect path.
+    pub fn run(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffers: &TileVisibilityBuffers,
+        tiles: &[u8],
+        viewport: TileViewport,
+        arena_slots: u32,
+    ) -> Result<u32, TileVisibilityError> {
+        if !tiles.len().is_multiple_of(TILE_DESCRIPTOR_STRIDE) {
+            return Err(TileVisibilityError::MalformedTiles {
+                bytes: tiles.len(),
+                stride: TILE_DESCRIPTOR_STRIDE,
+            });
+        }
+        let tile_count = u32::try_from(tiles.len() / TILE_DESCRIPTOR_STRIDE).unwrap_or(u32::MAX);
+        if !buffers.fits(tile_count) {
+            return Err(TileVisibilityError::TooManyTiles {
+                tiles: tile_count,
+                capacity: buffers.tile_capacity,
+            });
+        }
+        // The validation `IndirectArgsPass::run` does on a CPU-uploaded slot
+        // table, moved onto the input the CPU still owns — see
+        // `TileVisibilityError::TileOutsideArena`.
+        for (index, tile) in tiles.chunks_exact(TILE_DESCRIPTOR_STRIDE).enumerate() {
+            let base = u64::from(read_u32(tile, 8));
+            let count = u64::from(read_u32(tile, 12));
+            if base + count > u64::from(arena_slots) {
+                return Err(TileVisibilityError::TileOutsideArena {
+                    index,
+                    end: base + count,
+                    arena_slots,
+                });
+            }
+        }
+
+        let params = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tile visibility params"),
+            size: PARAMS_SIZE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut params_bytes = Vec::with_capacity(PARAMS_SIZE as usize);
+        for value in [
+            viewport.tile_size[0],
+            viewport.tile_size[1],
+            viewport.pan[0],
+            viewport.pan[1],
+        ] {
+            params_bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        for value in viewport.viewport {
+            params_bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        for value in [tile_count, viewport.retain_radius, 0, 0] {
+            params_bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        queue.write_buffer(&params, 0, &params_bytes);
+
+        let tile_buffer = storage_buffer(
+            device,
+            "tile descriptors",
+            (tiles.len() as u64).max(TILE_DESCRIPTOR_STRIDE as u64),
+        );
+        if !tiles.is_empty() {
+            queue.write_buffer(&tile_buffer, 0, tiles);
+        }
+
+        let group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("tile visibility"),
+            layout: &self.layout,
+            entries: &[
+                binding(0, &params),
+                binding(1, &tile_buffer),
+                binding(2, &buffers.slots),
+                binding(3, &buffers.in_range),
+            ],
+        });
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("tile visibility"),
+        });
+        if tile_count > 0 {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&self.visibility);
+            pass.set_bind_group(0, &group, &[]);
+            pass.dispatch_workgroups(tile_count.div_ceil(BLOCK_SIZE), 1, 1);
+        }
+        queue.submit(Some(encoder.finish()));
+        Ok(tile_count)
+    }
+
+    /// Decide visibility and generate this frame's indirect draw arguments from
+    /// the result, without the slot table ever reaching the CPU.
+    ///
+    /// The whole of §4.3's draw path in one call, and it is two dispatches: this
+    /// pass writes the slots, [`IndirectArgsPass::run_with_slots`] turns them
+    /// into arguments. Nothing between them is read back.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_into_args(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffers: &TileVisibilityBuffers,
+        indirect: &IndirectArgsPass,
+        args: &IndirectArgsBuffers,
+        tiles: &[u8],
+        viewport: TileViewport,
+        vertex_count: u32,
+        first_instance: FirstInstance,
+    ) -> Result<IndirectArgsOutput, TileVisibilityError> {
+        let tile_count = self.run(device, queue, buffers, tiles, viewport, args.arena_slots)?;
+        Ok(indirect.run_with_slots(
+            device,
+            queue,
+            args,
+            &buffers.slots,
+            tile_count,
+            vertex_count,
+            first_instance,
+        ))
+    }
+
+    /// Read the visibility mask back — the differential's use, never the draw
+    /// path's.
+    pub fn read_in_range(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffers: &TileVisibilityBuffers,
+        tile_count: u32,
+    ) -> Result<Vec<u32>, TileVisibilityError> {
+        Ok(read_u32_buffer(
+            device,
+            queue,
+            &buffers.in_range,
+            tile_count as usize,
+        )?)
+    }
+
+    /// Read the generated slot table back — the differential's use, never the
+    /// draw path's.
+    pub fn read_slots(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        buffers: &TileVisibilityBuffers,
+        tile_count: u32,
+    ) -> Result<Vec<[u32; 4]>, TileVisibilityError> {
+        let words = read_u32_buffer(device, queue, &buffers.slots, tile_count as usize * 4)?;
+        Ok(words
+            .chunks_exact(4)
+            .map(|chunk| [chunk[0], chunk[1], chunk[2], chunk[3]])
+            .collect())
+    }
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> u32 {
+    match bytes.get(offset..offset + 4) {
+        Some(slice) => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]),
+        None => 0,
+    }
+}
+
+fn storage_buffer(device: &wgpu::Device, label: &str, size: u64) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        // Never zero: a zero-sized storage binding is invalid, and a boundary
+        // with no resident tiles still has to bind something.
+        size: size.max(16),
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_DST
+            | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    })
+}
+
+fn binding<'a>(index: u32, buffer: &'a wgpu::Buffer) -> wgpu::BindGroupEntry<'a> {
+    wgpu::BindGroupEntry {
+        binding: index,
+        resource: buffer.as_entire_binding(),
+    }
+}
+
+fn uniform_entry(binding: u32, size: u64) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: NonZeroU64::new(size),
+        },
+        count: None,
+    }
+}
+
+fn storage_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}

--- a/crates/wgpui-wgpu/src/render/compute/tile_visibility_pass.rs
+++ b/crates/wgpui-wgpu/src/render/compute/tile_visibility_pass.rs
@@ -42,7 +42,7 @@ use wgpui_core::ordering::BLOCK_SIZE;
 use wgpui_core::scene::TILE_DESCRIPTOR_STRIDE;
 
 use crate::render::compute::indirect_args_pass::{
-    IndirectArgsBuffers, IndirectArgsOutput, IndirectArgsPass,
+    GeneratedSlots, IndirectArgsBuffers, IndirectArgsOutput, IndirectArgsPass,
 };
 use crate::render::readback::{ReadbackError, read_u32_buffer};
 
@@ -167,6 +167,30 @@ impl TileVisibilityBuffers {
     pub fn fits(&self, tiles: u32) -> bool {
         self.tile_capacity >= tiles
     }
+}
+
+/// Where a tile-visibility result turns into draw arguments: the pass that does
+/// it, the buffers it writes, and the encoding it writes them in.
+///
+/// One type rather than four parameters because all four are properties of the
+/// same argument-generation stage, and the two that are not obviously paired
+/// still are: `vertex_count` and `first_instance` together *are* the record
+/// encoding, and splitting them across a call site is how a record ends up
+/// carrying a base the shader is not expecting (`indirect.rs`'s
+/// `FirstInstance` doc has the full story). Also what keeps
+/// [`TileVisibilityPass::run_into_args`] inside clippy's argument limit without
+/// a suppression, which is the same finding and the same resolution Phases 3
+/// and 4 both recorded.
+#[derive(Copy, Clone)]
+pub struct ArgsTarget<'a> {
+    /// The argument-generation pass.
+    pub pass: &'a IndirectArgsPass,
+    /// Its arena-shaped buffers.
+    pub buffers: &'a IndirectArgsBuffers,
+    /// Vertices one instance draws.
+    pub vertex_count: u32,
+    /// Where each record's base index is carried.
+    pub first_instance: FirstInstance,
 }
 
 /// The compiled tile-visibility pipeline. Build once, dispatch once per tiled
@@ -316,28 +340,33 @@ impl TileVisibilityPass {
     /// The whole of §4.3's draw path in one call, and it is two dispatches: this
     /// pass writes the slots, [`IndirectArgsPass::run_with_slots`] turns them
     /// into arguments. Nothing between them is read back.
-    #[allow(clippy::too_many_arguments)]
     pub fn run_into_args(
         &self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         buffers: &TileVisibilityBuffers,
-        indirect: &IndirectArgsPass,
-        args: &IndirectArgsBuffers,
+        target: ArgsTarget<'_>,
         tiles: &[u8],
         viewport: TileViewport,
-        vertex_count: u32,
-        first_instance: FirstInstance,
     ) -> Result<IndirectArgsOutput, TileVisibilityError> {
-        let tile_count = self.run(device, queue, buffers, tiles, viewport, args.arena_slots)?;
-        Ok(indirect.run_with_slots(
+        let tile_count = self.run(
             device,
             queue,
-            args,
-            &buffers.slots,
-            tile_count,
-            vertex_count,
-            first_instance,
+            buffers,
+            tiles,
+            viewport,
+            target.buffers.arena_slots,
+        )?;
+        Ok(target.pass.run_with_slots(
+            device,
+            queue,
+            target.buffers,
+            GeneratedSlots {
+                buffer: &buffers.slots,
+                count: tile_count,
+            },
+            target.vertex_count,
+            target.first_instance,
         ))
     }
 

--- a/crates/wgpui-wgpu/tests/tile_visibility.rs
+++ b/crates/wgpui-wgpu/tests/tile_visibility.rs
@@ -24,7 +24,7 @@ use wgpui_core::scene::{TileCoord, TileDescriptor, TileGrid, encode_tiles, tile_
 
 use wgpui_wgpu::render::compute::indirect_args_pass::{IndirectArgsBuffers, IndirectArgsPass};
 use wgpui_wgpu::render::compute::tile_visibility_pass::{
-    TileViewport, TileVisibilityBuffers, TileVisibilityPass,
+    ArgsTarget, TileViewport, TileVisibilityBuffers, TileVisibilityPass,
 };
 use wgpui_wgpu::render::device::context_or_report;
 
@@ -205,12 +205,14 @@ fn arguments_generated_from_the_gpu_written_slot_table_match_the_cpu_reference()
                 &context.device,
                 &context.queue,
                 &visibility_buffers,
-                &indirect,
-                &args_buffers,
+                ArgsTarget {
+                    pass: &indirect,
+                    buffers: &args_buffers,
+                    vertex_count: QUAD_VERTEX_COUNT,
+                    first_instance: FirstInstance::Zero,
+                },
                 &tile_bytes,
                 tile_viewport(pan),
-                QUAD_VERTEX_COUNT,
-                FirstInstance::Zero,
             )
             .expect("the two dispatches must succeed");
         assert_eq!(output.slot_count, tiles.len() as u32);

--- a/crates/wgpui-wgpu/tests/tile_visibility.rs
+++ b/crates/wgpui-wgpu/tests/tile_visibility.rs
@@ -1,0 +1,396 @@
+//! §4.3's tile-visibility pass, checked against its CPU reference and driven
+//! through Phase 4's indirect-arg mechanism end to end.
+//! See docs/gpu-native-architecture.md §4.3, §8 Phase 4.5.
+//!
+//! Three claims, in the order they build on each other:
+//!
+//! 1. **The transcription is exact.** `tile_visibility.wgsl` and
+//!    `wgpui_core::scene::tile_visibility` agree slot-for-slot and flag-for-flag
+//!    over a scripted pan — Phase 3's discipline, unchanged.
+//! 2. **The GPU-written slot table drives Phase 4's mechanism unmodified.** The
+//!    argument records generated from it equal the ones
+//!    `wgpui_core::indirect::indirect_args` computes for the same tiles, with no
+//!    slot table ever reaching the CPU in between.
+//! 3. **An out-of-range tile issues a draw for zero instances**, which is how a
+//!    tile stops being drawn without anything new deciding that it should.
+
+use wgpui_core::geometry::Rect;
+use wgpui_core::indirect::{
+    DrawSlot, FirstInstance, QUAD_VERTEX_COUNT, UNUSED_INSTANCE, indirect_args,
+};
+use wgpui_core::patch::primitive::PrimitiveKind;
+use wgpui_core::scene::layer::LayerId;
+use wgpui_core::scene::{TileCoord, TileDescriptor, TileGrid, encode_tiles, tile_visibility};
+
+use wgpui_wgpu::render::compute::indirect_args_pass::{IndirectArgsBuffers, IndirectArgsPass};
+use wgpui_wgpu::render::compute::tile_visibility_pass::{
+    TileViewport, TileVisibilityBuffers, TileVisibilityPass,
+};
+use wgpui_wgpu::render::device::context_or_report;
+
+const TILE_EDGE: f32 = 256.0;
+const RETAIN_RADIUS: u32 = 1;
+/// Slots one tile reserves in the arena. Uniform across tiles here so the
+/// arena's shape is obvious in a failing assertion; nothing in the pass depends
+/// on it being uniform.
+const PER_TILE: u32 = 8;
+
+fn grid() -> TileGrid {
+    TileGrid::square(TILE_EDGE).expect("256px is a usable tile edge")
+}
+
+/// A resident tile set spanning both signs, so negative coordinates are
+/// exercised rather than assumed to work — they are bit-cast through a `u32` on
+/// the way to the shader, which is precisely where a sign would be lost.
+fn resident_tiles() -> Vec<TileDescriptor> {
+    let mut tiles = Vec::new();
+    let mut base = 0u32;
+    for y in -3..=3i32 {
+        for x in -3..=3i32 {
+            tiles.push(TileDescriptor {
+                coord: TileCoord::new(x, y),
+                base,
+                count: PER_TILE,
+            });
+            base += PER_TILE;
+        }
+    }
+    tiles
+}
+
+fn arena_slots(tiles: &[TileDescriptor]) -> u32 {
+    tiles
+        .iter()
+        .map(|tile| tile.base + tile.count)
+        .max()
+        .unwrap_or(0)
+}
+
+/// A pan script that crosses tile boundaries in both axes and both directions.
+fn pan_script() -> Vec<[f32; 2]> {
+    let mut script = vec![[0.0, 0.0]];
+    for step in 1..=10i32 {
+        script.push([-(step as f32) * 97.0, 0.0]);
+    }
+    for step in 1..=10i32 {
+        script.push([-970.0, -(step as f32) * 61.0]);
+    }
+    for step in 1..=10i32 {
+        script.push([-970.0 + step as f32 * 143.0, -610.0 + step as f32 * 89.0]);
+    }
+    script
+}
+
+fn viewport() -> Rect {
+    Rect::from_origin_size([0.0, 0.0], [900.0, 620.0])
+}
+
+fn tile_viewport(pan: [f32; 2]) -> TileViewport {
+    let view = viewport();
+    TileViewport {
+        tile_size: [TILE_EDGE, TILE_EDGE],
+        pan,
+        viewport: [view.min_x, view.min_y, view.max_x, view.max_y],
+        retain_radius: RETAIN_RADIUS,
+    }
+}
+
+#[test]
+fn the_tile_visibility_transcription_matches_its_cpu_reference_over_a_pan() {
+    let Some(context) = context_or_report("tile visibility differential") else {
+        return;
+    };
+    let pass = TileVisibilityPass::new(&context.device);
+    let tiles = resident_tiles();
+    let mut tile_bytes = Vec::new();
+    encode_tiles(&tiles, &mut tile_bytes);
+    let buffers = TileVisibilityBuffers::new(&context.device, tiles.len() as u32);
+    let grid = grid();
+    let slots = arena_slots(&tiles);
+
+    let mut visible_seen = 0usize;
+    let mut hidden_seen = 0usize;
+    for pan in pan_script() {
+        let tile_count = pass
+            .run(
+                &context.device,
+                &context.queue,
+                &buffers,
+                &tile_bytes,
+                tile_viewport(pan),
+                slots,
+            )
+            .expect("the dispatch must succeed");
+        assert_eq!(tile_count, tiles.len() as u32);
+
+        let content_viewport = TileGrid::content_viewport(
+            viewport(),
+            wgpui_core::scene::layer::LayerTransform::translated(pan[0], pan[1]),
+        );
+        let reference = tile_visibility(&grid, &tiles, content_viewport, RETAIN_RADIUS);
+
+        let gpu_mask = pass
+            .read_in_range(&context.device, &context.queue, &buffers, tile_count)
+            .expect("the mask reads back");
+        let gpu_slots = pass
+            .read_slots(&context.device, &context.queue, &buffers, tile_count)
+            .expect("the slots read back");
+
+        for (index, tile) in tiles.iter().enumerate() {
+            assert_eq!(
+                gpu_mask.get(index).copied(),
+                reference.in_range.get(index).copied(),
+                "pan {pan:?} disagreed about tile {:?}",
+                tile.coord
+            );
+        }
+        assert_eq!(
+            gpu_slots, reference.slots,
+            "pan {pan:?} produced a different slot table"
+        );
+
+        visible_seen += reference.visible_count();
+        hidden_seen += tiles.len() - reference.visible_count();
+    }
+
+    // A differential where every tile was always in range, or never was, would
+    // agree perfectly and prove nothing.
+    assert!(
+        visible_seen > 0 && hidden_seen > 0,
+        "the pan script never exercised both answers: {visible_seen} visible, \
+         {hidden_seen} hidden"
+    );
+}
+
+/// The claim that makes this a *reuse* of Phase 4 rather than a lookalike: the
+/// arguments generated from the GPU-written slot table are the ones the CPU
+/// reference computes for the same tiles — and the CPU never saw the table.
+#[test]
+fn arguments_generated_from_the_gpu_written_slot_table_match_the_cpu_reference() {
+    let Some(context) = context_or_report("tile visibility into indirect args") else {
+        return;
+    };
+    let visibility = TileVisibilityPass::new(&context.device);
+    let indirect = IndirectArgsPass::new(&context.device);
+    let tiles = resident_tiles();
+    let slots = arena_slots(&tiles);
+    let mut tile_bytes = Vec::new();
+    encode_tiles(&tiles, &mut tile_bytes);
+
+    let visibility_buffers = TileVisibilityBuffers::new(&context.device, tiles.len() as u32);
+    let args_buffers =
+        IndirectArgsBuffers::new(&context.device, slots, tiles.len() as u32 + 1);
+
+    // Identity draw order over the arena, nothing culled: this test is about the
+    // slot table's route to the arguments, and Phase 3's own results are already
+    // differentiated in `indirect_args_differential.rs`.
+    let draw_order: Vec<u8> = tiles
+        .iter()
+        .flat_map(|tile| 0..tile.count)
+        .flat_map(|local| local.to_le_bytes())
+        .collect();
+    context
+        .queue
+        .write_buffer(&args_buffers.draw_order, 0, &draw_order);
+    context
+        .queue
+        .write_buffer(&args_buffers.culled, 0, &vec![0u8; slots as usize * 4][..]);
+
+    let grid = grid();
+    let mut any_empty = false;
+    let mut any_populated = false;
+    for pan in pan_script() {
+        let output = visibility
+            .run_into_args(
+                &context.device,
+                &context.queue,
+                &visibility_buffers,
+                &indirect,
+                &args_buffers,
+                &tile_bytes,
+                tile_viewport(pan),
+                QUAD_VERTEX_COUNT,
+                FirstInstance::Zero,
+            )
+            .expect("the two dispatches must succeed");
+        assert_eq!(output.slot_count, tiles.len() as u32);
+
+        let content_viewport = TileGrid::content_viewport(
+            viewport(),
+            wgpui_core::scene::layer::LayerTransform::translated(pan[0], pan[1]),
+        );
+        let reference_visibility = tile_visibility(&grid, &tiles, content_viewport, RETAIN_RADIUS);
+        let reference_slots: Vec<DrawSlot> = reference_visibility
+            .slots
+            .iter()
+            .enumerate()
+            .map(|(index, slot)| DrawSlot {
+                layer: LayerId::from_raw(index as u64 + 1),
+                kind: PrimitiveKind::Quad,
+                base: slot[0],
+                count: slot[1],
+            })
+            .collect();
+        let order: Vec<u32> = tiles.iter().flat_map(|tile| 0..tile.count).collect();
+        let reference = indirect_args(
+            &reference_slots,
+            &order,
+            &vec![0u32; slots as usize],
+            slots as usize,
+            QUAD_VERTEX_COUNT,
+            FirstInstance::Zero,
+        );
+
+        let gpu_args = indirect
+            .read_args(
+                &context.device,
+                &context.queue,
+                &args_buffers,
+                output.slot_count,
+            )
+            .expect("the arguments read back");
+        assert_eq!(
+            gpu_args, reference.args,
+            "pan {pan:?} generated different draw arguments"
+        );
+
+        let gpu_visible = indirect
+            .read_visible(&context.device, &context.queue, &args_buffers)
+            .expect("the indirection buffer reads back");
+        assert_eq!(
+            gpu_visible, reference.visible,
+            "pan {pan:?} produced a different indirection buffer"
+        );
+
+        // §4.3's actual promise, in the form a draw call sees it: an
+        // out-of-range tile's record draws nothing, and its indirection range
+        // holds no instances at all.
+        for (index, tile) in tiles.iter().enumerate() {
+            let in_range = reference_visibility.in_range.get(index).copied() == Some(1);
+            let record = gpu_args.get(index).copied().unwrap_or_default();
+            if in_range {
+                any_populated = true;
+                assert_eq!(
+                    record.instance_count, tile.count,
+                    "an in-range tile must draw its whole reservation"
+                );
+            } else {
+                any_empty = true;
+                assert_eq!(
+                    record.instance_count, 0,
+                    "tile {:?} is out of range and must draw zero instances",
+                    tile.coord
+                );
+                let start = tile.base as usize;
+                let end = start + tile.count as usize;
+                assert!(
+                    gpu_visible
+                        .get(start..end)
+                        .unwrap_or(&[])
+                        .iter()
+                        .all(|entry| *entry == UNUSED_INSTANCE),
+                    "tile {:?} is out of range but left live instances in its \
+                     indirection range",
+                    tile.coord
+                );
+            }
+        }
+    }
+    assert!(
+        any_empty && any_populated,
+        "the script never produced both a drawn and an undrawn tile"
+    );
+}
+
+/// A bookkeeping bug must be reported rather than dispatched with — the same
+/// rule `IndirectArgsPass::run` holds to, moved onto the input the CPU still
+/// owns once the slot table is written on the device.
+#[test]
+fn a_tile_reserving_past_the_arena_is_refused_rather_than_dispatched() {
+    let Some(context) = context_or_report("tile visibility validation") else {
+        return;
+    };
+    let pass = TileVisibilityPass::new(&context.device);
+    let buffers = TileVisibilityBuffers::new(&context.device, 4);
+    let mut bytes = Vec::new();
+    encode_tiles(
+        &[TileDescriptor {
+            coord: TileCoord::ORIGIN,
+            base: 60,
+            count: 8,
+        }],
+        &mut bytes,
+    );
+    assert!(
+        pass.run(
+            &context.device,
+            &context.queue,
+            &buffers,
+            &bytes,
+            tile_viewport([0.0, 0.0]),
+            64,
+        )
+        .is_err(),
+        "a tile ending at slot 68 in a 64-slot arena must be refused"
+    );
+
+    // And a malformed table, for the same reason.
+    assert!(
+        pass.run(
+            &context.device,
+            &context.queue,
+            &buffers,
+            &[0u8; 7],
+            tile_viewport([0.0, 0.0]),
+            64,
+        )
+        .is_err()
+    );
+
+    // More tiles than the buffers hold is a caller bug too, not a silent
+    // truncation of the visible set.
+    let mut many = Vec::new();
+    encode_tiles(
+        &(0..16i32)
+            .map(|x| TileDescriptor {
+                coord: TileCoord::new(x, 0),
+                base: 0,
+                count: 1,
+            })
+            .collect::<Vec<_>>(),
+        &mut many,
+    );
+    assert!(
+        pass.run(
+            &context.device,
+            &context.queue,
+            &buffers,
+            &many,
+            tile_viewport([0.0, 0.0]),
+            64,
+        )
+        .is_err()
+    );
+}
+
+/// A boundary with no resident tiles must dispatch nothing and not fail — the
+/// first frame of any tiled boundary, before anything has been revealed.
+#[test]
+fn a_boundary_with_no_resident_tiles_is_inert() {
+    let Some(context) = context_or_report("tile visibility empty") else {
+        return;
+    };
+    let pass = TileVisibilityPass::new(&context.device);
+    let buffers = TileVisibilityBuffers::new(&context.device, 1);
+    let count = pass
+        .run(
+            &context.device,
+            &context.queue,
+            &buffers,
+            &[],
+            tile_viewport([0.0, 0.0]),
+            0,
+        )
+        .expect("an empty tile set is not an error");
+    assert_eq!(count, 0);
+}

--- a/docs/phase-4.5-results.md
+++ b/docs/phase-4.5-results.md
@@ -40,12 +40,22 @@ Both Phase 0 placeholders named in §3's file map are now real:
 `shaders/tile_visibility.wgsl` was a one-line comment and
 `render/compute/tile_visibility_pass.rs` was three lines of module doc.
 
-**No deviation from §3's file map this phase**, which is the first time across
-six phases — Phase 1 recorded six, Phase 2 two, Phase 3 four, Phase 4 two. §3
-gives `tile.rs` to "`TileCoord`, `(boundary, TileCoord)` addressing (§4.3)" and
-everything built here is that module growing into its own remit. `TiledVisit`
-went into `boundary/compositor.rs` because it is the per-frame compositing
-decision that file already owns.
+**No *new* file outside §3's map this phase** — the first time across six
+phases, where Phase 1 recorded six deviations, Phase 2 two, Phase 3 four, and
+Phase 4 two. Every file above is one §3 already names, and both compute-pass
+files landed exactly where §3 put them.
+
+**One stretch, stated rather than counted as zero.** §3 describes `tile.rs` as
+"`TileCoord`, `(boundary, TileCoord)` addressing (§4.3)", and what is in it now
+is more than addressing: the grid geometry, the visibility predicate, and the
+residency budget with its two eviction rules. That is the tile module growing
+into the whole of §4.3's mechanism rather than a new concern smuggled into an
+existing file — the alternative was three files of a few hundred lines each,
+which `AGENTS.md` explicitly steers away from — but a reader comparing this
+against §3's one-line description should expect a bigger file than that line
+suggests. `TiledVisit` went into `boundary/compositor.rs`, which is itself
+already a documented Phase 2 deviation, because it is the per-frame compositing
+decision that file exists to own.
 
 ---
 

--- a/docs/phase-4.5-results.md
+++ b/docs/phase-4.5-results.md
@@ -1,0 +1,590 @@
+# Phase 4.5 Results — `Buffering::Tiled`, Tile Visibility, and Resident-Tile Eviction
+
+Status: **Phase 4.5 executed, the gate met — with one clause met exactly and a
+third layer disclosed beside it.** This documents what was built, what the gate
+actually asserts, what was measured on real hardware, what verification found
+broken and fixed, and what a human should still treat as open. It follows
+`docs/gpu-native-architecture.md` ("2.0" below) §4.3 and §8's Phase 4.5 row, and
+§9's risk table, which names this phase's specific failure mode. Work lives on
+branch `wgpui-2.0/phase-4.5-tiled-buffering`, pushed to origin, not merged, no
+PR.
+
+**Nothing under `src/` changed.** `git diff origin/2.0..HEAD -- src/` is empty,
+checked by running it. The whole branch diff touches 11 files, all under
+`crates/`, plus this one. No dependency was added, so `cargo metadata --locked`
+exits 0 — Phase 4's lockfile trap was checked for rather than assumed absent.
+
+**Contents:** §1 What shipped, and where · §2 §4.3's claim, tested · §3 The
+tile-visibility design · §4 The multi-tile content rule, and the measurement that
+changed it · §5 Eviction and the resident-tile budget · §6 The gate · §7 Tile
+size, measured · §8 What verification found · §9 GPU adapter honesty · §10 Check,
+test, and clippy status · §11 Gate assessment — honest read · §12 What is open
+
+---
+
+## 1. What shipped, and where
+
+| File | Lines | Role |
+|---|---|---|
+| `wgpui-core/src/scene/tile.rs` | 1,275 | `TileGrid`, `TileSpan`, `TilePlacement`, `TileResidency`, `tile_visibility` — the grid, the predicate, the placement rule, the budget |
+| `wgpui-core/src/shaders/tile_visibility.wgsl` | 97 | The predicate, transcribed |
+| `wgpui-core/src/boundary/compositor.rs` | +146 | `Compositor::visit_tiled`, `TiledVisit`, and the `sweep` fix (§8) |
+| `wgpui-core/src/boundary/policy.rs` | +123 | Both Phase 2 placeholders closed; `resident_tile_budget` |
+| `wgpui-core/src/test_support/ui_walk.rs` | +691 | `TiledCanvasDriver`, `NodeGraphSpec`, `TiledFrameStats` — the gate's harness |
+| `wgpui-wgpu/src/render/compute/tile_visibility_pass.rs` | 429 | The dispatch, and the route into Phase 4's argument generation |
+| `wgpui-wgpu/src/render/compute/indirect_args_pass.rs` | +96 | `run_with_slots` — the seam a GPU-written slot table enters through |
+| `wgpui-wgpu/tests/tile_visibility.rs` | 396 | The WGSL/Rust differential, end to end into draw arguments |
+| `wgpui-wgpu/examples/phase45_tiling_bench.rs` | 301 | §4.3's tile-size tradeoff, measured |
+
+Both Phase 0 placeholders named in §3's file map are now real:
+`shaders/tile_visibility.wgsl` was a one-line comment and
+`render/compute/tile_visibility_pass.rs` was three lines of module doc.
+
+**No deviation from §3's file map this phase**, which is the first time across
+six phases — Phase 1 recorded six, Phase 2 two, Phase 3 four, Phase 4 two. §3
+gives `tile.rs` to "`TileCoord`, `(boundary, TileCoord)` addressing (§4.3)" and
+everything built here is that module growing into its own remit. `TiledVisit`
+went into `boundary/compositor.rs` because it is the per-frame compositing
+decision that file already owns.
+
+---
+
+## 2. §4.3's claim, tested rather than trusted
+
+§4.3 says tiling "turns out to need almost no new machinery," and the brief for
+this phase asked that the claim be verified by reading what exists rather than
+assumed. It is **substantially true, with one qualification worth stating.**
+
+**True, and load-bearing.** Phase 1's groundwork is real and was read before
+being relied on: `scene/tile.rs` shipped `TileCoord` signed-on-purpose with
+tests, `LayerKey { boundary, tile: Option<TileCoord> }` already carried the
+address, and `LayerKey::tiled` already existed commented "§4.3, Phase 4.5".
+**`LayerKey` did not change in this phase at all** — that is the concrete
+evidence the bet paid, and it is why a tile could be a `Layer` rather than a new
+kind of thing. Every one of §4.3's four bullets held up:
+
+- A tile *is* a `Layer`. `LayerTable::insert` starting a new layer at
+  `Invalidation::all()` is what makes a newly-revealed tile dirty; nothing in
+  this phase marks a tile dirty, and `Compositor::visit_tiled` creates no layer,
+  allocates no slab, and raises no invalidation.
+- Panning is `TRANSFORM`-only via `LayerTable::set_transform`, live since Phase 2
+  and used here unmodified.
+- The visibility computation is genuinely small — 97 lines of WGSL, one
+  invocation per tile, no new pipeline.
+- Eviction is R-N §3.4's mark-and-sweep with "unvisited" reinterpreted spatially.
+
+**The qualification: §4.3's "the CPU never enumerates tile candidates" is true of
+the draw path and not of residency, and cannot be.** A newly-revealed tile needs
+content rendered into it, which is CPU work no visibility kernel can do. So the
+predicate exists twice — once in `TileResidency` deciding what stays resident,
+once in `tile_visibility.wgsl` deciding what draws — and they are checked against
+each other rather than assumed to agree (§3). That is not a defect in the design;
+it is a sentence in §4.3 that reads as stronger than what the mechanism can
+deliver, and the code says so where a reader will hit it.
+
+---
+
+## 3. The tile-visibility design
+
+### The pass writes Phase 4's slot table, and that is the whole integration
+
+`tile_visibility.wgsl` writes one `vec4<u32>` per resident tile:
+`[base, count, 0, 0]`. That is not a convention this phase invented — it is
+byte-for-byte `wgpui_core::indirect::encode_slots`' layout, the input
+`indirect_args.wgsl`'s `compact` has read since Phase 4, asserted identical by a
+test in `scene/tile.rs` that encodes the same records both ways and compares the
+bytes.
+
+So an out-of-range tile is a slot with a zero count. Phase 4's `compact` turns
+that into a zero-instance argument record; `pack` drops it from a
+`multi_draw_indirect_count` entirely. **There is no tile draw path, no tile
+pipeline, and nothing new deciding what draws.** A tile stops being drawn because
+the existing mechanism finds nothing in it to draw.
+
+`IndirectArgsPass::run_with_slots` is the seam. The existing `run` became a thin
+wrapper that uploads a CPU slot table and calls the same dispatch, so the
+GPU-driven path and the CPU-driven one are the same code below the slot buffer.
+
+**One consequence, handled rather than dropped.** `run` validates each slot's
+reservation against the arena before dispatching, and a GPU-written table cannot
+be read without exactly the readback this path exists to avoid. So the check
+moved onto the tile descriptors the CPU still writes, in
+`TileVisibilityPass::run`. Dropping it would hand the compaction an out-of-range
+base, which is an uncaptured device error and by default aborts the process.
+
+### The dilation is exact, which is what lets the two halves agree
+
+The shader dilates the viewport *rectangle* by `retain_radius × tile_size`;
+`TileResidency` dilates the tile *span* by `retain_radius` coordinates. These
+select the same tiles exactly, because tile edges sit at exact multiples of the
+tile size, so `floor((min − r·w)/w)` *is* `floor(min/w) − r`. A test sweeps 40
+viewport positions × 3 radii and asserts the two agree per tile rather than
+trusting the algebra.
+
+The edge rule is `Rect::intersects`, strict on every side — a region ending
+exactly on a tile boundary does not reach into the next tile, the same strictness
+every other predicate in this crate uses.
+
+### The differential
+
+`tests/tile_visibility.rs`, on the adapter named in §9, four tests, **all four
+confirmed running on the GPU rather than skipping** (checked with `--nocapture`,
+not inferred from a pass):
+
+1. **The transcription is exact.** 31 pan steps over a 49-tile resident set
+   spanning both signs of both coordinates, compared slot-for-slot and
+   flag-for-flag against `scene::tile_visibility`. Guarded against passing
+   vacuously: a script where every tile was always in range would agree perfectly
+   and prove nothing, so the test asserts both answers actually occurred.
+2. **The arguments generated from the GPU-written table** equal what
+   `indirect::indirect_args` computes for the same tiles — records *and* the
+   indirection buffer — with no slot table reaching the CPU in between. This is
+   what makes the integration a reuse of Phase 4 rather than a lookalike.
+3. **An out-of-range tile draws zero instances and leaves its whole indirection
+   range at `UNUSED_INSTANCE`**, asserted separately, because a wrong count with
+   live instances behind it would draw the wrong thing in the right quantity.
+4. **Bookkeeping bugs are refused**: a tile reserving past the arena, a malformed
+   descriptor table, more tiles than the buffers hold.
+
+Negative tile coordinates are exercised deliberately — they are bit-cast through
+a `u32` on the way to the shader, which is precisely where a sign would be lost.
+
+---
+
+## 4. The multi-tile content rule, and the measurement that changed it
+
+§4.3 requires *a* rule and offers two: clip a spanning primitive into each tile,
+or put it on an unbuffered overlay layer, "the same named pattern SFD §2 already
+proposes," with the instruction to "reuse that pattern rather than inventing a
+second one."
+
+**Clipping is not available in this phase.** It needs a per-primitive clip
+rectangle, and `Quad` does not have one — `docs/phase-1-results.md` §2 already
+recorded that absence. Clipping *geometrically* instead is a different operation:
+shrinking a rounded, bordered quad's rectangle moves its corners and border
+inward, so a node body straddling a tile edge would render as two
+differently-shaped halves. Not merely more work — not yet expressible, and the
+expressible version is wrong.
+
+**So: the overlay. But the obvious form of it does not survive its own gate.**
+
+"Any primitive touching two tiles goes on the overlay" was built first. On the
+node-graph workload — 130×70 nodes on a 256px grid — a node straddles a tile edge
+for most origins, and the crossing gate measured **73% of the scene's primitives
+on the unbuffered layer: 144 overlay primitives written against 52 tile ones.**
+The mechanism was working and buying almost nothing, because the layer that is
+*not* tile-culled held most of the content.
+
+**The rule as shipped:** a primitive no larger than a tile is **anchored** to the
+tile holding its top-left corner, overhang and all. Only genuinely oversized
+content — a wire spanning several columns, a group box around a subgraph —
+reaches the overlay. This is still the overlay pattern rather than a second one:
+the overlay exists, it holds what cannot be anchored, and it is
+`LayerKey::untiled`, the same layer an untiled boundary already has. What changed
+is which content needs it.
+
+**Anchoring's one obligation, checkable rather than remembered.** An anchored
+primitive reaches at most one tile past its own, so a tile must stay resident
+while its overhang is on screen. `TileGrid::overhang_is_covered(retain_radius)`
+requires a radius of one or more, and a test shows that at radius zero the
+overhang genuinely does go missing along the leading edge — so the constraint is
+demonstrated, not asserted.
+
+**What the overlay costs now, measured across a distribution rather than one
+frame.** The single crossing the gate samples wrote **nothing** to the overlay,
+which would be a misleading number to publish alone — it means no oversized wire
+entered the visible region on that frame, not that the overlay is free. Over
+twenty consecutive crossings: **70 overlay primitives on 5 of 20 frames, against
+629 written into tiles** — about 10% of pan work, on a quarter of frames.
+
+The overlay's remaining price stands: what sits there is not tile-culled, so a
+graph made mostly of very long wires still grows an always-resident layer.
+Per-tile clipping becomes the better answer the moment `Quad` gains a content
+mask, and that is where the rule should be revisited (§12).
+
+---
+
+## 5. Eviction and the resident-tile budget
+
+Two mechanisms, because §4.3 and §9's risk table both say one was never enough:
+`evict_after_frames` is a per-tile timer, and "an erratic pan pattern … can keep
+many tiles within 'recently visited' simultaneously, which `evict_after_frames`
+alone doesn't bound."
+
+1. **Spatial mark-and-sweep.** A tile out of range for longer than the boundary's
+   `evict_after_frames` is evicted. R-N §3.4 unchanged, with "unvisited" meaning
+   "not in range" instead of "not in the tree".
+2. **A total resident-tile budget with LRU eviction** beyond it
+   (`BoundaryPolicy::resident_tile_budget`, default 256).
+
+**A tile in range this frame is never evicted by either rule.** Evicting a tile
+the same frame is about to render would trade a memory bound for unbounded work.
+The consequence is stated rather than hidden: a budget below the viewport's own
+in-range tile count cannot be met, and `TileResidency::over_budget()` reports the
+shortfall.
+
+LRU order comes from a monotonic touch stamp, not from the frame number: a whole
+span shares one frame, so an eviction order tying across a hundred tiles would be
+decided by hash iteration order, which is to say not decided.
+
+**The budget is proven by comparison, not by a small number.** The erratic-pan
+test runs the same 400-frame diagonal-with-reversal walk twice — once with a
+budget, once with one large enough to be inert — and asserts the timer-only arm
+peaks at more than twice what the bounded arm holds. A test that only checked
+"the resident count stayed under the budget" would pass equally well against a
+pan that never had many tiles live, which would leave the budget untested.
+
+---
+
+## 6. The gate
+
+> §8's wording: *Panning a node-graph-style canvas across a tile boundary renders
+> only the newly-revealed tile(s) — measured directly, not inferred — while
+> panning within the resident grid costs one `TRANSFORM` update per visible tile
+> and zero render/reconcile/layout work anywhere.*
+
+### The harness, and why it measures rather than restates
+
+`TiledCanvasDriver` builds a node graph on an unbounded content plane and drives
+it through the real patch protocol into a real `Scene`. **Every frame offers
+every visible tile its content, not only the revealed ones.** That is deliberate
+and it is what makes the gate a measurement: if the harness skipped resident
+tiles, "panning costs zero render work" would be true because the harness
+declined to do any. Instead the work is offered every frame and the patch
+protocol's own cross-frame addressing (§5.0) is what reduces it to nothing.
+
+### Clause 2 — panning within the resident grid
+
+Eight consecutive 24px pans on a 256px grid. Per frame, asserted and printed:
+
+```
+gate (within grid): 42 visible tiles, 43 TRANSFORM updates,
+                    0 primitives written, 0 upload bytes, 0 layers displayed
+```
+
+43 = one per visible tile plus the overlay, which is the gate's "one `TRANSFORM`
+update per visible tile" exactly. Every layer the frame touched is asserted to
+carry `TRANSFORM` **and nothing else** — not merely to contain it. Zero
+primitives written, zero bytes uploaded, zero layers left needing re-display,
+zero layers created. **Met.**
+
+One detail that is load-bearing rather than cosmetic: the baseline pan is 8px,
+not zero. A 1024×768 viewport sits on exact multiples of 256, so it starts
+perfectly tile-aligned and the first pixel of any pan reveals a whole new column
+— which is a *crossing*, the other clause. The test asserts the no-crossing
+condition per step rather than assuming it.
+
+### Clause 1 — crossing a tile boundary
+
+One full-tile pan, with the measurement printed:
+
+```
+gate (crossing): 6 of 42 tiles revealed, 75 primitives written
+                 (75 in tiles, 0 on the overlay), against 432 resident before
+```
+
+"Measured directly" is the load-bearing phrase, so the assertion is not that the
+count is small. It is that **the set of tile layers carrying `DISPLAY` after the
+frame is exactly the set belonging to the revealed tiles** — a set equality, no
+more and no fewer. 75 primitives against a 432-primitive whole-region refill is
+17%. **Met.**
+
+**The third layer, disclosed rather than folded in.** A crossing can also dirty
+the overlay, when oversized content enters or leaves the visible region. On the
+sampled frame it wrote nothing; over twenty crossings it wrote 70 primitives on 5
+frames (§4). So the gate's "only the newly-revealed tile(s)" is exactly true of
+the tile grid, and the boundary has a third layer that is not a tile and is not
+covered by that phrasing. The test asserts the tile set exactly and bounds the
+overlay's share separately, rather than widening the first assertion to fit.
+
+---
+
+## 7. Tile size, measured rather than asserted
+
+§4.3 asks for a starting size "from common compositor practice (roughly
+256–512px)" **validated against a representative node-graph workload, not
+asserted**. `examples/phase45_tiling_bench.rs` sweeps 128 through 1024 —
+deliberately outside the band at both ends, because a sweep covering only the
+band could not show the band is the right place to be.
+
+Adapter as §9. 1600×900 viewport, retain radius 1, budget 256, 2 warm-up runs
+discarded, 12 timed.
+
+| edge | tiles | slots | crossing | refill | ratio | overlay | vis med | vis best | buffered area |
+|---|---|---|---|---|---|---|---|---|---|
+| 128 | 160 | 151 | 86 | 409 | 4.8× | 21.8% | 165.5µs | 160.4µs | 1.49× viewport |
+| **256** | **60** | **55** | **50** | **566** | **11.3×** | **2.8%** | **164.3µs** | **158.8µs** | **2.07× viewport** |
+| 384 | 40 | 36 | 132 | 814 | 6.2× | 2.7% | 1206.2µs | 654.1µs | 2.74× viewport |
+| 512 | 28 | 25 | 205 | 1006 | 4.9× | 3.6% | 342.7µs | 229.8µs | 3.51× viewport |
+| 1024 | 15 | 13 | 481 | 1934 | 4.0× | 0.0% | 283.6µs | 241.2µs | 7.47× viewport |
+
+**`TileGrid::DEFAULT_EDGE` is 256 because of this table**, not because 256 is a
+round number.
+
+The table was produced three times across the phase. Every counter column —
+tiles, slots, crossing, refill, overlay, area — was **identical on every run**;
+only the two timing columns moved. That is the expected split (the counters are
+deterministic properties of the scene, the clocks are a shared laptop) and it is
+stated because it is the reason the argument above rests on the counters.
+
+**§9's risk table predicted the "too small" failure as inflated draw-call
+overhead. That is visible — 151 slots against 55 — but it is not the binding
+constraint.** The binding one is the overlay: at 128px a 130×70 node is *larger
+than a tile*, cannot be anchored, and goes to the unbuffered layer — 21.8% of the
+scene against 2.8% at 256. Tile size interacts with the workload's natural
+content size directly, and a tile smaller than that unit degrades much faster
+than the draw-call argument alone predicts.
+
+**Two caveats the benchmark prints beneath itself, both of which change how the
+table should be read.**
+
+1. **The `refill` baseline is not constant across rows.** A retain radius of one
+   buffers a ring one tile wide, so the buffered region grows with the tile size
+   — 1.49× the viewport at 128, 7.47× at 1024. `Buffering::Margin(None)` buffers
+   2.25× (§4.1), so only rows near that area are like-for-like. That is the 256
+   row, at 2.07×. Large-tile rows are compared against a bigger buffer than
+   `Margin` would have kept, and their ratio flatters tiling. Left in with the
+   area disclosed, because the shape of the tradeoff is the point of the sweep.
+2. **The `vis` column is a ceiling, not the kernel's cost.** It ends in
+   `Device::poll(wait_indefinitely)`, which waits for everything already
+   submitted — the same effect `docs/phase-4-results.md` §5 records for the
+   readback path. The column is flat across a 10× tile-count range because what
+   it mostly measures is one submit-and-synchronize round trip. A real frame
+   pipelines this dispatch and never polls it, so no number there is a per-frame
+   cost. The 384 row's median against its own best (1206µs vs 654µs) is the
+   scale of the noise. It is reported to show the pass is not accidentally
+   expensive, which it is not.
+
+---
+
+## 8. What verification found
+
+Re-reading this branch's own commits rather than trusting their messages.
+
+**1. A real leak: `Compositor::sweep` returned only the boundary's own layer.**
+It pushed `state.layer` — the untiled/overlay layer — which was the complete
+answer for as long as a boundary had exactly one layer, and stopped being
+complete the moment this phase gave it one per resident tile. An evicted tiled
+boundary drops its `BoundaryState`, taking its `TileResidency` with it, so that
+call is the last moment anything knows those tiles existed; every tile's slab
+reservation then outlived the scene. The method's own doc is the argument for why
+it had to include them: the layer entry "is the compositor's to release, and
+nothing else knows when the interval has elapsed." Fixed, and **the test pinning
+it was confirmed to actually catch it by reverting the fix and watching it
+fail**, rather than by assuming a new test tests something.
+
+**2. The multi-tile content rule as first built put 73% of the scene on the
+unbuffered layer** (§4). Found by running the gate, not by reading the code.
+
+**3. `set_transform` before the boundary exists is inert, and it silently broke
+the gate harness's first frame.** `Compositor::set_transform` is documented to
+report `false` rather than create a boundary. The driver moved the canvas before
+declaring it, so frame one resolved its tile span at the identity, and frame
+two's ordinary 24px pan then looked like a tile crossing. Fixed in the driver,
+and the ordering hazard written into `visit_tiled`'s doc where the next caller
+will read it.
+
+**4. `TileSpan::tiles()` was a hang, not an error, on a directly-built huge
+span.** Unreachable through `visible_span`, which refuses a span above
+`MAX_TILES` outright — but `TileSpan` is two public coordinate pairs a caller can
+construct, and a billion-tile span would have looped rather than failed. Now
+truncates at the same cap, with a test.
+
+**5. Two of this phase's own first tests were wrong, and both were replaced with
+stronger ones.** The eviction interval is anchored on the frame a tile was last
+visited, and the first test was off by one against `Compositor::sweep`'s own
+boundary. And a budget below the viewport's in-range tile count cannot be met at
+all — so the erratic-pan test now proves the budget by comparison against a
+timer-only arm rather than by a number staying small, and the unmet case is
+asserted separately.
+
+**Not fixed, recorded:** a boundary switched from `Tiled` back to `Margin` keeps
+its tile layers until it is swept. Releasing them inside `visit_tiled` would mean
+that method returning layers on the path where it reports having no tile set at
+all. No caller in this phase changes a boundary's buffering mid-life; the
+behaviour is in `visit_tiled`'s doc and in §12.
+
+---
+
+## 9. GPU adapter honesty check
+
+Per Phase 0's discipline, checked before any number above was trusted:
+`cargo run -p wgpui-wgpu --release --example adapter_probe`.
+
+```
+== Adapters enumerated on VULKAN | DX12 ==
+  name="NVIDIA GeForce RTX 4060 Laptop GPU" backend=Vulkan device_type=DiscreteGpu driver_info="561.03"
+  name="NVIDIA GeForce RTX 4060 Laptop GPU" backend=Dx12   device_type=DiscreteGpu driver="32.0.15.6103"  (x3)
+  name="Microsoft Basic Render Driver"      backend=Dx12   device_type=Cpu
+== Picking the first adapter and requesting a device ==
+  Selected: NVIDIA GeForce RTX 4060 Laptop GPU (Vulkan, DiscreteGpu)
+  software/CPU-fallback adapter: no
+  request_device: OK
+```
+
+**This is the same machine Phases 0, 3, and 4 ran on** — verified against
+`docs/phase-4-results.md` §7 rather than assumed — so its caveats carry over
+verbatim: one adapter, one driver version, one OS, one laptop-class discrete
+NVIDIA part. Every GPU test and the benchmark report the adapter and its
+negotiated features before printing anything
+(`[INDIRECT_FIRST_INSTANCE=true MULTI_DRAW_INDIRECT_COUNT=true]`).
+
+**A caveat specific to this phase, smaller than Phase 4's.** The tile-visibility
+kernel uses no optional device feature at all — no indirect features, no
+subgroups, nothing a device could lack. So unlike Phase 4's fallback paths, there
+is no untested arm here that exists *for* hardware this machine is not. What is
+still one-machine is the timing column in §7, and that column is already
+disclosed as a synchronization ceiling rather than a cost.
+
+---
+
+## 10. Check, test, and clippy status
+
+```
+cargo check  -p wgpui-core -p wgpui-wgpu --all-targets   → clean, zero warnings
+cargo test   -p wgpui-core                               → 309 passed, 0 failed
+cargo test   -p wgpui-wgpu                               → 25 + 5 + 8 + 5 + 4 + 4
+                                                           = 51 passed, 0 failed
+cargo metadata --locked                                  → exit 0
+cargo clippy -p wgpui-core -p wgpui-wgpu --all-targets -- --deny warnings
+                                                         → clean from a cold build,
+                                                           zero suppressions
+```
+
+360 tests across the two crates this phase touches. No test is skipped on this
+machine: every GPU-dependent test goes through `device::context_or_report`, which
+prints the adapter it got or a plain SKIPPED line — never silence that could pass
+for coverage. All four tile-visibility tests were confirmed to print an adapter
+line rather than skip.
+
+`cargo test --workspace` was **not** run: it pulls in `gpui-ce`'s legacy suite,
+recorded since Phase 1 as running 10+ minutes without completing, which no 2.0
+branch modifies. Tests are scoped to the touched crates.
+
+Clippy was run cold (`cargo clean -p` on both crates first) rather than trusted
+from an incremental cache. Note that `AGENTS.md` prefers `./script/clippy`, which
+adds `--release --all-features` and runs `cargo-machete`/`typos` when installed;
+the command above is the narrower one the phase brief specified, so the
+release-profile and all-features variants have not been run — the same disclosure
+Phase 4 made.
+
+**Zero suppressions in this phase's diff** — `git diff origin/2.0..HEAD | grep
+'^+.*allow('` is empty. Clippy found three things and all three were fixed rather
+than silenced, which is the standard Phases 3 and 4 both set:
+
+1. **`neg_cmp_op_on_partial_ord`** on `TileGrid::new`, which spelled its NaN
+   rejection as `!(width >= MIN_EDGE)`. The codebase already had the right idiom
+   for exactly this — `Rect::is_empty` uses `partial_cmp` and documents why —
+   and the fix follows it. A real readability finding on a real NaN branch, not
+   a false positive.
+2. **`too_many_arguments`** on `IndirectArgsPass::run_with_slots` (8/7). Fixed by
+   introducing `GeneratedSlots { buffer, count }`, which is the same resolution
+   Phase 4 applied to `issue_composites` and buys the same thing beyond the lint:
+   a count from one pass can no longer be paired with another pass's buffer,
+   which would generate arguments for records that are not there, silently.
+3. **`too_many_arguments`** on `TileVisibilityPass::run_into_args` (10). Fixed by
+   `ArgsTarget`, grouping the argument-generation stage's pass, buffers, and
+   record encoding. `vertex_count` and `first_instance` together *are* the
+   encoding, and splitting them across a call site is how a record ends up
+   carrying a base the shader is not expecting.
+
+The third of those had been suppressed with an `#[allow]` mid-phase and was
+un-suppressed during this pass rather than left.
+
+---
+
+## 11. Gate assessment — honest read
+
+**Clause 2 — panning within the resident grid costs one `TRANSFORM` update per
+visible tile and zero render/reconcile/layout work: met, exactly.** 42 visible
+tiles, 43 `TRANSFORM` updates (tiles plus overlay), zero primitives written, zero
+bytes uploaded, zero layers displayed, zero layers created, across eight
+consecutive frames — with every touched layer asserted to carry `TRANSFORM` and
+nothing else, and with the harness offering the work rather than declining it.
+
+**Clause 1 — crossing a tile boundary renders only the newly-revealed tiles,
+measured directly: met for the tile grid, with a third layer disclosed.** The set
+of tile layers carrying `DISPLAY` is exactly the revealed set — a set equality,
+directly measured. 75 primitives against a 432-primitive refill.
+
+The honest qualification is that a tiled boundary has three kinds of layer, not
+two: resident tiles, evicted tiles, and one unbuffered overlay. The gate's
+phrasing covers the first two. The overlay can also re-render on a crossing —
+measured at 70 primitives across 5 of 20 crossings, about 10% of pan work — and
+that is a property of the multi-tile content rule this phase chose, not a defect
+in the tiling. A reviewer who reads "only the newly-revealed tile(s)" as covering
+the whole boundary should treat the overlay as an additional, measured, bounded
+cost rather than as a met-or-not clause.
+
+Three things worth recording as genuinely open rather than met:
+
+- **The gate is measured through `wgpui-core`'s scene, not a running
+  application.** There is still no window loop; `TiledCanvasDriver` drives the
+  real patch protocol into a real `Scene`, and `FrameRenderer` is not wired to
+  tiled boundaries (§12). The GPU half is proven at the pass level by
+  differential, not by a frame that drew a tiled canvas end to end.
+- **One workload.** The tile-size table is one node-graph shape at one viewport.
+  A whiteboard with a few enormous strokes, or a level editor with dense small
+  sprites, would sit differently against the anchoring rule in particular.
+- **One machine**, identical to every prior phase's caveat, unimproved.
+
+---
+
+## 12. What is open for later phases
+
+### Already scheduled, and correctly not done here
+
+1. **Text, `Img`, and `StyledText` `diff_key` are Phase 5.** Unchanged by this
+   phase and unblocked by it. A tile's `GlyphRun` slot is generated with every
+   other layer's and nothing issues its draws, exactly as
+   `docs/phase-4-results.md` §10 recorded.
+2. **The regular-content layout kernel is Phase 6.1**, and is still a rescoped
+   *spike* gated on its own fused-dispatch follow-up per §8's row — Phase 0's
+   Spike B measured a standalone dispatch losing by ~1000×. Nothing here changes
+   that either way.
+3. **Zoom/multi-resolution tiling stays rejected (§10).** `Buffering::Tiled`
+   re-renders at the current scale on a zoom change, the same as `Margin`.
+   `TileGrid` holds a tile size and no scale, so there is no half-built
+   multi-resolution path to remove later.
+
+### Loose ends of this phase
+
+4. **`FrameRenderer` does not know about tiled boundaries.** `render/frame.rs`
+   builds its slot table from `Scene::draw_slots` — every layer, tiles included,
+   which is correct but does not route through `TileVisibilityPass`. The two are
+   proven to agree at the pass level (§3) and are not yet wired into one frame.
+   That wiring belongs with whatever phase brings a real window loop, alongside
+   Phase 4's own item 4 (nothing drives `LayerTexturePool::acquire`/`sweep` in
+   the frame loop either).
+5. **Per-tile clipping is the better multi-tile rule once `Quad` has a content
+   mask** (§4). The anchoring rule shipped here is correct and measured, and it
+   leaves oversized content un-culled on the overlay. The moment a per-primitive
+   clip rect exists, `TilePlacement` is the one place that decision lives.
+6. **Switching a live boundary from `Tiled` to `Margin` strands its tile layers**
+   until the boundary is swept (§8). Documented, not fixed.
+7. **Per-frame allocations in the tile pass**, matching Phase 4's item 5
+   unchanged: `TileVisibilityPass::run` creates a params buffer, a descriptor
+   buffer, and a bind group per call. `O(tiles)` and outside any gate's clock,
+   but the same argument that justified caching `QuadDrawPlan` applies, and the
+   same choice was made — left alone rather than fixed, to keep this phase's diff
+   to what it could verify.
+8. **Phase 3's Scene A occlusion loss remains unaddressed**, and this phase is
+   where §9's risk table said it would become relevant: "a zoomed-out node graph
+   is the obvious candidate, tying directly to §4.3's tiling motivation." Tiling
+   in fact *helps* the shape of that problem — an out-of-range tile's primitives
+   are never uploaded or dispatched at all — but nothing here measured the
+   interaction, and the 3%-visible scene Phase 3 measured is not the same as a
+   tiled one. Still open, now with a plausible mitigation nobody has tested.
+
+### What a human should do before calling this closed
+
+1. **Run the gate on a second workload** — a whiteboard (few, very large strokes)
+   and a sprite grid (many, very small) are the two shapes that would stress the
+   anchoring rule from opposite directions. The bench takes a `NodeGraphSpec`
+   today; a second generator is the work.
+2. **Re-run the tile-size sweep on a machine that is not also running a
+   desktop**, and on hardware without a discrete GPU. The `vis` column is
+   already disclosed as a synchronization ceiling, but the crossing/refill
+   columns are CPU-side counts and would be worth confirming unchanged.
+3. **Let `gpui-ce`'s legacy suite finish once** — outstanding since Phase 1,
+   still not something any 2.0 branch modifies.

--- a/docs/phase-4.5-results.md
+++ b/docs/phase-4.5-results.md
@@ -9,10 +9,22 @@ broken and fixed, and what a human should still treat as open. It follows
 branch `wgpui-2.0/phase-4.5-tiled-buffering`, pushed to origin, not merged, no
 PR.
 
-**Nothing under `src/` changed.** `git diff origin/2.0..HEAD -- src/` is empty,
-checked by running it. The whole branch diff touches 11 files, all under
+**Nothing under `src/` changed, and `docs/gpu-native-architecture.md` was not
+edited.** `git diff 057487cc7d..HEAD -- src/ docs/gpu-native-architecture.md` is
+empty, checked by running it. The whole branch diff is 12 files: 11 under
 `crates/`, plus this one. No dependency was added, so `cargo metadata --locked`
 exits 0 — Phase 4's lockfile trap was checked for rather than assumed absent.
+
+**Read those diffs against `057487cc7d`, not against `origin/2.0`.** This branch
+was cut from `057487cc7d` (Phase 4's merge), and `2.0` has since advanced by one
+unrelated commit — `d41f2e8a79`, "docs: name path tessellation as a deliberate,
+disclosed CPU-side item", which adds a paragraph to §10 of the spec. A
+`git diff origin/2.0..HEAD` therefore *appears* to show this branch deleting 18
+lines of the architecture document. It does not: that paragraph was never in this
+branch's base. This is recorded because the appearance is alarming and the check
+that resolves it is not obvious — the branch is one commit behind `2.0` and
+should be rebased onto it before any merge, at which point the spec diff is empty
+by inspection as well as by merge-base.
 
 **Contents:** §1 What shipped, and where · §2 §4.3's claim, tested · §3 The
 tile-visibility design · §4 The multi-tile content rule, and the measurement that


### PR DESCRIPTION
`scene/tile.rs` grows from Phase 1's address into §4.3's mechanism, without `LayerKey` changing at all — which is the evidence Phase 1's bet paid.

Three things, and nothing that duplicates a `Layer`:

- `TileGrid`: where a tile sits, which tiles a rect covers, and the content-space viewport at a pan offset. The edge rule matches `Rect::intersects` exactly, so a region ending on a tile boundary does not reach into the next tile.
- `tile_visibility`: §4.3's "which tile coordinates intersect (viewport union retain radius)", written in Rust as the reference `tile_visibility.wgsl` will transcribe. It emits `[base, count, 0, 0]` records — Phase 4's own slot encoding, byte-identical, asserted against `indirect::encode_slots` — so an out-of-range tile is a zero-count slot the existing `compact` turns into a zero-instance draw. No new drawing path.
- `TileResidency`: R-N §3.4's mark-and-sweep triggered spatially, plus the total resident-tile budget with LRU eviction §4.3 and §9's risk table both ask for as first-class. A tile in range this frame is never evicted by either rule; a budget that cannot be met is reported through `over_budget()` rather than absorbed.

The multi-tile content rule is chosen here and argued in `TilePlacement`'s doc: spanning content goes to an unbuffered overlay layer (SFD §2's existing pattern, reusing `LayerKey::untiled`), not per-tile clipping. Not taste — per-tile clipping needs a per-primitive clip rect `Quad` does not have (phase-1-results §2), and clipping geometrically instead moves a rounded quad's corners and border inward, so a node straddling a tile edge would render as two differently-shaped halves.

`boundary/policy.rs`'s two Phase 2 placeholders are closed for real: `margin()` now reports a tiled boundary's retain radius in pixels instead of falling back to the auto margin, and `is_implemented()` is gone rather than left always-true. `BoundaryPolicy` gains `resident_tile_budget`.

Two test findings, both mine, both kept as better tests than the ones that found them: the eviction interval is anchored on the frame a tile was last visited (my first test was off by one against `Compositor::sweep`'s own boundary), and a budget below the viewport's own in-range tile count cannot be met at all — so the erratic-pan test now proves the budget by *comparison* against a timer-only arm rather than by a number staying small, and the unmet case is asserted separately.