### PR TITLE
Fix: wrap set_var in unsafe block for Rust 1.80 compatibility

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1097,7 +1097,7 @@ pub trait InputHandler: 'static {
     fn apple_press_and_hold_enabled(&mut self) -> bool {
         #[cfg(target_os = "macos")]
         {
-            std::env::set_var("ApplePressAndHoldEnabled", "NO");
+            unsafe { std::env::set_var("ApplePressAndHoldEnabled", "NO") };
             false
         }
         #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
std::env::set_var became unsafe in Rust 1.80, causing compilation errors on newer toolchains.